### PR TITLE
Expose exponentiation operator via the API

### DIFF
--- a/libclingo/clingo.h
+++ b/libclingo/clingo.h
@@ -2184,7 +2184,8 @@ enum clingo_ast_binary_operator {
     clingo_ast_binary_operator_minus          = 4,
     clingo_ast_binary_operator_multiplication = 5,
     clingo_ast_binary_operator_division       = 6,
-    clingo_ast_binary_operator_modulo         = 7
+    clingo_ast_binary_operator_modulo         = 7,
+    clingo_ast_binary_operator_power          = 8
 
 };
 typedef int clingo_ast_binary_operator_t;

--- a/libclingo/clingo.hh
+++ b/libclingo/clingo.hh
@@ -1318,7 +1318,8 @@ enum class BinaryOperator : clingo_ast_binary_operator_t {
     Minus          = clingo_ast_binary_operator_minus,
     Multiplication = clingo_ast_binary_operator_multiplication,
     Division       = clingo_ast_binary_operator_division,
-    Modulo         = clingo_ast_binary_operator_modulo
+    Modulo         = clingo_ast_binary_operator_modulo,
+    Power          = clingo_ast_binary_operator_power
 };
 
 inline std::ostream &operator<<(std::ostream &out, BinaryOperator op) {
@@ -1331,6 +1332,7 @@ inline std::ostream &operator<<(std::ostream &out, BinaryOperator op) {
         case BinaryOperator::Multiplication: { out << "*"; break; }
         case BinaryOperator::Division:       { out << "/"; break; }
         case BinaryOperator::Modulo:         { out << "\\"; break; }
+        case BinaryOperator::Power:          { out << "**"; break; }
     }
     return out;
 }

--- a/libpyclingo/pyclingo.cc
+++ b/libpyclingo/pyclingo.cc
@@ -3813,6 +3813,7 @@ BinaryOperator.Minus          -- arithmetic subtraction
 BinaryOperator.Multiplication -- arithmetic multipilcation
 BinaryOperator.Division       -- arithmetic division
 BinaryOperator.Modulo         -- arithmetic modulo
+BinaryOperator.Power          -- arithmetic exponentiation
 )";
     static constexpr clingo_ast_binary_operator_t const values[] = {
         clingo_ast_binary_operator_xor,
@@ -3823,6 +3824,7 @@ BinaryOperator.Modulo         -- arithmetic modulo
         clingo_ast_binary_operator_multiplication,
         clingo_ast_binary_operator_division,
         clingo_ast_binary_operator_modulo,
+        clingo_ast_binary_operator_power,
     };
     static constexpr const char * const strings[] = {
         "XOr",
@@ -3833,6 +3835,7 @@ BinaryOperator.Modulo         -- arithmetic modulo
         "Multiplication",
         "Division",
         "Modulo",
+        "Power",
     };
     Object tp_repr() {
         switch (offset) {
@@ -3844,6 +3847,7 @@ BinaryOperator.Modulo         -- arithmetic modulo
             case 5: { return PyString_FromString("*"); }
             case 6: { return PyString_FromString("/"); }
             case 7: { return PyString_FromString("\\"); }
+            case 8: { return PyString_FromString("**"); }
         }
         throw std::logic_error("cannot happen");
     }


### PR DESCRIPTION
I noticed that the Clingo API is missing the exponentiation (or ”power”) operator. In my project, I have a `switch` statement that covers all types of binary operators and noticed that it made a difference if I had a `default` case or if I listed all possible cases separately if my input program contained `**` as an arithmetic operator.

This was a bit tricky to debug, because the compiler does not give any hints about the issue, as it doesn’t expect out-of-bounds values with `enum class` values (which possibly is a case of undefined behavior).

This pull request adds the missing exponentiation operator to the C API as well as the C++ and Python bindings.

If I see that correctly, the binary operator type is transferred from Clingo’s internal representation to the C API in: https://github.com/potassco/clingo/blob/9bbad4cf18723be04d14c4d8a4aba424a29de4ea/libclingo/src/ast.cc#L137 from a Clingo-internal `BinOp`: https://github.com/potassco/clingo/blob/9bbad4cf18723be04d14c4d8a4aba424a29de4ea/libgringo/gringo/term.hh#L48 through a `static_cast`. (This also explains why the compiler doesn’t complain about the missing `enum class` value.) For this reason, it seems like it’s enough to add the missing exponentiation operator to the respective enums in the C API as well as the C++ and Python bindings. I’m not sure about the Lua bindings, but to me it looks like they don’t need to be touched in this case.

I’m not sure whether this can be unit-tested in a meaningful way. Please also let me know if I have overseen another place in the code that would need to be adjusted :slightly_smiling_face:.