### PR TITLE
Build PPC wheels for releases

### DIFF
--- a/.github/manylinux.py
+++ b/.github/manylinux.py
@@ -96,7 +96,7 @@ def run():
         mkdir('re2c_source')
         check_call(['curl', '-LJ', '-o', 're2c.tar.gz', 'https://github.com/skvadrik/re2c/archive/2.0.3.tar.gz'])
         check_call(['tar', 'xzf', 're2c.tar.gz', '-C', 're2c_source', '--strip-components=1'])
-        check_call(['cmake', '-G', 'Ninja', '-Hre2c_source', '-Bre2c_build', '-DRE2C_BUILD_RE2GO=OFF'])
+        check_call(['cmake', '-Hre2c_source', '-Bre2c_build', '-DRE2C_BUILD_RE2GO=OFF'])
         check_call(['cmake', '--build', 're2c_build', '--target', 'install'])
     else:
         check_call(['yum', 'install', '-y', 're2c', 'bison'])

--- a/.github/ppc.patch
+++ b/.github/ppc.patch
@@ -1,0 +1,8 @@
+diff --git a/pyproject.toml b/pyproject.toml
+index 7533528..962020e 100644
+--- a/pyproject.toml
++++ b/pyproject.toml
+@@ -1,2 +1,2 @@
+ [build-system]
+-requires = ["setuptools", "wheel", "scikit-build", "cmake", "ninja"]
++requires = ["setuptools", "wheel", "scikit-build", "ninja"]

--- a/.github/ppc.patch
+++ b/.github/ppc.patch
@@ -1,8 +1,0 @@
-diff --git a/pyproject.toml b/pyproject.toml
-index 7533528..962020e 100644
---- a/pyproject.toml
-+++ b/pyproject.toml
-@@ -1,2 +1,2 @@
- [build-system]
--requires = ["setuptools", "wheel", "scikit-build", "cmake", "ninja"]
-+requires = ["setuptools", "wheel", "scikit-build", "ninja"]

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -36,11 +36,6 @@ jobs:
       run: |
         docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
-    - name: Patch build system
-      if: ${{ matrix.image != 'manylinux2014_x86_64' }}
-      run: |
-        git apply .github/ppc.patch
-
     - name: Build wheels (wip)
       if: ${{ github.event.inputs.wip == 'true' && matrix.image == 'manylinux2014_x86_64' }}
       run: |

--- a/.github/workflows/manylinux.yml
+++ b/.github/workflows/manylinux.yml
@@ -19,6 +19,7 @@ jobs:
       matrix:
         image:
           - manylinux2014_x86_64
+          - manylinux2014_ppc64le
 
     steps:
     - name: Checkout repo
@@ -35,13 +36,18 @@ jobs:
       run: |
         docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
 
+    - name: Patch build system
+      if: ${{ matrix.image != 'manylinux2014_x86_64' }}
+      run: |
+        git apply .github/ppc.patch
+
     - name: Build wheels (wip)
-      if: ${{ github.event.inputs.wip == 'true' }}
+      if: ${{ github.event.inputs.wip == 'true' && matrix.image == 'manylinux2014_x86_64' }}
       run: |
         docker run --rm -e PLAT --workdir /github/workspace -v $GITHUB_WORKSPACE:/"/github/workspace" quay.io/pypa/${{ matrix.image }} /opt/python/cp38-cp38/bin/python ".github/manylinux.py"
 
     - name: Publish package to TestPyPI (wip)
-      if: ${{ github.event.inputs.wip == 'true' }}
+      if: ${{ github.event.inputs.wip == 'true' && matrix.image == 'manylinux2014_x86_64' }}
       uses: pypa/gh-action-pypi-publish@master
       with:
         user: __token__


### PR DESCRIPTION
Resolves #295 

Continuing the discussion on #295, this PR adds PPC to the manylinux "matrix" and sets it to a no-op for non-release builds.
This required a small patch to the build system requirements to avoid building CMake and its dependencies through QEMU, which would hit the Actions 6-hour time limit.

The wip build workflow was tested here: https://github.com/joshessman-llnl/clingo/actions/runs/774538046
It failed during the PyPI stage (as I didn't have the auth token, of course), but successfully built the x86 wheels and skipped the ppc wheels.

The release build workflow was tested here: https://github.com/joshessman-llnl/clingo/actions/runs/774560389
Again the PyPI upload failed but both sets of wheels built as expected (PPC still in progress).

I also had to default to the GNU Make generator when building re2c - Ninja gets installed later in the build process.  I believe that building re2c for releases is technically unnecessary but wanted to avoid the implicit requirement that all PPC builds are releases.