### PR TITLE
add __repr__ to every item that has __str__

### DIFF
--- a/libpyclingo/.pylintrc
+++ b/libpyclingo/.pylintrc
@@ -1,0 +1,582 @@
+[MASTER]
+
+# A comma-separated list of package or module names from where C extensions may
+# be loaded. Extensions are loading into the active Python interpreter and may
+# run arbitrary code.
+extension-pkg-whitelist=
+
+# Add files or directories to the blacklist. They should be base names, not
+# paths.
+ignore=CVS
+
+# Add files or directories matching the regex patterns to the blacklist. The
+# regex matches against base names, not paths.
+ignore-patterns=
+
+# Python code to execute, usually for sys.path manipulation such as
+# pygtk.require().
+#init-hook=''
+
+# Use multiple processes to speed up Pylint. Specifying 0 will auto-detect the
+# number of processors available to use.
+jobs=1
+
+# Control the amount of potential inferred values when inferring a single
+# object. This can help the performance when dealing with large functions or
+# complex, nested conditions.
+limit-inference-results=100
+
+# List of plugins (as comma separated values of python module names) to load,
+# usually to register additional checkers.
+load-plugins=
+
+# Pickle collected data for later comparisons.
+persistent=yes
+
+# Specify a configuration file.
+#rcfile=
+
+# When enabled, pylint would attempt to guess common misconfiguration and emit
+# user-friendly hints instead of false-positive error messages.
+suggestion-mode=yes
+
+# Allow loading of arbitrary C extensions. Extensions are imported into the
+# active Python interpreter and may run arbitrary code.
+unsafe-load-any-extension=no
+
+
+[MESSAGES CONTROL]
+
+# Only show warnings with the listed confidence levels. Leave empty to show
+# all. Valid levels: HIGH, INFERENCE, INFERENCE_FAILURE, UNDEFINED.
+confidence=
+
+# Disable the message, report, category or checker with the given id(s). You
+# can either give multiple identifiers separated by comma (,) or put this
+# option multiple times (only on the command line, not in the configuration
+# file where it should appear only once). You can also use "--disable=all" to
+# disable everything first and then reenable specific checks. For example, if
+# you want to run only the similarities checker, you can use "--disable=all
+# --enable=similarities". If you want to run only the classes checker, but have
+# no Warning level messages displayed, use "--disable=all --enable=classes
+# --disable=W".
+disable=print-statement,
+        parameter-unpacking,
+        unpacking-in-except,
+        old-raise-syntax,
+        backtick,
+        long-suffix,
+        old-ne-operator,
+        old-octal-literal,
+        import-star-module-level,
+        non-ascii-bytes-literal,
+        raw-checker-failed,
+        bad-inline-option,
+        locally-disabled,
+        file-ignored,
+        suppressed-message,
+        useless-suppression,
+        deprecated-pragma,
+        use-symbolic-message-instead,
+        apply-builtin,
+        basestring-builtin,
+        buffer-builtin,
+        cmp-builtin,
+        coerce-builtin,
+        execfile-builtin,
+        file-builtin,
+        long-builtin,
+        raw_input-builtin,
+        reduce-builtin,
+        standarderror-builtin,
+        unicode-builtin,
+        xrange-builtin,
+        coerce-method,
+        delslice-method,
+        getslice-method,
+        setslice-method,
+        no-absolute-import,
+        old-division,
+        dict-iter-method,
+        dict-view-method,
+        next-method-called,
+        metaclass-assignment,
+        indexing-exception,
+        raising-string,
+        reload-builtin,
+        oct-method,
+        hex-method,
+        nonzero-method,
+        cmp-method,
+        input-builtin,
+        round-builtin,
+        intern-builtin,
+        unichr-builtin,
+        map-builtin-not-iterating,
+        zip-builtin-not-iterating,
+        range-builtin-not-iterating,
+        filter-builtin-not-iterating,
+        using-cmp-argument,
+        eq-without-hash,
+        div-method,
+        idiv-method,
+        rdiv-method,
+        exception-message-attribute,
+        invalid-str-codec,
+        sys-max-int,
+        bad-python3-import,
+        deprecated-string-function,
+        deprecated-str-translate-call,
+        deprecated-itertools-function,
+        deprecated-types-field,
+        next-method-defined,
+        dict-items-not-iterating,
+        dict-keys-not-iterating,
+        dict-values-not-iterating,
+        deprecated-operator-function,
+        deprecated-urllib-function,
+        xreadlines-attribute,
+        deprecated-sys-function,
+        exception-escape,
+        comprehension-escape,
+        no-self-use
+
+# Enable the message, report, category or checker with the given id(s). You can
+# either give multiple identifier separated by comma (,) or put this option
+# multiple time (only on the command line, not in the configuration file where
+# it should appear only once). See also the "--disable" option for examples.
+enable=c-extension-no-member
+
+
+[REPORTS]
+
+# Python expression which should return a score less than or equal to 10. You
+# have access to the variables 'error', 'warning', 'refactor', and 'convention'
+# which contain the number of messages in each category, as well as 'statement'
+# which is the total number of statements analyzed. This score is used by the
+# global evaluation report (RP0004).
+evaluation=10.0 - ((float(5 * error + warning + refactor + convention) / statement) * 10)
+
+# Template used to display messages. This is a python new-style format string
+# used to format the message information. See doc for all details.
+#msg-template=
+
+# Set the output format. Available formats are text, parseable, colorized, json
+# and msvs (visual studio). You can also give a reporter class, e.g.
+# mypackage.mymodule.MyReporterClass.
+output-format=text
+
+# Tells whether to display a full report or only the messages.
+reports=no
+
+# Activate the evaluation score.
+score=yes
+
+
+[REFACTORING]
+
+# Maximum number of nested blocks for function / method body
+max-nested-blocks=5
+
+# Complete name of functions that never returns. When checking for
+# inconsistent-return-statements if a never returning function is called then
+# it will be considered as an explicit return statement and no message will be
+# printed.
+never-returning-functions=sys.exit
+
+
+[MISCELLANEOUS]
+
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO
+
+
+[BASIC]
+
+# Naming style matching correct argument names.
+argument-naming-style=snake_case
+
+# Regular expression matching correct argument names. Overrides argument-
+# naming-style.
+argument-rgx=^[a-z][a-z0-9]*((_[a-z0-9]+)*_?)?$
+
+# Naming style matching correct attribute names.
+attr-naming-style=snake_case
+
+# Regular expression matching correct attribute names. Overrides attr-naming-
+# style.
+#attr-rgx=
+
+# Bad variable names which should always be refused, separated by a comma.
+bad-names=foo,
+          bar,
+          baz,
+          toto,
+          tutu,
+          tata
+
+# Naming style matching correct class attribute names.
+class-attribute-naming-style=any
+
+# Regular expression matching correct class attribute names. Overrides class-
+# attribute-naming-style.
+#class-attribute-rgx=
+
+# Naming style matching correct class names.
+class-naming-style=PascalCase
+
+# Regular expression matching correct class names. Overrides class-naming-
+# style.
+#class-rgx=
+
+# Naming style matching correct constant names.
+const-naming-style=UPPER_CASE
+
+# Regular expression matching correct constant names. Overrides const-naming-
+# style.
+#const-rgx=
+
+# Minimum line length for functions/classes that require docstrings, shorter
+# ones are exempt.
+docstring-min-length=-1
+
+# Naming style matching correct function names.
+function-naming-style=snake_case
+
+# Regular expression matching correct function names. Overrides function-
+# naming-style.
+#function-rgx=
+
+# Good variable names which should always be accepted, separated by a comma.
+good-names=i,
+           j,
+           k,
+           ex,
+           Run,
+           _
+
+# Include a hint for the correct naming format with invalid-name.
+include-naming-hint=no
+
+# Naming style matching correct inline iteration names.
+inlinevar-naming-style=any
+
+# Regular expression matching correct inline iteration names. Overrides
+# inlinevar-naming-style.
+#inlinevar-rgx=
+
+# Naming style matching correct method names.
+method-naming-style=snake_case
+
+# Regular expression matching correct method names. Overrides method-naming-
+# style.
+#method-rgx=
+
+# Naming style matching correct module names.
+module-naming-style=snake_case
+
+# Regular expression matching correct module names. Overrides module-naming-
+# style.
+#module-rgx=
+
+# Colon-delimited sets of names that determine each other's naming style when
+# the name regexes allow several styles.
+name-group=
+
+# Regular expression which should only match function or class names that do
+# not require a docstring.
+no-docstring-rgx=^_
+
+# List of decorators that produce properties, such as abc.abstractproperty. Add
+# to this list to register other decorators that produce valid properties.
+# These decorators are taken in consideration only for invalid-name.
+property-classes=abc.abstractproperty
+
+# Naming style matching correct variable names.
+variable-naming-style=snake_case
+
+# Regular expression matching correct variable names. Overrides variable-
+# naming-style.
+variable-rgx=^[a-z][a-z0-9]*((_[a-z0-9]+)*_?)?$
+
+
+[TYPECHECK]
+
+# List of decorators that produce context managers, such as
+# contextlib.contextmanager. Add to this list to register other decorators that
+# produce valid context managers.
+contextmanager-decorators=contextlib.contextmanager
+
+# List of members which are set dynamically and missed by pylint inference
+# system, and so shouldn't trigger E1101 when accessed. Python regular
+# expressions are accepted.
+generated-members=
+
+# Tells whether missing members accessed in mixin class should be ignored. A
+# mixin class is detected if its name ends with "mixin" (case insensitive).
+ignore-mixin-members=yes
+
+# Tells whether to warn about missing members when the owner of the attribute
+# is inferred to be None.
+ignore-none=yes
+
+# This flag controls whether pylint should warn about no-member and similar
+# checks whenever an opaque object is returned when inferring. The inference
+# can return multiple potential results while evaluating a Python object, but
+# some branches might not be evaluated, which results in partial inference. In
+# that case, it might be useful to still emit no-member and other checks for
+# the rest of the inferred objects.
+ignore-on-opaque-inference=yes
+
+# List of class names for which member attributes should not be checked (useful
+# for classes with dynamically set attributes). This supports the use of
+# qualified names.
+ignored-classes=optparse.Values,thread._local,_thread._local
+
+# List of module names for which member attributes should not be checked
+# (useful for modules/projects where namespaces are manipulated during runtime
+# and thus existing member attributes cannot be deduced by static analysis). It
+# supports qualified module names, as well as Unix pattern matching.
+ignored-modules=clingo,clingo.ast
+
+# Show a hint with possible names when a member name was not found. The aspect
+# of finding the hint is based on edit distance.
+missing-member-hint=yes
+
+# The minimum edit distance a name should have in order to be considered a
+# similar match for a missing member name.
+missing-member-hint-distance=1
+
+# The total number of similar names that should be taken in consideration when
+# showing a hint for a missing member.
+missing-member-max-choices=1
+
+# List of decorators that change the signature of a decorated function.
+signature-mutators=
+
+
+[FORMAT]
+
+# Expected format of line ending, e.g. empty (any line ending), LF or CRLF.
+expected-line-ending-format=
+
+# Regexp for a line that is allowed to be longer than the limit.
+ignore-long-lines=^\s*(# )?<?https?://\S+>?$
+
+# Number of spaces of indent required inside a hanging or continued line.
+indent-after-paren=4
+
+# String used as indentation unit. This is usually "    " (4 spaces) or "\t" (1
+# tab).
+indent-string='    '
+
+# Maximum number of characters on a single line.
+max-line-length=160
+
+# Maximum number of lines in a module.
+max-module-lines=1000
+
+# List of optional constructs for which whitespace checking is disabled. `dict-
+# separator` is used to allow tabulation in dicts, etc.: {1  : 1,\n222: 2}.
+# `trailing-comma` allows a space between comma and closing bracket: (a, ).
+# `empty-line` allows space-only lines.
+no-space-check=trailing-comma,
+               dict-separator
+
+# Allow the body of a class to be on the same line as the declaration if body
+# contains single statement.
+single-line-class-stmt=no
+
+# Allow the body of an if to be on the same line as the test if there is no
+# else.
+single-line-if-stmt=no
+
+
+[STRING]
+
+# This flag controls whether the implicit-str-concat-in-sequence should
+# generate a warning on implicit string concatenation in sequences defined over
+# several lines.
+check-str-concat-over-line-jumps=no
+
+
+[SPELLING]
+
+# Limits count of emitted suggestions for spelling mistakes.
+max-spelling-suggestions=4
+
+# Spelling dictionary name. Available dictionaries: none. To make it work,
+# install the python-enchant package.
+spelling-dict=
+
+# List of comma separated words that should not be checked.
+spelling-ignore-words=
+
+# A path to a file that contains the private dictionary; one word per line.
+spelling-private-dict-file=
+
+# Tells whether to store unknown words to the private dictionary (see the
+# --spelling-private-dict-file option) instead of raising a message.
+spelling-store-unknown-words=no
+
+
+[LOGGING]
+
+# Format style used to check logging format string. `old` means using %
+# formatting, `new` is for `{}` formatting,and `fstr` is for f-strings.
+logging-format-style=old
+
+# Logging modules to check that the string format arguments are in logging
+# function parameter format.
+logging-modules=logging
+
+
+[SIMILARITIES]
+
+# Ignore comments when computing similarities.
+ignore-comments=yes
+
+# Ignore docstrings when computing similarities.
+ignore-docstrings=yes
+
+# Ignore imports when computing similarities.
+ignore-imports=no
+
+# Minimum lines number of a similarity.
+min-similarity-lines=4
+
+
+[VARIABLES]
+
+# List of additional names supposed to be defined in builtins. Remember that
+# you should avoid defining new builtins when possible.
+additional-builtins=
+
+# Tells whether unused global variables should be treated as a violation.
+allow-global-unused-variables=yes
+
+# List of strings which can identify a callback function by name. A callback
+# name must start or end with one of those strings.
+callbacks=cb_,
+          _cb
+
+# A regular expression matching the name of dummy variables (i.e. expected to
+# not be used).
+dummy-variables-rgx=_+$|(_[a-zA-Z0-9_]*[a-zA-Z0-9]+?$)|dummy|^ignored_|^unused_
+
+# Argument names that match this expression will be ignored. Default to name
+# with leading underscore.
+ignored-argument-names=_.*|^ignored_|^unused_
+
+# Tells whether we should check for unused import in __init__ files.
+init-import=no
+
+# List of qualified module names which can have objects that can redefine
+# builtins.
+redefining-builtins-modules=six.moves,past.builtins,future.builtins,builtins,io
+
+
+[CLASSES]
+
+# List of method names used to declare (i.e. assign) instance attributes.
+defining-attr-methods=__init__,
+                      __new__,
+                      setUp,
+                      __post_init__
+
+# List of member names, which should be excluded from the protected access
+# warning.
+exclude-protected=_asdict,
+                  _fields,
+                  _replace,
+                  _source,
+                  _make
+
+# List of valid names for the first argument in a class method.
+valid-classmethod-first-arg=cls
+
+# List of valid names for the first argument in a metaclass class method.
+valid-metaclass-classmethod-first-arg=cls
+
+
+[IMPORTS]
+
+# List of modules that can be imported at any level, not just the top level
+# one.
+allow-any-import-level=
+
+# Allow wildcard imports from modules that define __all__.
+allow-wildcard-with-all=no
+
+# Analyse import fallback blocks. This can be used to support both Python 2 and
+# 3 compatible code, which means that the block might have code that exists
+# only in one or another interpreter, leading to false positives when analysed.
+analyse-fallback-blocks=no
+
+# Deprecated modules which should not be used, separated by a comma.
+deprecated-modules=optparse,tkinter.tix
+
+# Create a graph of external dependencies in the given file (report RP0402 must
+# not be disabled).
+ext-import-graph=
+
+# Create a graph of every (i.e. internal and external) dependencies in the
+# given file (report RP0402 must not be disabled).
+import-graph=
+
+# Create a graph of internal dependencies in the given file (report RP0402 must
+# not be disabled).
+int-import-graph=
+
+# Force import order to recognize a module as part of the standard
+# compatibility libraries.
+known-standard-library=
+
+# Force import order to recognize a module as part of a third party library.
+known-third-party=enchant
+
+# Couples of modules and preferred modules, separated by a comma.
+preferred-modules=
+
+
+[DESIGN]
+
+# Maximum number of arguments for function / method.
+max-args=10
+
+# Maximum number of attributes for a class (see R0902).
+max-attributes=7
+
+# Maximum number of boolean expressions in an if statement (see R0916).
+max-bool-expr=5
+
+# Maximum number of branch for function / method body.
+max-branches=20
+
+# Maximum number of locals for function / method body.
+max-locals=20
+
+# Maximum number of parents for a class (see R0901).
+max-parents=7
+
+# Maximum number of public methods for a class (see R0904).
+max-public-methods=20
+
+# Maximum number of return / yield for function / method body.
+max-returns=20
+
+# Maximum number of statements in function / method body.
+max-statements=50
+
+# Minimum number of public methods for a class (see R0903).
+min-public-methods=0
+
+
+[EXCEPTIONS]
+
+# Exceptions that will emit a warning when being caught. Defaults to
+# "BaseException, Exception".
+overgeneral-exceptions=BaseException,
+                       Exception

--- a/libpyclingo/clingo/ast.py
+++ b/libpyclingo/clingo/ast.py
@@ -1168,7 +1168,7 @@ class Transformer:
         if isinstance(ast, AST):
             return self.visit(ast, *args, **kwargs) # type: ignore
 
-        if isinstance(ast, Sequence):
+        if isinstance(ast, abc.Sequence):
             return self.visit_sequence(ast, *args, **kwargs)
 
         raise TypeError('unexpected type')

--- a/libpyclingo/clingo/ast.py
+++ b/libpyclingo/clingo/ast.py
@@ -874,6 +874,11 @@ class AST:
     def __str__(self):
         return _str(_lib.clingo_ast_to_string_size, _lib.clingo_ast_to_string, self._rep)
 
+    def __repr__(self):
+        name = str(self.ast_type).replace('ASTType', 'ast')
+        args = ', '.join(repr(x) for x in self.values())
+        return f'{name}({args})'
+
     def __copy__(self) -> 'AST':
         '''
         Return a shallow copy of the ast.

--- a/libpyclingo/clingo/solving.py
+++ b/libpyclingo/clingo/solving.py
@@ -143,6 +143,9 @@ class SolveResult:
             return "UNSAT"
         return "UNKNOWN"
 
+    def __repr__(self):
+        return f"SolveResult({self._rep})"
+
 class SolveControl:
     '''
     Object that allows for controlling a running search.
@@ -348,6 +351,9 @@ class Model:
 
     def __str__(self):
         return " ".join(map(str, self.symbols(shown=True)))
+
+    def __repr__(self):
+        return f'Model({self._rep!r})'
 
     @property
     def context(self) -> SolveControl:

--- a/libpyclingo/clingo/tests/test_ast.py
+++ b/libpyclingo/clingo/tests/test_ast.py
@@ -11,7 +11,7 @@ from .. import ast
 from ..ast import (AST, ASTSequence, Id, Location, Program, ProgramBuilder, Position, StrSequence,
                    SymbolicTerm, TheoryUnparsedTermElement,
                    parse_string)
-from ..symbol import Function
+from ..symbol import *
 from ..control import Control
 
 class VariableRenamer(ast.Transformer):
@@ -386,3 +386,13 @@ class TestAST(TestCase):
         vrt = VariableRenamer()
         parse_string('p(X) :- q(X).', lambda stm: prg.append(str(vrt(stm))))
         self.assertEqual(prg[-1], 'p(_X) :- q(_X).')
+
+    def test_repr(self):
+        prg = []
+        input_ = """a :- &sum(body,second) { foo; (1 - 3) } > (4 * 17).
+&theory { (X * a ** stuff): dom(X); (1 - 3) }.
+&diff { (foo - bar) } <= 42."""
+        parse_string(input_, prg.append)
+        output_ = "\n".join(str(eval(repr(stm))) for stm in prg)
+        input_ = "#program base.\n" + input_
+        self.assertEqual(input_, output_)

--- a/libpyclingo/clingo/tests/test_ast.py
+++ b/libpyclingo/clingo/tests/test_ast.py
@@ -11,7 +11,7 @@ from .. import ast
 from ..ast import (AST, ASTSequence, Id, Location, Program, ProgramBuilder, Position, StrSequence,
                    SymbolicTerm, TheoryUnparsedTermElement,
                    parse_string)
-from ..symbol import *
+from ..symbol import Function, Number
 from ..control import Control
 
 class VariableRenamer(ast.Transformer):
@@ -340,7 +340,7 @@ class TestAST(TestCase):
         loc = Location(pos, pos)
 
         lst = ["x", "y", "z"]
-        sym = SymbolicTerm(loc, Function("a"))
+        sym = SymbolicTerm(loc, Function("a", [Number(1)]))
         tue = TheoryUnparsedTermElement(lst, sym)
         seq = tue.operators
         self.assertIsInstance(seq, StrSequence)
@@ -388,11 +388,16 @@ class TestAST(TestCase):
         self.assertEqual(prg[-1], 'p(_X) :- q(_X).')
 
     def test_repr(self):
-        prg = []
-        input_ = """a :- &sum(body,second) { foo; (1 - 3) } > (4 * 17).
-&theory { (X * a ** stuff): dom(X); (1 - 3) }.
-&diff { (foo - bar) } <= 42."""
-        parse_string(input_, prg.append)
-        output_ = "\n".join(str(eval(repr(stm))) for stm in prg)
-        input_ = "#program base.\n" + input_
-        self.assertEqual(input_, output_)
+        '''
+        Test the string representation of AST nodes.
+        '''
+        # pylint: disable=eval-used
+        stms = []
+        prg = dedent('''\
+            a :- &sum(body,second) { foo; (1 - 3) } > (4 * 17).
+            &theory { (X * a ** stuff): dom(X); (1 - 3) }.
+            &diff { (foo - bar) } <= 42.
+            1 #max { X : a } :- a, X = #count { a }.
+            ''')
+        parse_string(prg, stms.append)
+        self.assertEqual(stms, eval(repr(stms)))

--- a/libpyclingo/clingo/tests/test_atoms.py
+++ b/libpyclingo/clingo/tests/test_atoms.py
@@ -121,6 +121,8 @@ class TestAtoms(TestCase):
         self.assertEqual(hash(num), hash(lst.arguments[0]))
         self.assertNotEqual(num < sym, sym < num)
 
+        self.assertRegex(repr(num), 'TheoryTerm(.*)')
+
     def test_theory_element(self):
         '''
         Test theory element.
@@ -144,6 +146,8 @@ class TestAtoms(TestCase):
         self.assertNotEqual(a, b)
         self.assertNotEqual(hash(a), hash(b))
         self.assertNotEqual(a < b, b < a)
+
+        self.assertRegex(repr(a), 'TheoryElement(.*)')
 
     def test_theory_atom(self):
         '''
@@ -169,3 +173,5 @@ class TestAtoms(TestCase):
         self.assertNotEqual(a, b)
         self.assertNotEqual(hash(a), hash(b))
         self.assertNotEqual(a < b, b < a)
+
+        self.assertRegex(repr(a), 'TheoryAtom(.*)')

--- a/libpyclingo/clingo/tests/test_solving.py
+++ b/libpyclingo/clingo/tests/test_solving.py
@@ -22,6 +22,25 @@ class TestSolving(TestCase):
         self.mit = None
         self.ctl = None
 
+    def test_solve_result_str(self):
+        '''
+        Test string representation of solve results.
+        '''
+        ret = self.ctl.solve()
+        self.assertEqual(str(ret), 'SAT')
+        self.assertRegex(repr(ret), 'SolveResult(.*)')
+
+    def test_model_str(self):
+        '''
+        Test string representation of models.
+        '''
+        self.ctl.add('base', [], 'a.')
+        self.ctl.ground([('base', [])])
+        with self.ctl.solve(yield_=True) as hnd:
+            for mdl in hnd:
+                self.assertEqual(str(mdl), "a")
+                self.assertRegex(repr(mdl), "Model(.*)")
+
     def test_solve_cb(self):
         '''
         Test solving using callback.

--- a/libpyclingo/clingo/tests/test_symbol.py
+++ b/libpyclingo/clingo/tests/test_symbol.py
@@ -26,6 +26,12 @@ class TestSymbol(TestCase):
         '''
         self.assertEqual(str(Number(10)), "10")
 
+    def test_repr(self):
+        '''
+        Test representation of symbols.
+        '''
+        self.assertEqual(repr(Function('test', [Number(10), Infimum, Supremum, String("test")], False)), "Function('test', [Number(10), Infimum, Supremum, String('test')], False)")
+
     def test_cmp(self):
         '''
         Test hashing and comparisons.

--- a/libpyclingo/clingo/tests/test_symbol.py
+++ b/libpyclingo/clingo/tests/test_symbol.py
@@ -30,7 +30,9 @@ class TestSymbol(TestCase):
         '''
         Test representation of symbols.
         '''
-        self.assertEqual(repr(Function('test', [Number(10), Infimum, Supremum, String("test")], False)), "Function('test', [Number(10), Infimum, Supremum, String('test')], False)")
+        self.assertEqual(
+            repr(Function('test', [Number(10), Infimum, Supremum, String("test")], False)),
+            "Function('test', [Number(10), Infimum, Supremum, String('test')], False)")
 
     def test_cmp(self):
         '''

--- a/libpyclingo/clingo/theory_atoms.py
+++ b/libpyclingo/clingo/theory_atoms.py
@@ -86,6 +86,9 @@ class TheoryTerm:
                     _lib.clingo_theory_atoms_term_to_string,
                     self._rep, self._idx)
 
+    def __repr__(self):
+        return f'TheoryTerm({self._rep!r})'
+
     @property
     def arguments(self) -> List['TheoryTerm']:
         '''
@@ -142,6 +145,9 @@ class TheoryElement:
                     _lib.clingo_theory_atoms_element_to_string,
                     self._rep, self._idx)
 
+    def __repr__(self):
+        return f'TheoryElement({self._rep!r})'
+
     @property
     def condition(self) -> List[int]:
         '''
@@ -193,6 +199,9 @@ class TheoryAtom:
         return _str(_lib.clingo_theory_atoms_atom_to_string_size,
                     _lib.clingo_theory_atoms_atom_to_string,
                     self._rep, self._idx)
+
+    def __repr__(self):
+        return f'TheoryAtom({self._rep!r})'
 
     @property
     def elements(self) -> List[TheoryElement]:


### PR DESCRIPTION
Draft PR, do not merge.

Question 1:  Do theory related __repr__ make sense, as they can't be created by hand ?
Question 2: Should a single test file for every class be added currently simply testing the repr function ?