### PR TITLE
fix handling of undefined arithmetics

### DIFF
--- a/libgringo/gringo/base.hh
+++ b/libgringo/gringo/base.hh
@@ -249,7 +249,7 @@ inline BoundVec Bound::unpool() {
 }
 
 inline bool Bound::simplify(SimplifyState &state, Logger &log) {
-    return !bound->simplify(state, false, false, log).update(bound).undefined();
+    return !bound->simplify(state, false, false, log).update(bound, false).undefined();
 }
 
 inline void Bound::rewriteArithmetics(Term::ArithmeticsMap &arith, AuxGen &auxGen) {

--- a/libgringo/src/input/aggregates.cc
+++ b/libgringo/src/input/aggregates.cc
@@ -231,7 +231,7 @@ bool TupleBodyAggregate::simplify(Projections &project, SimplifyState &state, bo
     elems.erase(std::remove_if(elems.begin(), elems.end(), [&](BodyAggrElemVec::value_type &elem) {
         SimplifyState elemState(state);
         for (auto &term : std::get<0>(elem)) {
-            if (term->simplify(elemState, false, false, log).update(term).undefined()) { return true; }
+            if (term->simplify(elemState, false, false, log).update(term, false).undefined()) { return true; }
         }
         for (auto &lit : std::get<1>(elem)) {
             // NOTE: projection disabled with singelton=true
@@ -974,7 +974,7 @@ bool TupleHeadAggregate::simplify(Projections &project, SimplifyState &state, Lo
     elems.erase(std::remove_if(elems.begin(), elems.end(), [&](HeadAggrElemVec::value_type &elem) {
         SimplifyState elemState(state);
         for (auto &term : std::get<0>(elem)) {
-            if (term->simplify(elemState, false, false, log).update(term).undefined()) { return true; }
+            if (term->simplify(elemState, false, false, log).update(term, false).undefined()) { return true; }
         }
         if (!std::get<1>(elem)->simplify(log, project, elemState, false)) {
             return true;
@@ -1714,7 +1714,7 @@ bool DisjointAggregate::simplify(Projections &project, SimplifyState &state, boo
     elems.erase(std::remove_if(elems.begin(), elems.end(), [&](CSPElemVec::value_type &elem) {
         SimplifyState elemState(state);
         for (auto &term : elem.tuple) {
-            if (term->simplify(elemState, false, false, log).update(term).undefined()) { return true; }
+            if (term->simplify(elemState, false, false, log).update(term, false).undefined()) { return true; }
         }
         if (!elem.value.simplify(elemState, log)) { return true; }
         for (auto &lit : elem.cond) {
@@ -1871,7 +1871,7 @@ UHeadAggr MinimizeHeadLiteral::rewriteAggregates(UBodyAggrVec &) {
 
 bool MinimizeHeadLiteral::simplify(Projections &, SimplifyState &state, Logger &log) {
     for (auto &term : tuple_) {
-        if (term->simplify(state, false, false, log).update(term).undefined()) {
+        if (term->simplify(state, false, false, log).update(term, false).undefined()) {
             return false;
         }
     }
@@ -1979,8 +1979,8 @@ UHeadAggr EdgeHeadAtom::rewriteAggregates(UBodyAggrVec &) {
 }
 
 bool EdgeHeadAtom::simplify(Projections &, SimplifyState &state, Logger &log) {
-    return !u_->simplify(state, false, false, log).update(u_).undefined() &&
-           !v_->simplify(state, false, false, log).update(v_).undefined();
+    return !u_->simplify(state, false, false, log).update(u_, false).undefined() &&
+           !v_->simplify(state, false, false, log).update(v_, false).undefined();
 }
 
 void EdgeHeadAtom::rewriteArithmetics(Term::ArithmeticsMap &, AuxGen &) {
@@ -2063,7 +2063,7 @@ UHeadAggr ProjectHeadAtom::rewriteAggregates(UBodyAggrVec &body) {
 }
 
 bool ProjectHeadAtom::simplify(Projections &, SimplifyState &state, Logger &log) {
-    return !atom_->simplify(state, false, false, log).update(atom_).undefined();
+    return !atom_->simplify(state, false, false, log).update(atom_, false).undefined();
 }
 
 void ProjectHeadAtom::rewriteArithmetics(Term::ArithmeticsMap &arith, AuxGen &auxgen) {
@@ -2158,7 +2158,7 @@ UHeadAggr ExternalHeadAtom::rewriteAggregates(UBodyAggrVec &) {
 }
 
 bool ExternalHeadAtom::simplify(Projections &, SimplifyState &state, Logger &log) {
-    return !atom_->simplify(state, false, false, log).update(atom_).undefined() && !type_->simplify(state, false, false, log).update(type_).undefined();
+    return !atom_->simplify(state, false, false, log).update(atom_, false).undefined() && !type_->simplify(state, false, false, log).update(type_, false).undefined();
 }
 
 void ExternalHeadAtom::rewriteArithmetics(Term::ArithmeticsMap &arith, AuxGen &auxgen) {
@@ -2266,10 +2266,10 @@ UHeadAggr HeuristicHeadAtom::rewriteAggregates(UBodyAggrVec &body) {
 
 bool HeuristicHeadAtom::simplify(Projections &, SimplifyState &state, Logger &log) {
     return
-        !atom_->simplify(state, false, false, log).update(atom_).undefined() &&
-        !value_->simplify(state, false, false, log).update(value_).undefined() &&
-        !priority_->simplify(state, false, false, log).update(priority_).undefined() &&
-        !mod_->simplify(state, false, false, log).update(mod_).undefined();
+        !atom_->simplify(state, false, false, log).update(atom_, false).undefined() &&
+        !value_->simplify(state, false, false, log).update(value_, false).undefined() &&
+        !priority_->simplify(state, false, false, log).update(priority_, false).undefined() &&
+        !mod_->simplify(state, false, false, log).update(mod_, false).undefined();
 }
 
 void HeuristicHeadAtom::rewriteArithmetics(Term::ArithmeticsMap &arith, AuxGen &auxgen) {
@@ -2351,7 +2351,7 @@ UHeadAggr ShowHeadLiteral::rewriteAggregates(UBodyAggrVec &) {
 }
 
 bool ShowHeadLiteral::simplify(Projections &, SimplifyState &state, Logger &log) {
-    return !term_->simplify(state, false, false, log).update(term_).undefined();
+    return !term_->simplify(state, false, false, log).update(term_, false).undefined();
 }
 
 void ShowHeadLiteral::rewriteArithmetics(Term::ArithmeticsMap &, AuxGen &) {

--- a/libgringo/src/input/literals.cc
+++ b/libgringo/src/input/literals.cc
@@ -74,8 +74,8 @@ CSPLiteral *CSPLiteral::clone() const {
 // {{{1 definition of Literal::simplify
 
 bool RelationLiteral::simplify(Logger &log, Projections &, SimplifyState &state, bool, bool) {
-    if (left->simplify(state, false, false, log).update(left).undefined()) { return false; }
-    if (right->simplify(state, false, false, log).update(right).undefined()) { return false; }
+    if (left->simplify(state, false, false, log).update(left, false).undefined()) { return false; }
+    if (right->simplify(state, false, false, log).update(right, false).undefined()) { return false; }
     return true;
 }
 bool RangeLiteral::simplify(Logger &, Projections &, SimplifyState &, bool, bool) {
@@ -364,9 +364,9 @@ bool PredicateLiteral::simplify(Logger &log, Projections &project, SimplifyState
         positional = false;
     }
     auto ret(repr->simplify(state, positional, false, log));
-    ret.update(repr);
+    ret.update(repr, false);
     if (ret.undefined()) { return false; }
-    if (repr->simplify(state, positional, false, log).update(repr).project) {
+    if (repr->simplify(state, positional, false, log).update(repr, false).project) {
         auto rep(project.add(*repr));
         Term::replace(repr, std::move(rep));
     }

--- a/libgringo/src/input/theory.cc
+++ b/libgringo/src/input/theory.cc
@@ -269,7 +269,7 @@ void TheoryAtom::check(Location const &loc, Printable const &p, ChkLvlVec &level
 }
 
 bool TheoryAtom::simplify(Projections &project, SimplifyState &state, Logger &log) {
-    if (name_->simplify(state, false, false, log).update(name_).undefined()) {
+    if (name_->simplify(state, false, false, log).update(name_, false).undefined()) {
         return false;
     }
     for (auto &elem : elems_) {

--- a/libgringo/src/terms.cc
+++ b/libgringo/src/terms.cc
@@ -404,8 +404,8 @@ bool CSPMulTerm::operator==(CSPMulTerm const &x) const {
     else { return !var && !x.var && is_value_equal_to(coe, x.coe); }
 }
 bool CSPMulTerm::simplify(SimplifyState &state, Logger &log) {
-    if (var && var->simplify(state, false, false, log).update(var).undefined()) { return false;}
-    return !coe->simplify(state, false, false, log).update(coe).undefined();
+    if (var && var->simplify(state, false, false, log).update(var, false).undefined()) { return false;}
+    return !coe->simplify(state, false, false, log).update(coe, false).undefined();
 }
 void CSPMulTerm::rewriteArithmetics(Term::ArithmeticsMap &arith, AuxGen &auxGen) {
     if (var) { Term::replace(var, var->rewriteArithmetics(arith, auxGen)); }

--- a/libgringo/tests/ground/program.cc
+++ b/libgringo/tests/ground/program.cc
@@ -83,7 +83,7 @@ TEST_CASE("ground-program", "[ground]") {
             toString(parse("p(X):-q(X).")));
         REQUIRE(
             "% positive component\n"
-            "p(#Range0):-#Range0=1..2." ==
+            "p((#Range0+0)):-#Range0=1..2." ==
             toString(parse("p(1..2).")));
         REQUIRE(
             "% positive component\n"

--- a/libgringo/tests/input/aggregate.cc
+++ b/libgringo/tests/input/aggregate.cc
@@ -382,17 +382,17 @@ TEST_CASE("input-aggregate", "[input]") {
 
     SECTION("simplify") {
         // body tuple aggregate
-        REQUIRE("(#Range0>#sum{#Range1:p(#Range2),#range(#Range1,3,4),#range(#Range2,5,6)},[(#Range0,1,2)])" == simplify(bdaggr(NAF::POS, AggregateFunction::SUM, boundvec(Relation::LT, dterm(1,2)), bdelemvec(termvec(dterm(3,4)), litvec(dlit(5,6))))));
+        REQUIRE("((#Range0+0)>#sum{(#Range1+0):p((#Range2+0)),#range(#Range1,3,4),#range(#Range2,5,6)},[(#Range0,1,2)])" == simplify(bdaggr(NAF::POS, AggregateFunction::SUM, boundvec(Relation::LT, dterm(1,2)), bdelemvec(termvec(dterm(3,4)), litvec(dlit(5,6))))));
         // body lit aggregate
-        REQUIRE("(#Range0>#sum{p(#Range1):p(#Range2),#range(#Range1,3,4),#range(#Range2,5,6)},[(#Range0,1,2)])" == simplify(bdaggr(NAF::POS, AggregateFunction::SUM, boundvec(Relation::LT, dterm(1,2)), condlitvec(dlit(3,4), litvec(dlit(5,6))))));
+        REQUIRE("((#Range0+0)>#sum{p((#Range1+0)):p((#Range2+0)),#range(#Range1,3,4),#range(#Range2,5,6)},[(#Range0,1,2)])" == simplify(bdaggr(NAF::POS, AggregateFunction::SUM, boundvec(Relation::LT, dterm(1,2)), condlitvec(dlit(3,4), litvec(dlit(5,6))))));
         // conjunction
-        REQUIRE("(p(#Range0)&#range(#Range0,1,2):p(#Range1),#range(#Range1,3,4),[])" == simplify(bdaggr(dlit(1,2), litvec(dlit(3,4)))));
+        REQUIRE("(p((#Range0+0))&#range(#Range0,1,2):p((#Range1+0)),#range(#Range1,3,4),[])" == simplify(bdaggr(dlit(1,2), litvec(dlit(3,4)))));
         // head tuple aggregate
-        REQUIRE("(#Range0>#sum{#Range1:p(#Range2):p(#Range3),#range(#Range1,3,4),#range(#Range2,5,6),#range(#Range3,7,8)},[(#Range0,1,2)])" == simplify(hdaggr(AggregateFunction::SUM, boundvec(Relation::LT, dterm(1,2)), hdelemvec(termvec(dterm(3,4)), dlit(5,6), litvec(dlit(7,8))))));
+        REQUIRE("((#Range0+0)>#sum{(#Range1+0):p((#Range2+0)):p((#Range3+0)),#range(#Range1,3,4),#range(#Range2,5,6),#range(#Range3,7,8)},[(#Range0,1,2)])" == simplify(hdaggr(AggregateFunction::SUM, boundvec(Relation::LT, dterm(1,2)), hdelemvec(termvec(dterm(3,4)), dlit(5,6), litvec(dlit(7,8))))));
         // head lit aggregate
-        REQUIRE("(#Range0>#sum{p(#Range1):p(#Range2),#range(#Range1,3,4),#range(#Range2,5,6)},[(#Range0,1,2)])" == simplify(hdaggr(AggregateFunction::SUM, boundvec(Relation::LT, dterm(1,2)), condlitvec(dlit(3,4), litvec(dlit(5,6))))));
+        REQUIRE("((#Range0+0)>#sum{p((#Range1+0)):p((#Range2+0)),#range(#Range1,3,4),#range(#Range2,5,6)},[(#Range0,1,2)])" == simplify(hdaggr(AggregateFunction::SUM, boundvec(Relation::LT, dterm(1,2)), condlitvec(dlit(3,4), litvec(dlit(5,6))))));
         // disjunction
-        REQUIRE("(p(#Range0):#range(#Range0,1,2):p(#Range1),#range(#Range1,3,4),[])" == simplify(hdaggr(condlitvec(dlit(1,2), litvec(dlit(3,4))))));
+        REQUIRE("(p((#Range0+0)):#range(#Range0,1,2):p((#Range1+0)),#range(#Range1,3,4),[])" == simplify(hdaggr(condlitvec(dlit(1,2), litvec(dlit(3,4))))));
     }
 
     SECTION("rewriteArithmetics") {

--- a/libgringo/tests/input/program.cc
+++ b/libgringo/tests/input/program.cc
@@ -98,7 +98,7 @@ TEST_CASE("input-program", "[input]") {
         REQUIRE("p(1):-q(3).p(2):-q(3).p(1):-q(4).p(2):-q(4)." == rewrite(parse("p(1;2):-q(3;4).")));
         REQUIRE("p((X+Y)):-q(#Arith0);#Arith0=(X+Y)." == rewrite(parse("p(X+Y):-q(X+Y).")));
         REQUIRE("#Arith0<=#count{(X+Y):q((X+Y)):r(#Arith0),s(#Arith1),#Arith1=(A+B)}:-t(#Arith0);#Arith0=(X+Y);1<=#count{(X+Y):u(#Arith0),v(#Arith2),#Arith2=(A+B)}." == rewrite(parse("X+Y#count{X+Y:q(X+Y):r(X+Y),s(A+B)}:-t(X+Y),1#count{X+Y:u(X+Y),v(A+B)}.")));
-        REQUIRE("p(#Range0):-q(#Range1);#range(#Range1,A,B);#range(#Range0,X,Y)." == rewrite(parse("p(X..Y):-q(A..B).")));
+        REQUIRE("p((#Range0+0)):-q((#Range1+0));#range(#Range1,A,B);#range(#Range0,X,Y)." == rewrite(parse("p(X..Y):-q(A..B).")));
         REQUIRE("p(1):-q.p(2):-q.p(3):-q.p:-q." == rewrite(parse("p(1;2;3;):-q.")));
         REQUIRE("p(Z):-p(A,B);Y=#count{0,q(B):q(B)};X=#count{0,q(A):q(A)};Z=#count{0,r(X,Y):r(X,Y)}." == rewrite(parse("p(Z):-p(A,B),X={q(A)},Y={q(B)},Z={r(X,Y)}.")));
         REQUIRE("p(Z):-Z=#count{0,p(X):p(X)};Z>0." == rewrite(parse("p(Z):-Z={p(X)},Z>0.")));
@@ -107,12 +107,12 @@ TEST_CASE("input-program", "[input]") {
         REQUIRE("#project p(X):-[p(X)].#project p(Y):-[p(Y)]." == rewrite(parse("#project p(X;Y).")));
         REQUIRE("#edge(a,b).#edge(c,d)." == rewrite(parse("#edge (a,b;c,d).")));
         REQUIRE("#edge((X+X),b)." == rewrite(parse("#edge (X+X,b).")));
-        REQUIRE("#edge(#Range0,b):-#range(#Range0,1,10)." == rewrite(parse("#edge (1..10,b).")));
+        REQUIRE("#edge((#Range0+0),b):-#range(#Range0,1,10)." == rewrite(parse("#edge (1..10,b).")));
         REQUIRE("#heuristic a(#Arith0)[1@0,sign]:-[a(#Arith0)];#Arith0=(X+X)." == rewrite(parse("#heuristic a(X+X). [1@0,sign]")));
         REQUIRE("#heuristic a[(X+X)@2,sign]:-[a]." == rewrite(parse("#heuristic a. [X+X@2,sign]")));
-        REQUIRE("#heuristic a(#Range0)[2@0,sign]:-[a(#Range0)];#range(#Range0,1,2)." == rewrite(parse("#heuristic a(1..2). [2,sign]")));
+        REQUIRE("#heuristic a((#Range0+0))[2@0,sign]:-[a((#Range0+0))];#range(#Range0,1,2)." == rewrite(parse("#heuristic a(1..2). [2,sign]")));
         REQUIRE("#theory x{node{};&edge/1:node,head}.#false:-p(Z);not &edge((Z+Z)){(z),(Y): p(Y,#Arith1),#Arith1=(Y+Y)}." == rewrite(parse("#theory x{ node{}; &edge/1: node, head }.&edge(Z+Z) { z, Y : p(Y,Y+Y)} :- p(Z).")));
-        REQUIRE("#theory x{node{};&edge/1:node,head}.#false:-p(Z);#range(#Range0,Z,Z);not &edge(#Range0){(z),(Y): p(Y,#Range1),#range(#Range1,Y,Y)}." == rewrite(parse("#theory x{ node{}; &edge/1: node, head }.&edge(Z..Z) { z, Y : p(Y,Y..Y)} :- p(Z).")));
+        REQUIRE("#theory x{node{};&edge/1:node,head}.#false:-p(Z);#range(#Range0,Z,Z);not &edge((#Range0+0)){(z),(Y): p(Y,(#Range1+0)),#range(#Range1,Y,Y)}." == rewrite(parse("#theory x{ node{}; &edge/1: node, head }.&edge(Z..Z) { z, Y : p(Y,Y..Y)} :- p(Z).")));
     }
 
     SECTION("defines") {

--- a/libgringo/tests/output/lparse.cc
+++ b/libgringo/tests/output/lparse.cc
@@ -1120,6 +1120,12 @@ TEST_CASE("output-lparse", "[output]") {
 
     SECTION("undefinedRule") {
         REQUIRE(
+            "([[q(1)]],[-:3:3-4: info: operation undefined:\n  (A+0)\n])" ==
+            IO::to_string(solve(
+                "a(a).\n"
+                "a(1).\n"
+                "q(A+0) :- a(A).\n", {"q("})));
+        REQUIRE(
             "([[q(2)]],[-:4:3-6: info: operation undefined:\n  (A+B)\n])" ==
             IO::to_string(solve(
                 "a(a).\n"
@@ -1163,7 +1169,7 @@ TEST_CASE("output-lparse", "[output]") {
                 "b(1).\n"
                 ":- a(A), b(B), A $< B.\n")));
         REQUIRE(
-            "([[a(1),a(2)=1,a(a),b(1)]],[-:5:19-20: info: operation undefined:\n  (1*A+1)\n])" ==
+            "([[a(1),a(2)=1,a(a),b(1)]],[-:5:19-20: info: operation undefined:\n  (A+1)\n])" ==
             IO::to_string(solve(
                 "a(a).\n"
                 "a(1).\n"
@@ -1180,7 +1186,7 @@ TEST_CASE("output-lparse", "[output]") {
                 "a(1).\n"
                 "#disjoint { X : X : a(X) }.\n")));
         REQUIRE(
-            "([[a(1),a(1)=1,a(a)]],[-:4:20-21: info: operation undefined:\n  (1*X+1)\n])" ==
+            "([[a(1),a(1)=1,a(a)]],[-:4:20-21: info: operation undefined:\n  (X+1)\n])" ==
             IO::to_string(solve(
                 "a(a).\n"
                 "a(1).\n"
@@ -1190,19 +1196,19 @@ TEST_CASE("output-lparse", "[output]") {
 
     SECTION("undefinedBodyAggregate") {
         REQUIRE(
-            "([[a(1),a(a),h]],[-:3:15-16: info: operation undefined:\n  (1*X+1)\n])" ==
+            "([[a(1),a(a),h]],[-:3:15-16: info: operation undefined:\n  (X+1)\n])" ==
             IO::to_string(solve(
                 "a(a).\n"
                 "a(1).\n"
                 "h :- #count { X+1 : a(X) } < 2.\n")));
         REQUIRE(
-            "([[a(1),a(a),h]],[-:3:14-15: info: operation undefined:\n  (1*X+1)\n])" ==
+            "([[a(1),a(a),h]],[-:3:14-15: info: operation undefined:\n  (X+1)\n])" ==
             IO::to_string(solve(
                 "a(a).\n"
                 "a(1).\n"
                 "h :- { not a(X+1) : a(X) } < 2.\n")));
         REQUIRE(
-            "([[a(1),a(a),g(1)]],[-:4:30-31: info: operation undefined:\n  (1*X+1)\n,-:3:30-31: info: operation undefined:\n  (1*X+1)\n])" ==
+            "([[a(1),a(a),g(1)]],[-:4:30-31: info: operation undefined:\n  (X+1)\n,-:3:30-31: info: operation undefined:\n  (X+1)\n])" ==
             IO::to_string(solve(
                 "a(a).\n"
                 "a(1).\n"
@@ -1212,13 +1218,13 @@ TEST_CASE("output-lparse", "[output]") {
 
     SECTION("undefinedAssignmentAggregate") {
         REQUIRE(
-            "([[a(1),a(a),h(1)]],[-:3:22-23: info: operation undefined:\n  (1*X+1)\n])" ==
+            "([[a(1),a(a),h(1)]],[-:3:22-23: info: operation undefined:\n  (X+1)\n])" ==
             IO::to_string(solve(
                 "a(a).\n"
                 "a(1).\n"
                 "h(C) :- C = #count { X+1 : a(X) }.\n")));
         REQUIRE(
-            "([[a(1),a(a),h(1)]],[-:3:21-22: info: operation undefined:\n  (1*X+1)\n])" ==
+            "([[a(1),a(a),h(1)]],[-:3:21-22: info: operation undefined:\n  (X+1)\n])" ==
             IO::to_string(solve(
                 "a(a).\n"
                 "a(1).\n"
@@ -1231,31 +1237,31 @@ TEST_CASE("output-lparse", "[output]") {
 
     SECTION("undefinedHeadAggregate") {
         REQUIRE(
-            "([[a(1),a(a)],[a(1),a(a),p(1)]],[-:3:10-11: info: operation undefined:\n  (1*X+1)\n])" ==
+            "([[a(1),a(a)],[a(1),a(a),p(1)]],[-:3:10-11: info: operation undefined:\n  (X+1)\n])" ==
             IO::to_string(solve(
                 "a(a).\n"
                 "a(1).\n"
                 "#count { X+1 : p(X) : a(X) }.\n")));
         REQUIRE(
-            "([[a(1),a(a)],[a(1),a(a),p(2)]],[-:3:16-17: info: operation undefined:\n  (1*X+1)\n])" ==
+            "([[a(1),a(a)],[a(1),a(a),p(2)]],[-:3:16-17: info: operation undefined:\n  (X+1)\n])" ==
             IO::to_string(solve(
                 "a(a).\n"
                 "a(1).\n"
                 "#count { X : p(X+1) : a(X) }.\n")));
         REQUIRE(
-            "([[a(1),a(a)],[a(1),a(a),p(2)]],[-:3:5-6: info: operation undefined:\n  (1*X+1)\n])" ==
+            "([[a(1),a(a)],[a(1),a(a),p(2)]],[-:3:5-6: info: operation undefined:\n  (X+1)\n])" ==
             IO::to_string(solve(
                 "a(a).\n"
                 "a(1).\n"
                 "{ p(X+1) : a(X) }.\n")));
         REQUIRE(
-            "([[p(1)]],[-:3:17-18: info: operation undefined:\n  (1*X+1)\n])" ==
+            "([[p(1)]],[-:3:17-18: info: operation undefined:\n  (X+1)\n])" ==
             IO::to_string(solve(
                 "a(a).\n"
                 "a(1).\n"
                 "X <= { p(X) } < X+1 :- a(X).\n", { "p(" })));
         REQUIRE(
-            "([[p(1)]],[-:3:1-2: info: operation undefined:\n  (1*X+-1)\n])" ==
+            "([[p(1)]],[-:3:1-2: info: operation undefined:\n  (X+-1)\n])" ==
             IO::to_string(solve(
                 "a(a).\n"
                 "a(1).\n"
@@ -1264,21 +1270,21 @@ TEST_CASE("output-lparse", "[output]") {
 
     SECTION("undefinedConjunction") {
         REQUIRE(
-            "([[a(a)],[h]],[-:4:10-11: info: operation undefined:\n  (1*A+1)\n])" ==
+            "([[a(a)],[h]],[-:4:10-11: info: operation undefined:\n  (A+1)\n])" ==
             IO::to_string(solve(
                 "{a(a)}.\n"
                 "a(1..2).\n"
                 "p(2..3).\n"
                 "h :- p(1+A):a(A).\n", {"h", "a(a)"})));
         REQUIRE(
-            "([[a(a)],[a(a),p(2),p(3)],[h],[p(2),p(3)]],[-:4:14-15: info: operation undefined:\n  (1*A+1)\n])" ==
+            "([[a(a)],[a(a),p(2),p(3)],[h],[p(2),p(3)]],[-:4:14-15: info: operation undefined:\n  (A+1)\n])" ==
             IO::to_string(solve(
                 "{a(a)}.\n"
                 "a(1..2).\n"
                 "{p(2..3)} != 1.\n"
                 "h :- not p(1+A):a(A).\n", {"h", "a(a)", "p("})));
         REQUIRE(
-            "([[a(a),h],[a(a),p(2),p(3)],[h],[p(2),p(3)]],[-:4:24-25: info: operation undefined:\n  (1*A+1)\n])" ==
+            "([[a(a),h],[a(a),p(2),p(3)],[h],[p(2),p(3)]],[-:4:24-25: info: operation undefined:\n  (A+1)\n])" ==
             IO::to_string(solve(
                 "{a(a)}.\n"
                 "a(1..2).\n"
@@ -1288,13 +1294,13 @@ TEST_CASE("output-lparse", "[output]") {
 
     SECTION("undefinedDisjunction") {
         REQUIRE(
-            "([[]],[-:3:5-6: info: operation undefined:\n  (1*A+1)\n])" ==
+            "([[]],[-:3:5-6: info: operation undefined:\n  (A+1)\n])" ==
             IO::to_string(solve(
                 "a(a).\n"
                 "a(1..2).\n"
                 "p(1+A):a(A).\n", {"p("})));
         REQUIRE(
-            "([[p(2)],[p(3)]],[-:3:15-16: info: operation undefined:\n  (1*A+1)\n])" ==
+            "([[p(2)],[p(3)]],[-:3:15-16: info: operation undefined:\n  (A+1)\n])" ==
             IO::to_string(solve(
                 "a(a).\n"
                 "a(1..2).\n"


### PR DESCRIPTION
A term of the form `X+0` was replaced by `X`. This lead to the situation
that the program

    q(a).
    p(X+0) :- q(X).

would derive `p(a)`, which is not in line with the AG semantics.