### PR TITLE
Add cast for LiteralId data_.offset to fix Windows bitfield issue

### DIFF
--- a/libgringo/gringo/output/literal.hh
+++ b/libgringo/gringo/output/literal.hh
@@ -65,7 +65,7 @@ public:
     LiteralId()
     : repr_(std::numeric_limits<uint64_t>::max()) { }
     LiteralId(NAF sign, AtomType type, Potassco::Id_t offset, Potassco::Id_t domain)
-    : data_{static_cast<uint32_t>(sign), static_cast<uint32_t>(type), domain, offset} { }
+    : data_{static_cast<uint32_t>(sign), static_cast<uint32_t>(type), domain, static_cast<uint64_t>(offset)} { }
     Potassco::Id_t offset() const { return data_.offset; }
     Potassco::Id_t domain() const { return data_.domain; }
     AtomType type() const { return static_cast<AtomType>(data_.type); }


### PR DESCRIPTION
When clingo.dll is compiled in VS2015, the 'offset' member of the LiteralId bitfield does not get set correctly, presumably due to platform differences. This causes all LiteralIds to be created with an offset of 0; a knock-on effect of this is that if multiple PredicateLiterals are constructed only the first one is assigned a UID, as subsequent checks (lines 948,949 in libgringo/src/output/literals.cc) mistakenly see that a UID already exists (but for the first PredicateLiteral rather than the one being constructed).

This can be demonstrated by changing line 33 of app/example/main.cc to use "a(1). a(2)" as input to the grounder, and then running the example. Expected output: "a(1) a(2)". Actual output "a(1)". After the fix, output is "a(1) a(2)" as expected. 

This fix casts the 'offset' input to the LiteralId constructor to be the same width as the bitfield (uint64_t) before assigning it to the bitfield member, which appears sufficient to fix the assignment issue. (Similar issues have not been observed with the domain property and so it has been left unaltered for the sake of minimality.)

This change has not been tested with compilers other than VS2015 as I don't have access to suitable build environments.