### PR TITLE
Remove extraneous semicolon

### DIFF
--- a/libclingo/clingo.hh
+++ b/libclingo/clingo.hh
@@ -1871,7 +1871,7 @@ class StatisticsBase {
 public:
     using statistics_t = typename std::conditional<constant, clingo_statistics_t const *, clingo_statistics_t*>::type;
     using KeyIteratorT = KeyIterator<StatisticsBase>;
-    using ArrayIteratorT = ArrayIterator<StatisticsBase, StatisticsBase const *>;;
+    using ArrayIteratorT = ArrayIterator<StatisticsBase, StatisticsBase const *>;
     using KeyRangeT = IteratorRange<KeyIteratorT>;
     explicit StatisticsBase(statistics_t stats, uint64_t key)
     : stats_(stats)


### PR DESCRIPTION
This is really just a minor nit :slightly_smiling_face:.

Clang complains about this extraneous semicolon. As this semicolon occurs in a header file, it introduces a lot of noise when building projects that use Clingo as a dependency.

Please let me know if you prefer such pull requests to be directed at the `wip` branch instead of `master`.