### PR TITLE
Use 0 instead of nullptr for python's tp_print for Python 3.8

### DIFF
--- a/libpyclingo/pyclingo.cc
+++ b/libpyclingo/pyclingo.cc
@@ -1177,7 +1177,7 @@ PyTypeObject ObjectBase<T>::type = {
     sizeof(T),                                  // tp_basicsize
     0,                                          // tp_itemsize
     PythonDetail::Get_tp_dealloc<T>::value,     // tp_dealloc
-    nullptr,                                    // tp_print
+    0,                                          // tp_print
     nullptr,                                    // tp_getattr
     nullptr,                                    // tp_setattr
     nullptr,                                    // tp_compare


### PR DESCRIPTION
In Python 3.8, the reserved `tp_print` slot was changed from a function
pointer to a number.  In C, there is no `nullptr`; either a 0 or NULL
casts automatically to both pointers and numbers.

Replace `nullptr` with `0` for `tp_print` to be compatible with Python
3.8.

See the [Fedora BZ](https://bugzilla.redhat.com/show_bug.cgi?id=1743883) for more information.