### PR TITLE
typo in comment

### DIFF
--- a/libpyclingo/clingo/theory.py
+++ b/libpyclingo/clingo/theory.py
@@ -287,7 +287,7 @@ class Theory:
         Get the integer index of a symbol assigned by the theory when a
         model is found.
 
-        Using indices allows for efficent retreival of values.
+        Using indices allows for efficent retrieval of values.
 
         Arguments
         ---------


### PR DESCRIPTION
According to this dictionary (https://en.wiktionary.org/wiki/retrieval), it's spelled 'retrieval'