### PR TITLE
prototypical implementation of add_clause in propagate init

### DIFF
--- a/app/clingo/tests/lua/add-clause-lua.lp
+++ b/app/clingo/tests/lua/add-clause-lua.lp
@@ -1,0 +1,49 @@
+#script (lua)
+
+require("clingo")
+
+Propagator = { }
+Propagator.__index = Propagator
+
+function Propagator.new()
+    local self = setmetatable({}, Propagator)
+    self.lits = {}
+    self.step = 0
+    return self
+end
+
+function Propagator:init(init)
+    local a = init:solver_literal(init.symbolic_atoms:lookup(clingo.Function("a")).literal)
+    local b = init:solver_literal(init.symbolic_atoms:lookup(clingo.Function("b")).literal)
+    if self.step == 0 then
+        assert(init:add_clause({-a, -b}))
+        assert(init:add_clause({-a,  b}))
+        assert(init:add_clause({-a, -a, -b}))
+        assert(init:add_clause({-a, a}))
+    end
+    if self.step == 1 then
+        assert(init:add_clause({b}))
+        assert(init:add_clause({b}))
+    end
+    if self.step == 2 then
+        assert(not init:add_clause({}))
+        assert(not init:add_clause({a}))
+        assert(not init:add_clause({b}))
+        assert(not init:add_clause({-a}))
+        assert(not init:add_clause({-b}))
+    end
+    self.step = self.step + 1
+end
+
+function main(prg)
+    local p = Propagator.new()
+    prg:register_propagator(p)
+    prg:ground({{"base", {}}})
+    prg:solve()
+    prg:solve()
+    prg:solve()
+end
+
+#end.
+
+{ a; b }.

--- a/app/clingo/tests/lua/add-clause-lua.sol
+++ b/app/clingo/tests/lua/add-clause-lua.sol
@@ -1,0 +1,7 @@
+Step: 1
+
+b
+Step: 2
+b
+Step: 3
+UNSAT

--- a/app/clingo/tests/python/add-clause-py.lp
+++ b/app/clingo/tests/python/add-clause-py.lp
@@ -1,0 +1,37 @@
+#script (python)
+
+import clingo
+
+class Propagator:
+    def __init__(self):
+        self.step = 0
+
+    def init(self, init):
+        a = init.solver_literal(init.symbolic_atoms[clingo.Function("a")].literal)
+        b = init.solver_literal(init.symbolic_atoms[clingo.Function("b")].literal)
+        if self.step == 0:
+            assert(init.add_clause([-a, -b]))
+            assert(init.add_clause([-a,  b]))
+            assert(init.add_clause([-a, -a, -b]))
+            assert(init.add_clause([-a, a]))
+        if self.step == 1:
+            assert(init.add_clause([b]))
+            assert(init.add_clause([b]))
+        if self.step == 2:
+            assert(not init.add_clause([]))
+            assert(not init.add_clause([a]))
+            assert(not init.add_clause([b]))
+            assert(not init.add_clause([-a]))
+            assert(not init.add_clause([-b]))
+        self.step += 1
+
+def main(prg):
+    prg.register_propagator(Propagator())
+    prg.ground([("base", [])])
+    prg.solve()
+    prg.solve()
+    prg.solve()
+
+#end.
+
+{ a; b }.

--- a/app/clingo/tests/python/add-clause-py.sol
+++ b/app/clingo/tests/python/add-clause-py.sol
@@ -1,0 +1,7 @@
+Step: 1
+
+b
+Step: 2
+b
+Step: 3
+UNSAT

--- a/libclingo/clingo.h
+++ b/libclingo/clingo.h
@@ -1086,6 +1086,17 @@ CLINGO_VISIBILITY_DEFAULT clingo_propagator_check_mode_t clingo_propagate_init_g
 //! @param[in] init the target
 //! @return the assignment
 CLINGO_VISIBILITY_DEFAULT clingo_assignment_t const *clingo_propagate_init_assignment(clingo_propagate_init_t const *init);
+//! Add the given clause to the solver.
+//!
+//! This method sets its result to false if the clause is causing a conflict.
+//!
+//! @param[in] init the target
+//! @param[in] clause the clause to add
+//! @param[in] size the size of the clause
+//! @param[out] result result indicating whether the clause is conflicting
+//! @return whether the call was successful; might set one of the following error codes:
+//! - ::clingo_error_bad_alloc
+CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_add_clause(clingo_propagate_init_t *init, clingo_literal_t const *clause, size_t size, bool *result);
 
 //! @}
 

--- a/libclingo/clingo.hh
+++ b/libclingo/clingo.hh
@@ -834,6 +834,7 @@ public:
     TheoryAtoms theory_atoms() const;
     PropagatorCheckMode get_check_mode() const;
     void set_check_mode(PropagatorCheckMode mode);
