### PR TITLE
Remove unnecessary semicolons to avoid compiler warnings

### DIFF
--- a/libclingo/clingo/control.hh
+++ b/libclingo/clingo/control.hh
@@ -117,8 +117,8 @@ struct SolveEventHandler {
     virtual ~SolveEventHandler() = default;
 };
 using USolveEventHandler = std::unique_ptr<SolveEventHandler>;
-inline bool SolveEventHandler::on_model(Model &) { return true; };
-inline void SolveEventHandler::on_finish(SolveResult) { };
+inline bool SolveEventHandler::on_model(Model &) { return true; }
+inline void SolveEventHandler::on_finish(SolveResult) { }
 
 struct SolveFuture {
     virtual SolveResult get() = 0;


### PR DESCRIPTION
This small patch removes two unnecessary semicolons from the clingo API that result in compiler warnings with GCC 7.