### PR TITLE
libclingo: fix catching polymorphic exception by value

### DIFF
--- a/libclingo/clingo.hh
+++ b/libclingo/clingo.hh
@@ -3873,7 +3873,7 @@ inline void Control::ground(PartSpan parts, GroundCallback cb) {
                             if (!cb(reinterpret_cast<clingo_symbol_t const *>(symret.begin()), symret.size(), cbdata)) { throw Ret(); }
                         });
                     }
-                    catch (Ret e) { return false; }
+                    catch (Ret const &e) { return false; }
                 }
             }
             CLINGO_CALLBACK_CATCH(d.second);


### PR DESCRIPTION
GCC 8 warns about polymorphic structs being caught by value rather than by reference. Fix by catching a reference. This currently prevents building on, e.g., Fedora 28 or later.