+    bool add_clause(LiteralSpan clause);
     clingo_propagate_init_t *to_c() const { return init_; }
 private:
     clingo_propagate_init_t *init_;
@@ -2739,6 +2740,12 @@ inline PropagatorCheckMode PropagateInit::get_check_mode() const {
 
 inline void PropagateInit::set_check_mode(PropagatorCheckMode mode) {
     clingo_propagate_init_set_check_mode(init_, mode);
+}
+
+inline bool PropagateInit::add_clause(LiteralSpan clause) {
+    bool ret;
+    Detail::handle_error(clingo_propagate_init_add_clause(init_, clause.begin(), clause.size(), &ret));
+    return ret;
 }
 
 // {{{2 propagate control

--- a/libclingo/clingo/clingocontrol.hh
+++ b/libclingo/clingo/clingocontrol.hh
@@ -164,6 +164,7 @@ public:
     void addWatch(Lit_t lit) override { p_.addWatch(Clasp::decodeLit(lit)); }
     void addWatch(uint32_t solverId, Lit_t lit) override { p_.addWatch(solverId, Clasp::decodeLit(lit)); }
     void enableHistory(bool b) override { p_.enableHistory(b); };
+    bool addClause(Potassco::LitSpan lits) override;
     void setCheckMode(clingo_propagator_check_mode_t checkMode) override {
         p_.enableClingoPropagatorCheck(static_cast<Clasp::ClingoPropagatorCheck_t::Type>(checkMode));
     }

--- a/libclingo/clingo/control.hh
+++ b/libclingo/clingo/control.hh
@@ -180,6 +180,7 @@ using PropagateInit = clingo_propagate_init;
 } // namespace Gringo
 
 struct clingo_propagate_init {
+    virtual bool addClause(Potassco::LitSpan lits) = 0;
     virtual Gringo::Output::DomainData const &theory() const = 0;
     virtual Gringo::SymbolicAtoms const &getDomain() const = 0;
     virtual Gringo::Lit_t mapLit(Gringo::Lit_t lit) const = 0;

--- a/libclingo/src/control.cc
+++ b/libclingo/src/control.cc
@@ -662,6 +662,11 @@ extern "C" clingo_assignment_t const *clingo_propagate_init_assignment(clingo_pr
     return static_cast<clingo_assignment_t const *>(&init->assignment());
 }
 
+extern "C" bool clingo_propagate_init_add_clause(clingo_propagate_init_t *init, clingo_literal_t const *literals, size_t size, bool *ret) {
+    GRINGO_CLINGO_TRY { *ret = init->addClause(Potassco::LitSpan{literals, size}); }
+    GRINGO_CLINGO_CATCH;
+}
+
 // {{{1 propagate control
 
 struct clingo_propagate_control : Potassco::AbstractSolver { };

--- a/libpyclingo/pyclingo.cc
+++ b/libpyclingo/pyclingo.cc
@@ -3479,6 +3479,16 @@ Control.register_propagator
         Py_RETURN_NONE;
     }
 
+    Object addClause(Reference pyargs, Reference pykwds) {
+        static char const *kwlist[] = {"clause", nullptr};
+        Reference pyClause;
+        ParseTupleAndKeywords(pyargs, pykwds, "O", kwlist, pyClause);
+        auto clause = pyToCpp<std::vector<clingo_literal_t>>(pyClause);
+        bool ret;
+        handle_c_error(clingo_propagate_init_add_clause(init, clause.data(), clause.size(), &ret));
+        return cppToPy(ret);
+    }
+
     Object getCheckMode() {
         return PropagatorCheckMode::getAttr(clingo_propagate_init_get_check_mode(init));
     }
@@ -3523,6 +3533,20 @@ Returns
 -------
 int
     A solver literal.
+)"},
+    {"add_clause", to_function<&PropagateInit::addClause>(), METH_KEYWORDS | METH_VARARGS, R"(add_clause(self, clause: List[int]) -> None
+
+Statically adds the given clause to the problem.
+
+Parameters
+----------
+clause : List[int]
+    The clause over solver literals to add.
+
+Returns
+-------
+bool
+    Returns false if the clause is conflicting.
 )"},
     {nullptr, nullptr, 0, nullptr}
 };


### PR DESCRIPTION
Hi @BenKaufmann, I added a function to add clauses while initializing the propagator. Clauses are added while propagators are initialized, i.e., right after calling `clasp_->program()->endProgram()` but before `clasp_->prepare()`. As far as I can see this should be a good point to add constraints. Can you have a quick look whether this is correct?