### PR TITLE
Improve/simplify cleanup of domains

### DIFF
--- a/examples/clingo/cover/control-lua.lp
+++ b/examples/clingo/cover/control-lua.lp
@@ -64,7 +64,6 @@ function State:run(prg)
     local k = 0
     while ret.satisfiable do
         k = k + 1
-        pre:cleanup()
         pre:ground({{"step", {k}}}, self)
         ret = pre:solve{on_model=function(...) self:on_model(...) end}
     end

--- a/examples/clingo/cover/control-py.lp
+++ b/examples/clingo/cover/control-py.lp
@@ -45,7 +45,6 @@ class State:
         k = 0
         while ret.satisfiable:
             k = k + 1
-            pre.cleanup()
             pre.ground([("step", [k])], self)
             ret = pre.solve(on_model=self.on_model)
         self.prepare_instance(k)

--- a/examples/clingo/iclingo/incmode-lua.lp
+++ b/examples/clingo/iclingo/incmode-lua.lp
@@ -24,7 +24,6 @@ function main(prg)
         if step > 0 then
             prg:release_external(clingo.Function("query", {step-1}))
             table.insert(parts, {"step", {step}})
-            prg:cleanup()
         else
             table.insert(parts, {"base", {}})
         end

--- a/examples/clingo/iclingo/incmode-py.lp
+++ b/examples/clingo/iclingo/incmode-py.lp
@@ -21,7 +21,6 @@ def main(prg):
         if step > 0:
             prg.release_external(clingo.Function("query", [step-1]))
             parts.append(("step", [step]))
-            prg.cleanup()
         else:
             parts.append(("base", []))
         prg.ground(parts)

--- a/examples/clingo/tmode/visitor.lp
+++ b/examples/clingo/tmode/visitor.lp
@@ -114,7 +114,6 @@ def imain(prg):
         if step > 0:
             prg.release_external(clingo.Function("finally", [step-1]))
             parts.append(("dynamic", [step]))
-            prg.cleanup()
         else:
             parts.append(("initial", [0]))
         prg.ground(parts)

