### PR TITLE
extending the propagator interface for theory output

### DIFF
--- a/app/clingo/tests/python/project.lp
+++ b/app/clingo/tests/python/project.lp
@@ -1,30 +1,10 @@
-% Programme de fouille de motifs séquentiels (occurrences minimales)
 % author : T. Guyet
-% date : 02/2014
-% 
-% parametres de la ligne de commande:
-%   * -c th=? : fixe le seuil (3 par default)
-%   * -c ml=? : profondeur de la recherche (taille max des motifs) (4 par default)
-%
-% ces deux valeurs sont remplacées par des constantes du programme :
-%   - th : seuil de frequence, valeur par defaut 3 : elle peut être modifiée par eds parametres lors de l'appel du programme
-%   - nbs : nombre de symboles : defini lors de la construction de la séquence
+% date   : 02/2014
 #const th = 3.
 
-% liste des symboles fréquents
 symb(S) :- th { seq(P,S) }, S=1..nbs.
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% partie visualisation
-%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-%#show occ/3. %ne pas afficher les occ pour l'option project 
 #show pattern/2.
-%#show symb/1.
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% partie Contrôle de la résolution
-%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 #script(python)
 import sys, os
@@ -78,7 +58,6 @@ def readsequence(filename):
 
 def genASPsequence(seq, prg):
     i=1
-    #ajout de la constante pour le nombre de symboles
     s="#const nbs = "+str(max(seq)) +"."
     prg.add("base",[], s )
     for n in seq:
@@ -87,13 +66,13 @@ def genASPsequence(seq, prg):
         i=i+1
 
 def on_model(model):
-    pattern={} # map qui associe le numero d'instance à un numero de structure
-    
+    pattern={}
+
     for atom in model.symbols(atoms=True):
         if atom.name()=="pattern":
             args = atom.arguments
             pattern[ args[0] ]=args[1]
-    
+
     found=False
     for i in patterns:
         if i==pattern:
@@ -103,7 +82,6 @@ def on_model(model):
         patterns.append( pattern )
 
 def main(prg):
-    #Chargement du jeu de données
     theseq = readsequence("we_cmp.seq.minepi")
     genASPsequence(theseq, prg)
     prg.configuration.solve.project = "auto"
@@ -113,83 +91,31 @@ def main(prg):
         d=4
     else:
         d = d.number
-    
+
     prg.ground([("base",[])])
     prg.solve()
-    
+
     for k in range(2,d+1):
         prg.ground([("incr",[k])])
         prg.solve()
 #end.
 
-%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% partie Base
-%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-% génération de tous les motifs de taille 1
 1{ pattern(1, P) : symb(P) } 1.
 
-% on genere les occurrences pour chacun des patterns-singletons : le numero de l'instance est la position initiale (unique) !
 { occ(P, 1, P) : seq(P, S) } :- pattern(1,S).
 
-% pour imposer d'avoir nécessairement toutes les occurrenres d'un motifs (et pas simplement des sous-ensembles):
 :- seq(P, S), not occ(P, 1, P), pattern(1,S).
 
