### PR TITLE
Remove extraneous lambda captures

### DIFF
--- a/libgringo/src/input/aggregates.cc
+++ b/libgringo/src/input/aggregates.cc
@@ -323,7 +323,7 @@ CreateBody TupleBodyAggregate::toGround(ToGroundArg &x, Ground::UStmVec &stms) c
             return std::move(ret);
         });
         for (auto &y : elems) {
-            split.emplace_back([this,&completeRef,&y,&x](Ground::ULitVec &&lits) -> Ground::UStm {
+            split.emplace_back([&completeRef,&y,&x](Ground::ULitVec &&lits) -> Ground::UStm {
                 for (auto &z : y.second) { lits.emplace_back(z->toGround(x.domains, false)); }
                 auto ret = gringo_make_unique<Ground::BodyAggregateAccumulate>(completeRef, get_clone(y.first), std::move(lits));
                 completeRef.addAccuDom(*ret);
@@ -361,14 +361,14 @@ CreateBody TupleBodyAggregate::toGround(ToGroundArg &x, Ground::UStmVec &stms) c
             return std::move(ret);
         });
         for (auto &y : elems) {
-            split.emplace_back([this,&completeRef,&y,&x](Ground::ULitVec &&lits) -> Ground::UStm {
+            split.emplace_back([&completeRef,&y,&x](Ground::ULitVec &&lits) -> Ground::UStm {
                 for (auto &z : y.second) { lits.emplace_back(z->toGround(x.domains, false)); }
                 auto ret = gringo_make_unique<Ground::AssignmentAggregateAccumulate>(completeRef, get_clone(y.first), std::move(lits));
                 completeRef.addAccuDom(*ret);
                 return std::move(ret);
             });
         }
-        return CreateBody([&completeRef, this](Ground::ULitVec &lits, bool primary, bool auxiliary) {
+        return CreateBody([&completeRef](Ground::ULitVec &lits, bool primary, bool auxiliary) {
             if (primary) { lits.emplace_back(gringo_make_unique<Ground::AssignmentAggregateLiteral>(completeRef, auxiliary)); }
         }, std::move(split));
     }
@@ -1789,7 +1789,7 @@ CreateBody DisjointAggregate::toGround(ToGroundArg &x, Ground::UStmVec &stms) co
         return std::move(ret);
     });
     for (auto &y : elems) {
-        split.emplace_back([this,&completeRef,&y,&x](Ground::ULitVec &&lits) -> Ground::UStm {
+        split.emplace_back([&completeRef,&y,&x](Ground::ULitVec &&lits) -> Ground::UStm {
             for (auto &z : y.cond) { lits.emplace_back(z->toGround(x.domains, false)); }
             auto ret = gringo_make_unique<Ground::DisjointAccumulate>(completeRef, get_clone(y.tuple), get_clone(y.value), std::move(lits));
             completeRef.addAccuDom(*ret);

--- a/libgringo/src/input/theory.cc
+++ b/libgringo/src/input/theory.cc
@@ -393,20 +393,20 @@ CreateBody TheoryAtom::toGroundBody(ToGroundArg &x, Ground::UStmVec &stms, NAF n
     }
     auto &completeRef = static_cast<Ground::TheoryComplete&>(*stms.back());
     CreateStmVec split;
-    split.emplace_back([&completeRef, this](Ground::ULitVec &&lits) -> Ground::UStm {
+    split.emplace_back([&completeRef](Ground::ULitVec &&lits) -> Ground::UStm {
         auto ret = gringo_make_unique<Ground::TheoryAccumulate>(completeRef, std::move(lits));
         completeRef.addAccuDom(*ret);
         return std::move(ret);
     });
     for (auto &y : elems_) {
-        split.emplace_back([this,&completeRef,&y,&x](Ground::ULitVec &&lits) -> Ground::UStm {
+        split.emplace_back([&completeRef,&y,&x](Ground::ULitVec &&lits) -> Ground::UStm {
             auto ret = y.toGround(x, completeRef, std::move(lits));
             completeRef.addAccuDom(*ret);
             return std::move(ret);
         });
     }
     bool aux1 = type_ != TheoryAtomType::Body;
-    return CreateBody([this, &completeRef, naf, aux1](Ground::ULitVec &lits, bool primary, bool aux2) {
+    return CreateBody([&completeRef, naf, aux1](Ground::ULitVec &lits, bool primary, bool aux2) {
         if (primary) {
             auto ret = gringo_make_unique<Ground::TheoryLiteral>(completeRef, naf, aux1 || aux2);
             lits.emplace_back(std::move(ret));

--- a/libgringo/src/output/theory.cc
+++ b/libgringo/src/output/theory.cc
@@ -717,7 +717,7 @@ void TheoryData::printElem(std::ostream &out, Potassco::Id_t elemId, PrintLit pr
     }
     else if (!cond.empty()) {
         out << ": ";
-        print_comma(out, cond, ",", [this, &printLit](std::ostream &out, LiteralId const &lit){ printLit(out, lit); });
+        print_comma(out, cond, ",", [&printLit](std::ostream &out, LiteralId const &lit){ printLit(out, lit); });
     }
 }
 


### PR DESCRIPTION
This removes multiple occurrences of unnecessary lambda captures that result in warnings when compiling Clingo with clang.