### PR TITLE
Fix: Variants cannot be move-assigned from descendant Variants

### DIFF
--- a/libclingo/clingo.hh
+++ b/libclingo/clingo.hh
@@ -315,8 +315,12 @@ private:
         return *this;
     }
     Variant &operator=(Holder &&data) {
-        data_.swap(data);
-        data.destroy();
+        Holder x;
+        x.swap(data);
+        // Destroy the old data_ only after securing the new data
+        // Otherwise, data would be destroyed together with data_ if it was a descendant of data_
+        data_.destroy();
+        x.swap(data_);
         return *this;
     }
     template <class U, class... Args>

--- a/libclingo/tests/variant.cc
+++ b/libclingo/tests/variant.cc
@@ -6,6 +6,12 @@ namespace Clingo { namespace Test {
 
 using V = Variant<int, std::string, std::unique_ptr<int>>;
 
+struct R;
+using VR = Variant<int, R>;
+struct R {
+    VR x;
+};
+
 struct D {
     D(std::string &r) : r(r) { r = "not called"; }
     void visit(int &x) {
@@ -54,6 +60,11 @@ TEST_CASE("visitor", "[clingo]") {
     REQUIRE(y.get<std::string>() == "s1");
     x = y;
     REQUIRE(x.get<std::string>() == "s1");
+
+    VR xr{R{1}};
+    REQUIRE(xr.get<R>().x.get<int>() == 1);
+    xr = std::move(xr.get<R>().x);
+    REQUIRE(xr.get<int>() == 1);
 
 #if (__clang__ || __GNUC__ >= 5)
     std::string r;


### PR DESCRIPTION
This fixes an issue where move-assigning `Clingo::Variant`s from their own descendant `Variant`s would cause a segmentation fault.