### PR TITLE
Incorrectly documented return value of wait function

### DIFF
--- a/libgringo/clingo.h
+++ b/libgringo/clingo.h
@@ -774,11 +774,11 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_solve_async_get(clingo_solve_async_t *hand
 //! Wait for the specified amount of time to check if the search has finished.
 //!
 //! If the time is set to zero, this function can be used to poll if the search
-//! is still running.
+//! has already finished.
 //!
 //! @param[in] handle the target
 //! @param[in] timeout the maximum time to wait
-//! @param[out] result whether the search is still running
+//! @param[out] result whether the search has finished
 //! @return whether the call was successful; might set one of the following error codes:
 //! - ::clingo_error_bad_alloc
 //! - ::clingo_error_runtime if solving fails


### PR DESCRIPTION
I stumbled upon a probable mistake in the documentation of [`clingo_solve_async_wait`][1].

The Clingo C API documentation states that [`clingo_solve_async_wait`][1] returns `true` if the search is still running and `false` otherwise.

Judging from the implementation of [`ClaspFacade::AsyncSolve::wait`][2], which is in turn used by [`ClingoSolveFuture::wait`][3], it seems to be the other way around. That is, [`clingo_solve_async_wait`][1] apparently returns `true` if the search has finished before the timeout.

In my application, interpreting the return value `true` as “the search has finished” led to the correct results.

This patch fixes the documentation, assuming that this is, indeed, the intended behavior.

[1]: https://potassco.org/clingo/c-api/current/group__solveasync#ga793d2f39743369ca1f7deecd8590b7cd
[2]: https://github.com/potassco/clasp/blob/ab0806e0ddc1da1f05a50eb155d0036ad562e3cc/libclasp/src/clasp_facade.cpp#L397
[3]: https://github.com/potassco/clingo/blob/95cc1182fecc485361ae86044205a89c0f0f7149/libclingo/src/clingocontrol.cc#L667