-%%%%%%%%%%%%
-%% cas des tailles 2
-%1{ pattern(2, P) : symb(P) } 1.
-
-% extention des occurrences du motif
-%0{ occ(I,2,Q) : seq(Q,S), pattern(2,S), Q>P } 1 :- occ(I, 1, P).
-
-%:- occ(I, 1, P), occ(I, 2, Q), seq(P',S), pattern(2,S), P<P', P'<Q.
-%:- occ(I, 2, P), occ(J, 2, P'), P=P', I<J. %deux occurrences ne peuvent pas avoir la même fin
-%:- occ(I, 1, P), occ(J, 1, P'), occ(I, 2, Q), occ(J, 2, Q'), P<P', Q'<Q, I!=J. %pas d'inclusion des occurrences d'un meme motif
-
-% contrainte de frequence
-%idocc(I,2) :- occ(I,2,Q).
-%:- { idocc(I,2) } th-1.
-
-%%%%%%%%%%%%%%%%%%%%%%%%%%%
-%% partie incrementale
-%%%%%%%%%%%%%%%%%%%%%%%%%%%
-
-
 #program incr(n).
-%#external pattern(1..n, 1..nbs).
-%#external occ(I, n-1, 1..nbs)
 
-% extension du motif
 1{ pattern(n, P) : symb(P) } 1.
 
-% extension des occurrences du motif
-% ATTENTION : il faut mettre une contrainte de type 0 { ... } 1
-%   1: il faut en generer au plus 1 dans un AS
-%   0: il faut laisser la possibilite de ne pas pouvoir completer l'occurrence !
 0{ occ(I,n,Q) : seq(Q,S), pattern(n,S), Q>P } 1 :- occ(I, n-1, P).
-%0{ possocc(I,n,Q) : seq(Q,S), pattern(n,S), Q>P } 1 :- occ(I, n-1, P).
 
-%#show occ/3.
-
-%
-%#external closed(1..nbs).
-%% pour savoir si le motif plus petit est fermé par l'ajout de S:
-%nbnext(I,n-1,N) :- occ(I, n-1, P), N={ occ(I,n,Q) }.
-%closed(S) :- { nbnext(I,n-1,N) : N=0 } 0, pattern(n,S).
-%#show closed/1.
-
-
-% On prend le premier symbole de la fin du motif juste apres la fin d'une occurrence du motif "inferieur" :
 :- occ(I, n-1, P), occ(I, n, Q), seq(P',S), pattern(n,S), P<P', P'<Q.
-%:- occ(I, n-1, P), occ(I, n, Q), occ(J, 1, P'), J!=I, P<P', P'<Q.
+:- occ(I, n, P), occ(J, n, P'), P=P', I<J.
+:- occ(I, 1, P), occ(J, 1, P'), occ(I, n, Q), occ(J, n, Q'), P<P', Q'<Q, I!=J.
 
-:- occ(I, n, P), occ(J, n, P'), P=P', I<J. %deux occurrences ne peuvent pas avoir la même fin
-:- occ(I, 1, P), occ(J, 1, P'), occ(I, n, Q), occ(J, n, Q'), P<P', Q'<Q, I!=J. %pas d'inclusion des occurrences d'un meme motif
-
-%test(n) :- occ(I, n-1, P), occ(I, n, Q), seq(P',S), pattern(n,S), P<P', P'<Q.
-%#show test/1.
-
-% contrainte de frequence
 idocc(I,n) :- occ(I,n,Q).
 :- { idocc(I,n) } th-1.
 

--- a/examples/clingo/output/output-py.lp
+++ b/examples/clingo/output/output-py.lp
@@ -1,0 +1,32 @@
+#script (python)
+
+import sys
+import time
+import clingo
+
+### This propagator counts the models and adds a respective symbol to the model for inspection
+class Propagator:
+    def init(self, init):
+	self.model = 0
+        init.check_mode = clingo.PropagatorCheckMode.Total
+
+    def check(self, ctl):
+	self.model = self.model+1
+        return True
+
+    def extend_model(self, threadId, complement, ret):
+        ret.append(clingo.Number(self.model))
+
+def on_model(m):
+    print("This is the model with number: " + " ".join(map(str, m.symbols(extra=True))))
+
+def main(prg):
+    prg.register_propagator(Propagator())
+    prg.ground([("base", [])])
+    prg.solve(on_model=on_model)
+    sys.stdout.write("\n")
+
+#end.
+
+
+1{a;b;c}1.

--- a/libclingo/clingo.h
+++ b/libclingo/clingo.h
@@ -1476,6 +1476,18 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_add_clause(clingo_propag
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_propagate(clingo_propagate_control_t *control, bool *result);
 
 //! @}
+//! Callback function to inject symbols.
+//!
+//! @param symbols array of symbols
+//! @param symbols_size size of the symbol array
+//! @param data user data of the callback
+//! @return whether the call was successful; might set one of the following error codes:
+//! - ::clingo_error_bad_alloc
+//! @see ::clingo_ground_callback_t
+//! @see ::clingo_extend_model
+typedef bool (*clingo_symbol_callback_t) (clingo_symbol_t const *symbols, size_t symbols_size, void *data);
+
+
 
 //! Typedef for @ref ::clingo_propagator::init().
 typedef bool (*clingo_propagator_init_callback_t) (clingo_propagate_init_t *, void *);
@@ -1488,6 +1500,9 @@ typedef bool (*clingo_propagator_undo_callback_t) (clingo_propagate_control_t *,
 
 //! Typedef for @ref ::clingo_propagator::check().
 typedef bool (*clingo_propagator_check_callback_t) (clingo_propagate_control_t *, void *);
+
+//! Typedef for @ref ::clingo_propagator::extend_model().
+typedef bool (*clingo_propagator_extend_model_callback_t) (int, bool, clingo_symbol_callback_t  symbol_callback, void *symbol_callback_dataconst, void *);
 
 //! An instance of this struct has to be registered with a solver to implement a custom propagator.
 //!
@@ -1568,6 +1583,19 @@ typedef struct clingo_propagator {
     //! @return whether the call was successful
     //! @see ::clingo_propagator_check_callback_t
     bool (*check) (clingo_propagate_control_t *control, void *data);
+    //! This function is called whenever a model is printed (not when it is found).
+    //! The model can be extended by any number of symbols.
+    //!
+    //! When exactly this function is called, depends on the current output mode.
+    //!
+    //! @param[in] thread id of the solver that found the model
+    //! @param[in] flag to indicate that the complement of the model is requested
+    //! @param[out] a vector of symbols
+    //! @param[in] data user data for the callback
+    //! @return whether the call was successful
+    //! @see ::clingo_propagator_extend_model_callback_t
+    bool (*extend_model) (int, bool, clingo_symbol_callback_t symbol_callback, void *symbol_callback_data, void *);
+
 } clingo_propagator_t;
 
 //! @}
@@ -2955,16 +2983,6 @@ typedef struct clingo_part {
     clingo_symbol_t const *params; //!< array of parameters
     size_t size;                   //!< number of parameters
 } clingo_part_t;
-
-//! Callback function to inject symbols.
-//!
-//! @param symbols array of symbols
-//! @param symbols_size size of the symbol array
-//! @param data user data of the callback
-//! @return whether the call was successful; might set one of the following error codes:
-//! - ::clingo_error_bad_alloc
-//! @see ::clingo_ground_callback_t
-typedef bool (*clingo_symbol_callback_t) (clingo_symbol_t const *symbols, size_t symbols_size, void *data);
 
 //! Callback function to implement external functions.
 //!

--- a/libclingo/clingo/clingocontrol.hh
+++ b/libclingo/clingo/clingocontrol.hh
@@ -243,7 +243,11 @@ public:
     virtual void prePrepare(Clasp::ClaspFacade& ) { }
     virtual void preSolve(Clasp::ClaspFacade& clasp) { if (psf_) { psf_(clasp);} }
     virtual void postSolve(Clasp::ClaspFacade& ) { }
-    virtual void addToModel(Clasp::Model const&, bool /*complement*/, SymVec& ) { }
+    virtual void addToModel(Clasp::Model const& m, bool /*complement*/, SymVec& symVec) {
+        for (auto& prop : props_) {
+            prop->extend_model(m.sId, false, symVec);
+        }
+    }
 
     // {{{2 SymbolicAtoms interface
 
@@ -331,6 +335,20 @@ public:
     bool                                                       configUpdate_          = false;
     bool                                                       initialized_           = false;
     bool                                                       incmode_               = false;
+
+private:
+
+    class TheoryOutput : public Clasp::OutputTable::Theory {
+    public:
+        TheoryOutput(ClingoControl& ctl);
+        const char* first(const Clasp::Model& m) override;
+        const char* next() override;
+    private:
+        ClingoControl&              ctl_;
+        std::vector<std::string>    last_;
+        size_t                      index_;
+    } theory_;
+
 };
 
 // {{{1 declaration of ClingoModel

--- a/libclingo/clingo/control.hh
+++ b/libclingo/clingo/control.hh
@@ -185,6 +185,7 @@ namespace Gringo {
 struct Propagator : Potassco::AbstractPropagator {
     virtual ~Propagator() noexcept = default;
     virtual void init(Gringo::PropagateInit &init) = 0;
+    virtual void extend_model(int threadId, bool complement, SymVec&) { }
 };
 using UProp = std::unique_ptr<Propagator>;
 

--- a/libclingo/src/clingocontrol.cc
+++ b/libclingo/src/clingocontrol.cc
@@ -138,7 +138,10 @@ ClingoControl::ClingoControl(Scripts &scripts, bool clingoMode, Clasp::ClaspFaca
 , pgf_(pgf)
 , psf_(psf)
 , logger_(printer, messageLimit)
-, clingoMode_(clingoMode) { }
+, clingoMode_(clingoMode)
+, theory_(*this) {
+    clasp->ctx.output.theory = &theory_;
+}
 
 void ClingoControl::parse() {
     if (!parser_->empty()) {
@@ -396,6 +399,28 @@ void ClingoControl::prepare(Assumptions ass) {
 
 void *ClingoControl::claspFacade() {
     return clasp_;
+}
+
+ClingoControl::TheoryOutput::TheoryOutput(ClingoControl& ctl) : ctl_(ctl) { }
+
+const char* ClingoControl::TheoryOutput::first(const Clasp::Model& m) {
+    last_.clear();
+    SymVec symbols_;
+    index_ = 1;
+    for (auto& prop : ctl_.props_) {
+        prop->extend_model(m.sId, false, symbols_);
+    }
+    std::stringstream ss;
+    for (auto& s : symbols_) {
+        ss.str("");
+        s.print(ss);
+        last_.emplace_back(ss.str());
+    }
+    return last_.size() ? last_.front().c_str() : nullptr;
+}
+
+const char* ClingoControl::TheoryOutput::next() {
+    return last_.size() > index_ ? last_[index_++].c_str() : nullptr;
 }
 
 void ClingoControl::registerPropagator(std::unique_ptr<Propagator> p, bool sequential) {

--- a/libclingo/src/control.cc
+++ b/libclingo/src/control.cc
@@ -1214,6 +1214,16 @@ public:
     void check(Potassco::AbstractSolver& solver) override {
         if (prop_.check && !prop_.check(static_cast<clingo_propagate_control_t*>(&solver), data_)) { throw ClingoError(); }
     }
+    void extend_model(int threadId, bool complement, SymVec& symVec) override {
+	auto l = [](clingo_symbol_t const *symbols, size_t symbols_size, void *data) -> bool { 
+	    reinterpret_cast<SymVec*>(data)->insert(reinterpret_cast<SymVec*>(data)->end(),
+	                                            reinterpret_cast<const Symbol*>(symbols),
+						    reinterpret_cast<const Symbol*>(symbols+symbols_size));
+	    return true;
+	    };
+	if (prop_.extend_model && !prop_.extend_model(threadId, complement, l, &symVec, data_))
+	    { throw ClingoError(); }
+    }
 private:
     clingo_propagator_t prop_;
     void *data_;

--- a/libpyclingo/pyclingo.cc
+++ b/libpyclingo/pyclingo.cc
@@ -3182,6 +3182,25 @@ bool propagator_check(clingo_propagate_control_t *control, PyObject *prop) {
     }
 }
 
+bool propagator_extend_model(int thread_id, bool complement, clingo_symbol_callback_t symbol_callback, void* symbol_callback_data, PyObject *prop) {
+    PyBlock block;
+    try {
+        if (!PyObject_HasAttrString(prop, "extend_model")) { return true; }
+        Object i = cppToPy(thread_id);
+        Object c = cppToPy(complement);
+        std::vector<symbol_wrapper> v;
+        Object s = cppToPy(v);
+        Object n  = PyString_FromString("extend_model");
+        Object ret = PyObject_CallMethodObjArgs(prop, n.toPy(), i.toPy(), c.toPy(), s.toPy(), nullptr); 
+        pyToCpp(s,v);
+        return symbol_callback(reinterpret_cast<const clingo_symbol_t*>(v.data()), v.size(), symbol_callback_data);
+    }
+    catch (...) {
+        handle_cxx_error("Propagator::extend_model", "error during model extension");
+        return false;
+    }
+}
+
 // {{{1 wrap observer
 
 struct TruthValue : EnumType<TruthValue> {
@@ -5853,7 +5872,8 @@ active; you must not call any member function during search.)";
             reinterpret_cast<decltype(clingo_propagator_t::init)>(propagator_init),
             reinterpret_cast<decltype(clingo_propagator_t::propagate)>(propagator_propagate),
             reinterpret_cast<decltype(clingo_propagator_t::undo)>(propagator_undo),
-            reinterpret_cast<decltype(clingo_propagator_t::check)>(propagator_check)
+            reinterpret_cast<decltype(clingo_propagator_t::check)>(propagator_check),
+            reinterpret_cast<decltype(clingo_propagator_t::extend_model)>(propagator_extend_model)
         };
         prop.emplace_back(tp);
         handle_c_error(clingo_control_register_propagator(ctl, &propagator, tp.toPy(), false));
@@ -6409,7 +6429,20 @@ class Propagator(object)
         Arguments:
         control -- PropagateControl object
 
-        This function is called even if no watches have been added.)"},
+        This function is called even if no watches have been added.
+
+    extend_model(self, thread_id, complement, symbols) -> None
+        This function is called whenever a model is printed (not when it is found).
+        The model can be extended by any number of symbols.
+
+
+        Arguments:
+        thread_id -- the solver thread id
+        complement -- true if the complement of the model is requested
+        symbols -- a list of symbols to be added to the model
+	
+
+        When exactly this function is called, depends on the current output mode.)"},
     {"interrupt", to_function<&ControlWrap::interrupt>(), METH_NOARGS,
 R"(interrupt(self) -> None
 


### PR DESCRIPTION
I propose an addition to the propagator interface to add gringo symbols to any model.
These symbols can be inspected as extra symbols in the atoms() function.
They are also included in the ASP output, format independent.
Working for C/C++/Python. Need help with the lua implementation.