### PR TITLE
Control.solve(): rename async keyword argument to async_

### DIFF
--- a/app/clingo/tests/python/assumptions4.lp
+++ b/app/clingo/tests/python/assumptions4.lp
@@ -7,7 +7,7 @@ def main(prg):
     prg.ground([("base", [])])
     prg.solve(assumptions=[(Function("a"), True)])
 
-    with prg.solve(assumptions=[(Function("a"), True)], async=True) as handle:
+    with prg.solve(assumptions=[(Function("a"), True)], async_=True) as handle:
         handle.get()
 
     with prg.solve(assumptions=[(Function("a"), True)], yield_=True) as handle:

--- a/app/clingo/tests/python/cancel.lp
+++ b/app/clingo/tests/python/cancel.lp
@@ -8,7 +8,7 @@ def main(prg):
         prg.assign_external(clingo.Function("p"), True)
         prg.solve()
         prg.assign_external(clingo.Function("p"), False)
-        with prg.solve(async=True) as handle:
+        with prg.solve(async_=True) as handle:
             handle.wait(0.01)
             handle.cancel()
 

--- a/app/clingo/tests/python/interrupt.lp
+++ b/app/clingo/tests/python/interrupt.lp
@@ -8,7 +8,7 @@ def main(prg):
         prg.assign_external(clingo.Function("p"), True)
         prg.solve()
         prg.assign_external(clingo.Function("p"), False)
-        with prg.solve(async=True) as handle:
+        with prg.solve(async_=True) as handle:
             handle.wait(0.01)
             prg.interrupt()
 

--- a/app/clingo/tests/python/test.lp
+++ b/app/clingo/tests/python/test.lp
@@ -31,7 +31,7 @@ def main (prg):
         parts.append(("cumulative", [i]))
         prg.ground(parts)
         parts = []
-        with prg.solve(on_model=on_model, on_finish=on_finish, async=True) as handle:
+        with prg.solve(on_model=on_model, on_finish=on_finish, async_=True) as handle:
             handle.wait(0)
             ret = handle.get()
         writeln("Answer: 42")

--- a/app/clingo/tests/run.py
+++ b/app/clingo/tests/run.py
@@ -136,7 +136,7 @@ if parse_ret.action == "run":
                 inst = open(b + ".lp", 'rU').read()
                 if (not with_python and re.search(r"#script[ ]*\(python\)", inst)) or \
                    (not with_lua and re.search(r"#script[ ]*\(lua\)", inst)) or \
-                   (not with_threads and re.search("async=", inst)) or \
+                   (not with_threads and re.search("async_=", inst)) or \
                    (not with_threads and re.search("solve_async", inst)):
                     continue
 

--- a/examples/clingo/controller-async/controller.py
+++ b/examples/clingo/controller-async/controller.py
@@ -104,7 +104,7 @@ class Solver:
             self.prg.ground([("sleep", [self.k])])
             self.prg.release_external(clingo.Function("sleep", [self.k-1]))
             self.prg.assign_external(clingo.Function("sleep", [self.k]), True)
-        self.future = self.prg.solve(on_model=self.on_model, on_finish=on_finish, async=True)
+        self.future = self.prg.solve(on_model=self.on_model, on_finish=on_finish, async_=True)
 
     def stop(self):
         self.future.cancel()

--- a/examples/clingo/controller-processes/client.py
+++ b/examples/clingo/controller-processes/client.py
@@ -42,7 +42,7 @@ def main(prg):
             if state == States.SOLVE:
                 f = prg.solve(
                     on_model  = lambda model: conn.sendall(b"Answer: " + str(model).encode() + b"\n"),
-                    on_finish = lambda ret:   conn.sendall(b"finish:" + str(ret).encode() + (b":INTERRUPTED" if ret.interrupted else b"") + b"\n"), async=True)
+                    on_finish = lambda ret:   conn.sendall(b"finish:" + str(ret).encode() + (b":INTERRUPTED" if ret.interrupted else b"") + b"\n"), async_=True)
             msg = recv.readline().decode()
             if state == States.SOLVE:
                 f.cancel()

--- a/examples/clingo/controller-threads/controller.py
+++ b/examples/clingo/controller-threads/controller.py
@@ -129,7 +129,7 @@ class SolveThread(Thread):
     def run(self):
         while True:
             if self.state == SolveThread.STATE_SOLVE:
