### PR TITLE
Add dereference operators to Optional

### DIFF
--- a/libclingo/clingo.hh
+++ b/libclingo/clingo.hh
@@ -221,6 +221,10 @@ public:
     T const *get() const { return data_.get(); }
     T *operator->() { return get(); }
     T const *operator->() const { return get(); }
+    T &operator*() & { return *get(); }
+    T const &operator*() const & { return *get(); }
+    T &&operator*() && { return std::move(*get()); }
+    T const &&operator*() const && { return std::move(*get()); }
     template <class... Args>
     void emplace(Args&&... x) {
         clear();


### PR DESCRIPTION
This implements four dereference operators for `Clingo::Optional`, in analogy to the spefication of [`std::optional`](http://en.cppreference.com/w/cpp/utility/optional/operator*).