--- a/libclingo/clingo.h
+++ b/libclingo/clingo.h
@@ -3349,7 +3349,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_control_ground(clingo_control_t *control, 
 //! - ::clingo_error_bad_alloc
 //! - ::clingo_error_runtime if solving could not be started
 CLINGO_VISIBILITY_DEFAULT bool clingo_control_solve(clingo_control_t *control, clingo_solve_mode_bitset_t mode, clingo_literal_t const *assumptions, size_t assumptions_size, clingo_solve_event_callback_t notify, void *data, clingo_solve_handle_t **handle);
-//! Clean up the domains of clingo's grounding component using the solving
+//! Clean up the domains of the grounding component using the solving
 //! component's top level assignment.
 //!
 //! This function removes atoms from domains that are false and marks atoms as
@@ -3357,9 +3357,15 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_control_solve(clingo_control_t *control, c
 //! groundings because less rules have to be instantiated and more
 //! simplifications can be applied.
 //!
+//! @note It is typically not necessary to call this function manually because
+//! automatic cleanups at the right time are enabled by default.
+//
 //! @param[in] control the target
 //! @return whether the call was successful; might set one of the following error codes:
 //! - ::clingo_error_bad_alloc
+//!
+//! @see clingo_control_get_enable_cleanup()
+//! @see clingo_control_set_enable_cleanup()
 CLINGO_VISIBILITY_DEFAULT bool clingo_control_cleanup(clingo_control_t *control);
 //! Assign a truth value to an external atom.
 //!
@@ -3463,6 +3469,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_control_clasp_facade(clingo_control_t *con
 //! @param[out] configuration the configuration object
 //! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_control_configuration(clingo_control_t *control, clingo_configuration_t **configuration);
+
 //! Configure how learnt constraints are handled during enumeration.
 //!
 //! If the enumeration assumption is enabled, then all information learnt from
@@ -3478,7 +3485,35 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_control_configuration(clingo_control_t *co
 //! @param[in] control the target
 //! @param[in] enable whether to enable the assumption
 //! @return whether the call was successful
-CLINGO_VISIBILITY_DEFAULT bool clingo_control_use_enumeration_assumption(clingo_control_t *control, bool enable);
+CLINGO_VISIBILITY_DEFAULT bool clingo_control_set_enable_enumeration_assumption(clingo_control_t *control, bool enable);
+//! Check whether the enumeration assumption is enabled.
+//!
+//! See ::clingo_control_set_enable_enumeration_assumption().
+//! @param[in] control the target
+//! @return whether using the enumeration assumption is enabled
+CLINGO_VISIBILITY_DEFAULT bool clingo_control_get_enable_enumeration_assumption(clingo_control_t *control);
+
+//! Enable automatic cleanup after solving.
+//!
+//! @note Cleanup is enabled by default.
+//!
+//! @param[in] control the target
+//! @param[in] enable whether to enable cleanups
+//! @return whether the call was successful
+//!
+//! @see clingo_control_cleanup()
+//! @see clingo_control_get_enable_cleanup()
+CLINGO_VISIBILITY_DEFAULT bool clingo_control_set_enable_cleanup(clingo_control_t *control, bool enable);
+//! Check whether automatic cleanup is enabled.
+//!
+//! See ::clingo_control_set_enable_cleanup().
+//!
+//! @param[in] control the target
+//!
+//! @see clingo_control_cleanup()
+//! @see clingo_control_set_enable_cleanup()
+CLINGO_VISIBILITY_DEFAULT bool clingo_control_get_enable_cleanup(clingo_control_t *control);
+
 //! @}
 
 //! @name Program Inspection Functions

--- a/libclingo/clingo.hh
+++ b/libclingo/clingo.hh
@@ -2237,14 +2237,17 @@ public:
     void register_propagator(Propagator &propagator, bool sequential = false);
     void register_propagator(Heuristic &propagator, bool sequential = false);
     void register_observer(GroundProgramObserver &observer, bool replace = false);
-    void cleanup();
     bool is_conflicting() const noexcept;
     bool has_const(char const *name) const;
     Symbol get_const(char const *name) const;
     void interrupt() noexcept;
     void *claspFacade();
     void load(char const *file);
-    void use_enumeration_assumption(bool value);
+    void enable_enumeration_assumption(bool value);
+    bool enable_enumeration_assumption() const;
+    void cleanup();
+    void enable_cleanup(bool value);
+    bool enable_cleanup() const;
     ProgramBuilder builder();
     template <class F>
     void with_builder(F f) {
@@ -4441,10 +4444,6 @@ inline void Control::register_observer(GroundProgramObserver &observer, bool rep
     Detail::handle_error(clingo_control_register_observer(*impl_, &g_observer, replace, &impl_->observers_.front()));
 }
 
-inline void Control::cleanup() {
-    Detail::handle_error(clingo_control_cleanup(*impl_));
-}
-
 inline bool Control::is_conflicting() const noexcept {
     return clingo_control_is_conflicting(*impl_);
 }
@@ -4475,8 +4474,24 @@ inline void Control::load(char const *file) {
     Detail::handle_error(clingo_control_load(*impl_, file));
 }
 
-inline void Control::use_enumeration_assumption(bool value) {
-    Detail::handle_error(clingo_control_use_enumeration_assumption(*impl_, value));
+inline void Control::enable_enumeration_assumption(bool value) {
+    Detail::handle_error(clingo_control_set_enable_enumeration_assumption(*impl_, value));
+}
+
+inline bool Control::enable_enumeration_assumption() const {
+    return clingo_control_get_enable_enumeration_assumption(*impl_);
+}
+
+inline void Control::cleanup() {
+    Detail::handle_error(clingo_control_cleanup(*impl_));
+}
+
+inline void Control::enable_cleanup(bool value) {
+    Detail::handle_error(clingo_control_set_enable_cleanup(*impl_, value));
+}
+
+inline bool Control::enable_cleanup() const {
+    return clingo_control_get_enable_cleanup(*impl_);
 }
 
 inline Backend Control::backend() {

--- a/libclingo/clingo/clingocontrol.hh
+++ b/libclingo/clingo/clingocontrol.hh
@@ -324,8 +324,10 @@ public:
     Potassco::AbstractStatistics const *statistics() const override;
     ConfigProxy &getConf() override;
     void useEnumAssumption(bool enable) override;
-    bool useEnumAssumption() override;
-    void cleanupDomains() override;
+    bool useEnumAssumption() const override;
+    void cleanup() override;
+    void enableCleanup(bool enable) override;
+    bool enableCleanup() const override;
     USolveFuture solve(Assumptions ass, clingo_solve_mode_bitset_t mode, USolveEventHandler cb) override;
     Output::DomainData const &theory() const override { return out_->data; }
     void registerPropagator(UProp p, bool sequential) override;
@@ -376,6 +378,7 @@ public:
     UserStatistics                                             step_stats_;
     UserStatistics                                             accu_stats_;
     bool                                                       enableEnumAssupmption_ = true;
+    bool                                                       enableCleanup_         = true;
     bool                                                       clingoMode_;
     bool                                                       verbose_               = false;
     bool                                                       parsed                 = false;
@@ -384,6 +387,7 @@ public:
     bool                                                       configUpdate_          = false;
     bool                                                       initialized_           = false;
     bool                                                       incmode_               = false;
+    bool                                                       canClean_              = false;
 
 };
 

--- a/libclingo/clingo/control.hh
+++ b/libclingo/clingo/control.hh
@@ -239,8 +239,10 @@ struct clingo_control {
     virtual bool isConflicting() const noexcept = 0;
     virtual Potassco::AbstractStatistics const *statistics() const = 0;
     virtual void useEnumAssumption(bool enable) = 0;
-    virtual bool useEnumAssumption() = 0;
-    virtual void cleanupDomains() = 0;
+    virtual bool useEnumAssumption() const = 0;
+    virtual void cleanup() = 0;
+    virtual void enableCleanup(bool enable) = 0;
+    virtual bool enableCleanup() const = 0;
     virtual Gringo::Output::DomainData const &theory() const = 0;
     virtual void registerPropagator(Gringo::UProp p, bool sequential) = 0;
     virtual void registerObserver(Gringo::UBackend program, bool replace) = 0;

--- a/libclingo/src/control.cc
+++ b/libclingo/src/control.cc
@@ -1371,11 +1371,6 @@ extern "C" bool clingo_control_register_propagator(clingo_control_t *ctl, clingo
     GRINGO_CLINGO_CATCH;
 }
 
-extern "C" bool clingo_control_cleanup(clingo_control_t *ctl) {
-    GRINGO_CLINGO_TRY { ctl->cleanupDomains(); }
-    GRINGO_CLINGO_CATCH;
-}
-
 extern "C" bool clingo_control_has_const(clingo_control_t const *ctl, char const *name, bool *ret) {
     GRINGO_CLINGO_TRY {
         auto sym = ctl->getConst(name);
@@ -1401,9 +1396,27 @@ extern "C" bool clingo_control_load(clingo_control_t *ctl, char const *file) {
     GRINGO_CLINGO_CATCH;
 }
 
-extern "C" bool clingo_control_use_enumeration_assumption(clingo_control_t *ctl, bool value) {
+extern "C" bool clingo_control_set_enable_enumeration_assumption(clingo_control_t *ctl, bool value) {
     GRINGO_CLINGO_TRY { ctl->useEnumAssumption(value); }
     GRINGO_CLINGO_CATCH;
+}
+
+extern "C" bool clingo_control_get_enable_enumeration_assumption(clingo_control_t *ctl) {
+    return ctl->useEnumAssumption();
+}
+
+extern "C" bool clingo_control_cleanup(clingo_control_t *ctl) {
+    GRINGO_CLINGO_TRY { ctl->cleanup(); }
+    GRINGO_CLINGO_CATCH;
+}
+
+extern "C" bool clingo_control_set_enable_cleanup(clingo_control_t *ctl, bool value) {
+    GRINGO_CLINGO_TRY { ctl->enableCleanup(value); }
+    GRINGO_CLINGO_CATCH;
+}
+
+extern "C" bool clingo_control_get_enable_cleanup(clingo_control_t *ctl) {
+    return ctl->enableCleanup();
 }
 
 extern "C" bool clingo_control_backend(clingo_control_t *ctl, clingo_backend_t **ret) {

--- a/libclingo/src/gringo_app.cc
+++ b/libclingo/src/gringo_app.cc
@@ -216,10 +216,12 @@ struct IncrementalControl : Control {
     ConfigProxy &getConf() override { throw std::runtime_error("configuration not supported"); }
     void registerPropagator(UProp, bool) override { throw std::runtime_error("theory propagators not supported"); }
     void useEnumAssumption(bool) override { }
-    bool useEnumAssumption() override { return false; }
+    bool useEnumAssumption() const override { return false; }
+    void cleanup() override { }
+    void enableCleanup(bool) override { }
+    bool enableCleanup() const override { return false; }
     virtual ~IncrementalControl() { }
     Output::DomainData const &theory() const override { return out.data; }
-    void cleanupDomains() override { }
     bool beginAddBackend() override {
         backend_ = out.backend(logger());
         return backend_ != nullptr;

--- a/libclingo/src/incmode.cc
+++ b/libclingo/src/incmode.cc
@@ -80,7 +80,6 @@ struct Incmode {
             parts.push_back({"check", {Symbol::createNum(step)}});
             if (step > 0) {
                 assign_external_(Symbol::createFun("query", {Symbol::createNum(step - 1)}), Potassco::Value_t::Release);
-                ctl_.cleanupDomains();
                 parts.push_back({"step", {Symbol::createNum(step)}});
             }
             else {

--- a/libluaclingo/luaclingo.cc
+++ b/libluaclingo/luaclingo.cc
@@ -3527,9 +3527,14 @@ struct ControlWrap : Object<ControlWrap> {
     static int newindex(lua_State *L) {
         auto &self = get_self(L);
         char const *name = luaL_checkstring(L, 2);
-        if (strcmp(name, "use_enumeration_assumption") == 0) {
+        if (strcmp(name, "enable_enumeration_assumption") == 0) {
             bool enabled = lua_toboolean(L, 3) != 0;
-            handle_c_error(L, clingo_control_use_enumeration_assumption(self.ctl, enabled));
+            handle_c_error(L, clingo_control_set_enable_enumeration_assumption(self.ctl, enabled));
+            return 0;
+        }
+        else if (strcmp(name, "enable_cleanup") == 0) {
+            bool enabled = lua_toboolean(L, 3) != 0;
+            handle_c_error(L, clingo_control_set_enable_cleanup(self.ctl, enabled));
             return 0;
         }
         return luaL_error(L, "unknown field: %s", name);
@@ -3567,6 +3572,14 @@ struct ControlWrap : Object<ControlWrap> {
         }
         else if (strcmp(name, "is_conflicting") == 0) {
             lua_pushboolean(L, clingo_control_is_conflicting(self.ctl));
+            return 1;
+        }
+        else if (strcmp(name, "enable_enumeration_assumption") == 0) {
+            lua_pushboolean(L, clingo_control_get_enable_enumeration_assumption(self.ctl));
+            return 1;
+        }
+        else if (strcmp(name, "enable_cleanup") == 0) {
+            lua_pushboolean(L, clingo_control_get_enable_cleanup(self.ctl));
             return 1;
         }
         else {

--- a/libpyclingo/pyclingo.cc
+++ b/libpyclingo/pyclingo.cc
@@ -8081,6 +8081,15 @@ active; you must not call any member function during search.
         handle_c_error(clingo_control_cleanup(ctl));
         Py_RETURN_NONE;
     }
+    void set_enable_cleanup(Reference pyEnable) {
+        CHECK_BLOCKED("enable_cleanup");
+        int enable = pyEnable.isTrue();
+        handle_c_error(clingo_control_set_enable_cleanup(ctl, enable));
+    }
+    Object get_enable_cleanup() {
+        CHECK_BLOCKED("enable_cleanup");
+        return cppToPy(clingo_control_get_enable_cleanup(ctl));
+    }
     Object assign_external(Reference args) {
         CHECK_BLOCKED("assign_external");
         Reference pyExt, pyVal;
@@ -8133,10 +8142,14 @@ active; you must not call any member function during search.
         Py_XINCREF(stats);
         return stats;
     }
-    void set_use_enumeration_assumption(Reference pyEnable) {
-        CHECK_BLOCKED("use_enumeration_assumption");
+    void set_enable_enumeration_assumption(Reference pyEnable) {
+        CHECK_BLOCKED("enable_enumeration_assumption");
         int enable = pyEnable.isTrue();
-        handle_c_error(clingo_control_use_enumeration_assumption(ctl, enable));
+        handle_c_error(clingo_control_set_enable_enumeration_assumption(ctl, enable));
+    }
+    Object get_enable_enumeration_assumption() {
+        CHECK_BLOCKED("enable_enumeration_assumption");
+        return cppToPy(clingo_control_get_enable_enumeration_assumption(ctl));
     }
     Object conf() {
         CHECK_BLOCKED("configuration");
@@ -8445,10 +8458,20 @@ Returns
 -------
 None
 
+See Also
+--------
+Control.enable_cleanup
+
 Notes
 -----
 Any atoms falsified are completely removed from the logic program. Hence, a
 definition for such an atom in a successive step introduces a fresh atom.
+
+With the current implementation, the function only has an effect if called
+after solving and before any function is called that starts a new step.
+
+Typically, it is not necessary to call this function manually because automatic
+cleanups are enabled by default.
 )"},
     // assign_external
     {"assign_external", to_function<&ControlWrap::assign_external>(), METH_VARARGS,
@@ -9114,8 +9137,8 @@ PyGetSetDef ControlWrap::tp_getset[] = {
 
 `SymbolicAtoms` object to inspect the symbolic atoms.
 )", nullptr},
-    {(char*)"use_enumeration_assumption", nullptr, to_setter<&ControlWrap::set_use_enumeration_assumption>(),
-(char*)R"(set_use_enumeration_assumption: bool
+    {(char*)"enable_enumeration_assumption", to_getter<&ControlWrap::get_enable_enumeration_assumption>(), to_setter<&ControlWrap::set_enable_enumeration_assumption>(),
+(char*)R"(enable_enumeration_assumption: bool
 
 Whether do discard or keep learnt information from enumeration modes.
 
@@ -9134,6 +9157,11 @@ multiple calls to solve. Otherwise, the behavior of the solver will be
 unpredictable because there are no guarantees which information exactly is
 kept. There might be small speed benefits when disabling the enumeration
 assumption for single shot solving.
+)", nullptr},
+    {(char*)"enable_cleanup", to_getter<&ControlWrap::get_enable_cleanup>(), to_setter<&ControlWrap::set_enable_cleanup>(),
+(char*)R"(enable_cleanup: bool
+
+Whether to enable automatic calls to `Control.cleanup`.
 )", nullptr},
     {(char*)"is_conflicting", to_getter<&ControlWrap::isConflicting>(), nullptr, (char*)R"(is_conflicting: bool
 


### PR DESCRIPTION
This PR adds a flag to enable automatic cleanups when multi-shot solving. Furthermore, the cleanup function will only have an effect if called after solving when the solver has preprocessed the whole program and thus has a meaningful top-level assignment.