-                f = self.prg.solve(on_model=self.on_model, on_finish=self.on_finish, async=True)
+                f = self.prg.solve(on_model=self.on_model, on_finish=self.on_finish, async_=True)
             msg = self.input.receive()
             if self.state == SolveThread.STATE_SOLVE:
                 f.cancel()

--- a/examples/clingo/robots/visualize.py
+++ b/examples/clingo/robots/visualize.py
@@ -119,7 +119,7 @@ class Solver:
         for x in self.__assign:
             self.__prg.assign_external(x, True)
         self.__solution = None
-        self.__future = self.__prg.solve(on_model=self.__on_model, async=True)
+        self.__future = self.__prg.solve(on_model=self.__on_model, async_=True)
 
     def busy(self):
         if self.__future is None:
@@ -127,7 +127,7 @@ class Solver:
         if self.__future.wait(0):
             if self.__solution is None:
                 self.__next()
-                self.__future = self.__prg.solve(on_model=self.__on_model, async=True)
+                self.__future = self.__prg.solve(on_model=self.__on_model, async_=True)
                 return True
             else:
                 self.__future = None

--- a/examples/clingo/solve-async/solve-async-py.lp
+++ b/examples/clingo/solve-async/solve-async-py.lp
@@ -10,7 +10,7 @@ def make_on_finish(stop):
 def main(prg):
     stop = [False]
     prg.ground([("base", [])])
-    future, n, m = prg.solve(on_finish=make_on_finish(stop), async=True), 0, 0
+    future, n, m = prg.solve(on_finish=make_on_finish(stop), async_=True), 0, 0
     while not stop[0]:
         x, y, m = random(), random(), m+1
         if x * x + y * y < 1: n+= 1

--- a/libpyclingo/pyclingo.cc
+++ b/libpyclingo/pyclingo.cc
@@ -6320,7 +6320,7 @@ active; you must not call any member function during search.)";
         CHECK_BLOCKED("solve");
         Py_XDECREF(stats);
         stats = nullptr;
-        static char const *kwlist[] = {"assumptions", "on_model", "on_statistics", "on_finish", "yield_", "async", nullptr};
+        static char const *kwlist[] = {"assumptions", "on_model", "on_statistics", "on_finish", "yield_", "async_", nullptr};
         Reference pyAss = Py_None, pyM = Py_None, pyS = Py_None, pyF = Py_None, pyYield = Py_False, pyAsync = Py_False;
         ParseTupleAndKeywords(args, kwds, "|OOOOOO", kwlist, pyAss, pyM, pyS, pyF, pyYield, pyAsync);
         std::vector<clingo_literal_t> ass;
@@ -6569,7 +6569,7 @@ Arguments:
 path -- path to program)"},
     // solve
     {"solve", to_function<&ControlWrap::solve>(), METH_KEYWORDS | METH_VARARGS,
-R"(solve(self, assumptions, on_model, on_finish, yield_, async) -> SolveHandle|SolveResult
+R"(solve(self, assumptions, on_model, on_finish, yield_, async_) -> SolveHandle|SolveResult
 
 Starts a search.
 
@@ -6593,10 +6593,10 @@ assumptions   -- List of (atom, boolean) tuples or program literals that serve
                  (Default: [])
 yield_        -- The resulting SolveHandle is iterable yielding Model objects.
                  (Default: False)
-async         -- The solve call and SolveHandle.resume() are non-blocking.
+async_        -- The solve call and SolveHandle.resume() are non-blocking.
                  (Default: False)
 
-If neither yield_ nor async is set, the function returns a SolveResult right
+If neither yield_ nor async_ is set, the function returns a SolveResult right
 away.
 
 Note that in gringo or in clingo with lparse or text output enabled this
@@ -6655,7 +6655,7 @@ def on_finish(res, canceled):
 def main(prg):
     prg.add("p", [], "{a;b;c}.")
     prg.ground([("base", [])])
-    with prg.solve(on_model=on_model, on_finish=on_finish, async=True) as handle:
+    with prg.solve(on_model=on_model, on_finish=on_finish, async_=True) as handle:
         while not handle.wait(0):
             # do something asynchronously
         print(handle.get())


### PR DESCRIPTION
`async` is a reserved keyword starting with python 3.7:
https://docs.python.org/3/whatsnew/3.7.html#summary-release-highlights

This commit introduces a backwards incompatible change in the clingo
python module. The `Control` class method `solve()` now uses the following
keyword argument list:

`solve(self, assumptions, on_model, on_finish, yield_, async_)`