### PR TITLE
Experimental accessor functions to the clasp solver object

### DIFF
--- a/app/gringo/main.cc
+++ b/app/gringo/main.cc
@@ -193,6 +193,9 @@ struct IncrementalControl : Gringo::Control, Gringo::GringoModule {
     void interrupt() override {
         throw std::runtime_error("interrupting not supported in gringo");
     }
+    void *claspFacade() override {
+        return nullptr;
+    }
     void beginAdd() override {
         parse();
     }

--- a/libclingo/clingo/clingocontrol.hh
+++ b/libclingo/clingo/clingocontrol.hh
@@ -272,6 +272,7 @@ public:
     Gringo::TheoryData const &theory() const override { return out_->data.theoryInterface(); }
     void registerPropagator(Gringo::UProp p, bool sequential) override;
     void interrupt() override;
+    void *claspFacade() override;
     Gringo::Backend *backend() override;
     Potassco::Atom_t addProgramAtom() override;
     Gringo::Logger &logger() override { return logger_; }

--- a/libclingo/src/clingocontrol.cc
+++ b/libclingo/src/clingocontrol.cc
@@ -387,6 +387,10 @@ Gringo::SolveResult ClingoControl::solve(ModelHandler h, Assumptions &&ass) {
     return ret;
 }
 
+void *ClingoControl::claspFacade() {
+    return clasp_;
+}
+
 void ClingoControl::registerPropagator(std::unique_ptr<Gringo::Propagator> p, bool sequential) {
     propagators_.emplace_back(Gringo::gringo_make_unique<Clasp::ClingoPropagatorInit>(*p, propLock_.add(sequential)));
     claspConfig_.addConfigurator(propagators_.back().get(), Clasp::Ownership_t::Retain);

--- a/libgringo/clingo.h
+++ b/libgringo/clingo.h
@@ -3132,6 +3132,18 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_control_statistics(clingo_control_t *contr
 //!
 //! @param[in] control the target
 CLINGO_VISIBILITY_DEFAULT void clingo_control_interrupt(clingo_control_t *control);
+//! Get low-level access to clasp.
+//!
+//! @attention
+//! This function is intended for experimental use only and not part of the stable API.
+//!
+//! This function may return a <code>nullptr</code>.
+//! Otherwise, the returned pointer can be casted to a ClaspFacade pointer.
+//!
+//! @param[in] control the target
+//! @param[out] clasp pointer to the ClaspFacade object (may be <code>nullptr</code>)
+//! @return whether the call was successful
+CLINGO_VISIBILITY_DEFAULT bool clingo_control_clasp_facade(clingo_control_t *control, void **clasp);
 
 //! @}
 

--- a/libgringo/clingo.hh
+++ b/libgringo/clingo.hh
@@ -2044,6 +2044,7 @@ public:
     bool has_const(char const *name) const;
     Symbol get_const(char const *name) const;
     void interrupt() noexcept;
+    void *claspFacade();
     void load(char const *file);
     SolveAsync solve_async(ModelCallback mh = nullptr, FinishCallback fh = nullptr, SymbolicLiteralSpan assumptions = {});
     void use_enumeration_assumption(bool value);

--- a/libgringo/gringo/control.hh
+++ b/libgringo/gringo/control.hh
@@ -230,6 +230,7 @@ struct clingo_control {
     virtual Gringo::SolveFuture *solveAsync(ModelHandler mh, FinishHandler fh, Assumptions &&assumptions) = 0;
     virtual Gringo::SolveIter *solveIter(Assumptions &&assumptions) = 0;
     virtual void interrupt() = 0;
+    virtual void *claspFacade() = 0;
     virtual void add(std::string const &name, Gringo::FWStringVec const &params, std::string const &part) = 0;
     virtual void load(std::string const &filename) = 0;
     virtual Gringo::Symbol getConst(std::string const &name) = 0;

--- a/libgringo/src/control.cc
+++ b/libgringo/src/control.cc
@@ -1819,6 +1819,12 @@ void Control::interrupt() noexcept {
     clingo_control_interrupt(*impl_);
 }
 
+void *Control::claspFacade() {
+    void *ret;
+    handleCError(clingo_control_clasp_facade(impl_->ctl, &ret));
+    return ret;
+}
+
 void Control::load(char const *file) {
     handleCError(clingo_control_load(*impl_, file));
 }
@@ -3687,6 +3693,11 @@ extern "C" bool clingo_control_configuration(clingo_control_t *ctl, clingo_confi
 
 extern "C" bool clingo_control_statistics(clingo_control_t *ctl, clingo_statistics_t **stats) {
     GRINGO_CLINGO_TRY { *stats = static_cast<clingo_statistics_t*>(ctl->statistics()); }
+    GRINGO_CLINGO_CATCH;
+}
+
+extern "C" bool clingo_control_clasp_facade(clingo_control_t *ctl, void **clasp) {
+    GRINGO_CLINGO_TRY { *clasp = ctl->claspFacade(); }
     GRINGO_CLINGO_CATCH;
 }
 


### PR DESCRIPTION
I extended the clingo C/C++ APIs with some experimental functions to access the underlying clasp solver object.

In the documentation, I added a note stating that this is not part of the stable API.

I tried to roughly group the functions with the other solving-related functions. I hope that’s fine :).