### PR TITLE
Added Travis configuration file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+# Use container-based distribution
+sudo: false
+language: c++
+matrix:
+  include:
+    - compiler: gcc
+      addons:
+        apt:
+          sources:
+            - ubuntu-toolchain-r-test
+          packages:
+            - g++-5
+            - re2c
+            - liblua5.1-0-dev
+            - libcppunit-dev
+            - zsh
+script:
+  - mkdir build
+  - echo "CXX = 'g++-5'" > build/debug.py
+  - echo "CC = 'gcc-5'" >> build/debug.py
+  - scons -j3 && scons -j3 test


### PR DESCRIPTION
I built a simple Travis configuration for automatically building and testing clingo with gcc 5.

The configuration is working, as you can verify with the [latest commit’s build status on Travis](https://travis-ci.org/pluehne/clingo/builds/134591890).

The only thing left to do is to connect the potassco/clingo project with [Travis](https://travis-ci.org/) and to merge this commit into any branch that should be tested in the future.