### PR TITLE
add single-shot solving option

### DIFF
--- a/libclingo/clingo/clingocontrol.hh
+++ b/libclingo/clingo/clingocontrol.hh
@@ -97,6 +97,7 @@ struct ClingoOptions {
     bool                          wNoOther              = false;
     bool                          rewriteMinimize       = false;
     bool                          keepFacts             = false;
+    bool                          singleShot            = false;
     Foobar                        foobar;
 };
 
@@ -386,7 +387,6 @@ public:
     bool                                                       verbose_               = false;
     bool                                                       parsed                 = false;
     bool                                                       grounded               = false;
-    bool                                                       incremental_           = true;
     bool                                                       configUpdate_          = false;
     bool                                                       initialized_           = false;
     bool                                                       incmode_               = false;

--- a/libclingo/src/clingo_app.cc
+++ b/libclingo/src/clingo_app.cc
@@ -85,6 +85,7 @@ void ClingoApp::initOptions(Potassco::ProgramOptions::OptionContext& root) {
         ("keep-facts,@1"            , flag(grOpts_.keepFacts = false), "Do not remove facts from normal rules")
         ("reify-sccs,@1"            , flag(grOpts_.outputOptions.reifySCCs = false), "Calculate SCCs for reified output")
         ("reify-steps,@1"           , flag(grOpts_.outputOptions.reifySteps = false), "Add step numbers to reified output")
+        ("single-shot,@2"           , flag(grOpts_.singleShot = false), "Force single-shot solving mode")
         ("foobar,@4"                , storeTo(grOpts_.foobar, parseFoobar) , "Foobar")
         ;
     root.add(gringo);

--- a/libclingo/src/gringo_app.cc
+++ b/libclingo/src/gringo_app.cc
@@ -60,6 +60,7 @@ struct GringoOptions {
     bool                          wNoOther              = false;
     bool                          rewriteMinimize       = false;
     bool                          keepFacts             = false;
+    bool                          singleShot            = false;
     Foobar                        foobar;
 };
 
@@ -364,6 +365,7 @@ struct GringoApp : public Potassco::Application {
             ("keep-facts,@1", flag(grOpts_.keepFacts = false), "Do not remove facts from normal rules")
             ("reify-sccs,@1", flag(grOpts_.outputOptions.reifySCCs = false), "Calculate SCCs for reified output")
             ("reify-steps,@1", flag(grOpts_.outputOptions.reifySteps = false), "Add step numbers to reified output")
+            ("single-shot,@2", flag(grOpts_.singleShot = false), "Force single-shot grounding mode")
             ("foobar,@4", storeTo(grOpts_.foobar, parseFoobar), "Foobar")
             ;
         root.add(gringo);
@@ -408,11 +410,11 @@ struct GringoApp : public Potassco::Application {
         using namespace Gringo;
         IncrementalControl inc(out, input_, grOpts_);
         if (inc.scripts.callable("main")) {
-            inc.incremental_ = true;
+            inc.incremental_ = !grOpts_.singleShot;
             inc.scripts.main(inc);
         }
         else if (inc.incmode) {
-            inc.incremental_ = true;
+            inc.incremental_ = !grOpts_.singleShot;
             incmode(inc);
         }
         else {

--- a/libclingo/tests/clingo.cc
+++ b/libclingo/tests/clingo.cc
@@ -729,6 +729,18 @@ TEST_CASE("solving", "[clingo]") {
             REQUIRE(models == ModelVec({{}}));
         }
     }
+    SECTION("with single-shot control") {
+        MessageVec messages;
+        ModelVec models;
+        Control ctl{{"0", "--single-shot"}, [&messages](WarningCode code, char const *msg) { messages.emplace_back(code, msg); }, 20};
+        SECTION("single-shot") {
+            ctl.add("step", {"k"}, "p(k).");
+            ctl.ground({{"step", {Number(1)}}});
+            REQUIRE(test_solve(ctl.solve(), models).is_satisfiable());
+            REQUIRE(models == ModelVec({{Function("p", {Number(1)})}}));
+            REQUIRE_THROWS_AS(ctl.ground({{"step", {Number(2)}}}), std::logic_error);
+        }
+    }
 }
 
 } } // namespace Test Clingo


### PR DESCRIPTION
See also potassco/clasp#64.

- [x] add `--single-shot` option to enable some optimization that cannot be applied in the multi-shot case
- [x] raise an error if more than one step is started in single-shot mode
- [x] add unit tests