### PR TITLE
Cleanup/clingo hh

### DIFF
--- a/.github/conda.py
+++ b/.github/conda.py
@@ -22,7 +22,7 @@ def get_build_number(channels, version):
 
 
     build_number = -1
-    for pkg in pkgs[NAME]:
+    for pkg in pkgs.get(NAME, []):
         if pkg['channel'].find(channels[-1]) >= 0 and pkg["version"] == version:
             build_number = max(build_number, pkg['build_number'])
 

--- a/.github/manylinux.py
+++ b/.github/manylinux.py
@@ -53,7 +53,7 @@ def compile_wheels(idx):
     '''
     for pybin in glob('/opt/python/*/bin'):
         # Requires Py3.6 or greater - on the docker image 3.5 is cp35-cp35m
-        if "35" not in pybin:
+        if "35" not in pybin and "310" not in pybin:
             args = [path.join(pybin, 'pip'), 'wheel', '--verbose', '--no-deps', '-w', 'wheelhouse/']
             if idx is not None:
                 args.extend(['--extra-index-url', idx])

--- a/.github/manylinux.py
+++ b/.github/manylinux.py
@@ -83,12 +83,12 @@ def run():
     args = parser.parse_args()
 
     if args.release:
-        rename_clingo_cffi()
         url = 'https://pypi.org/simple'
         idx = None
     else:
         url = 'https://test.pypi.org/simple'
         idx = 'https://test.pypi.org/simple/'
+        rename_clingo_cffi()
 
     adjust_version(url)
 

--- a/.github/manylinux.py
+++ b/.github/manylinux.py
@@ -8,8 +8,6 @@ from subprocess import check_output, check_call, CalledProcessError
 from os import unlink, environ, path, mkdir
 from glob import glob
 
-from rename import rename_clingo_cffi
-
 ARCH = check_output(['uname', '-m']).decode().strip()
 
 
@@ -88,7 +86,6 @@ def run():
     else:
         url = 'https://test.pypi.org/simple'
         idx = 'https://test.pypi.org/simple/'
-        rename_clingo_cffi()
 
     adjust_version(url)
 

--- a/.github/pipsource.py
+++ b/.github/pipsource.py
@@ -48,10 +48,10 @@ def run():
     parser.add_argument('--release', action='store_true', help='Build release package.')
     args = parser.parse_args()
     if args.release:
-        rename_clingo_cffi()
         url = 'https://pypi.org/simple'
     else:
         url = 'https://test.pypi.org/simple'
+        rename_clingo_cffi()
 
     adjust_version(url)
     check_call(['cmake', '-G', 'Ninja', '-H.', '-Bbuild'])

--- a/.github/pipsource.py
+++ b/.github/pipsource.py
@@ -6,8 +6,6 @@ import argparse
 from re import finditer, escape, match, sub, search
 from subprocess import check_call, check_output
 
-from rename import rename_clingo_cffi
-
 def adjust_version(url):
     '''
     Adjust version in setup.py.
@@ -51,7 +49,6 @@ def run():
         url = 'https://pypi.org/simple'
     else:
         url = 'https://test.pypi.org/simple'
-        rename_clingo_cffi()
 
     adjust_version(url)
     check_call(['cmake', '-G', 'Ninja', '-H.', '-Bbuild'])

--- a/.github/pipwinmac.py
+++ b/.github/pipwinmac.py
@@ -95,7 +95,7 @@ def run():
     check_call(args)
 
     # build
-    args = ['python', 'setup.py', 'build', '--build-type', 'Release']
+    args = ['python', 'setup.py', 'bdist_wheel', '--build-type', 'Release']
     if os.name != 'posix':
         args.extend(['-G', 'NMake Makefiles'])
     check_call(args)

--- a/.github/pipwinmac.py
+++ b/.github/pipwinmac.py
@@ -13,8 +13,6 @@ from os import environ, pathsep
 import os
 import argparse
 
-from rename import rename_clingo_cffi
-
 NAMES = {
     "cpython": "cp",
     "pypy": "pp",
@@ -81,7 +79,6 @@ def run():
     else:
         url = 'https://test.pypi.org/simple'
         idx = 'https://test.pypi.org/simple'
-        rename_clingo_cffi()
 
     adjust_version(url)
 

--- a/.github/rename.py
+++ b/.github/rename.py
@@ -7,13 +7,18 @@ from os.path import isfile
 
 def rename_clingo_cffi():
     '''
-    Replace all occurences of 'clingo-cffi' by 'clingo' pip package files.
+    Replace all occurences of 'clingo' package by 'clingo-cffi' in pip package files.
     '''
     for n in ('setup.py', 'pyproject.toml'):
         if not isfile(n):
             continue
         with open(n, 'r+') as f:
-            content = re.sub(r'''(['"])clingo-cffi(['"])''', r'\1clingo\2', f.read())
+            content = ""
+            for line in f:
+                if re.match(r'^ *(install_requires|requires) *= *\[', line) or re.match(r'''^ *name *= *['"]''', line):
+                    content += re.sub(r'''(['"])clingo(['"])''', r'\1clingo-cffi\2', line)
+                else:
+                    content += line
             f.seek(0)
             f.write(content)
             f.truncate()

--- a/.github/workflows/pipwinmac-wip.yml
+++ b/.github/workflows/pipwinmac-wip.yml
@@ -32,7 +32,7 @@ jobs:
 
     - name: Install pip prerequisites
       run: |
-        pip install --user cffi scikit-build cmake ninja twine
+        pip install --user toml cffi scikit-build cmake ninja twine
 
     - name: Install macos-10.15 prerequisites
       if: ${{ matrix.os == 'macos-10.15' }}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,7 @@
 # Changes
 
 ## clingo 5.5.1
+  * fix error handling while solving in Python API (#334)
 
 ## clingo 5.5.0
   * allow for using `not` as a theory operator (#193)

--- a/examples/clingo/setconf/setconf-py.lp
+++ b/examples/clingo/setconf/setconf-py.lp
@@ -7,7 +7,7 @@ def print_conf(conf, ident):
         subconf = getattr(conf, key)
         if isinstance(subconf, clingo.Configuration):
             label = key
-            if (len(subconf) >= 0):
+            if subconf.is_array:
                 label += "[0.." + str(len(subconf)) + "]"
             print ("{0}{1} - {2}".format(ident, label, conf.description(key)))
             print_conf(subconf, "  " + ident + label + ".")

--- a/examples/gringo/sort/sort-py.lp
+++ b/examples/gringo/sort/sort-py.lp
@@ -1,14 +1,14 @@
 #script (python)
 
-import clingo
+from clingo import Number, Tuple_
 
 values = []
 
 def gather(a):
     values.append(a)
-    return 1
+    return Number(1)
 
 def sort():
-    return list(enumerate(sorted(values)))
+    return [Tuple_((Number(i), val)) for i, val in enumerate(sorted(values))]
 
 #end.

--- a/libclingo/clingo.h
+++ b/libclingo/clingo.h
@@ -1651,7 +1651,7 @@ enum clingo_configuration_type_e {
     clingo_configuration_type_array = 2, //!< the entry is an array
     clingo_configuration_type_map   = 4  //!< the entry is a map
 };
-//! Bitset for values of type ::clingo_configuration_type.
+//! Bitset for values of type ::clingo_configuration_type_e.
 typedef unsigned clingo_configuration_type_bitset_t;
 
 //! Handle for to the solver configuration.

--- a/libclingo/clingo.h
+++ b/libclingo/clingo.h
@@ -2618,14 +2618,14 @@ CLINGO_VISIBILITY_DEFAULT void clingo_ast_release(clingo_ast_t *ast);
 //! @name Functions to copy ASTs
 //! @{
 
-//! Deep copy an AST node.
+//! Create a shallow copy of an AST node.
 //!
 //! @param[in] ast the AST to copy
 //! @param[out] copy the resulting AST
 //! @return whether the call was successful; might set one of the following error codes:
 //! - ::clingo_error_bad_alloc
 CLINGO_VISIBILITY_DEFAULT bool clingo_ast_copy(clingo_ast_t *ast, clingo_ast_t **copy);
-//! Create a shallow copy of an AST node.
+//! Create a deep copy of an AST node.
 //!
 //! @param[in] ast the AST to copy
 //! @param[out] copy the resulting AST

--- a/libclingo/clingo.hh
+++ b/libclingo/clingo.hh
@@ -379,12 +379,14 @@ private:
 };
 
 template <class T, class A=T*, class P=ValuePointer<T>>
-class ArrayIterator : public std::iterator<std::random_access_iterator_tag, T, ptrdiff_t, P, T> {
+class ArrayIterator {
 public:
-    using base = std::iterator<std::random_access_iterator_tag, T, ptrdiff_t, P, T>;
-    using difference_type = typename base::difference_type;
-    using reference = typename base::reference;
-    using pointer = typename base::pointer;
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = T;
+    using difference_type = ptrdiff_t;
+    using pointer = P;
+    using reference = T;
+
     explicit ArrayIterator(A arr, size_t index = 0)
     : arr_(std::move(arr))
     , index_(index) { }
@@ -646,8 +648,14 @@ private:
     clingo_symbolic_atom_iterator_t range_;
 };
 
-class SymbolicAtomIterator : private SymbolicAtom, public std::iterator<std::input_iterator_tag, SymbolicAtom> {
+class SymbolicAtomIterator : private SymbolicAtom {
 public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = SymbolicAtom;
+    using difference_type = ptrdiff_t;
+    using pointer = SymbolicAtom*;
+    using reference = SymbolicAtom&;
+
     explicit SymbolicAtomIterator(clingo_symbolic_atoms_t const *atoms, clingo_symbolic_atom_iterator_t range)
     : SymbolicAtom{atoms, range} { }
     SymbolicAtom &operator*() { return *this; }
@@ -692,10 +700,14 @@ enum class TheoryTermType : clingo_theory_term_type_t {
 };
 
 template <class T>
-class TheoryIterator : public std::iterator<std::random_access_iterator_tag, T const, ptrdiff_t, T*, T> {
+class TheoryIterator {
 public:
-    using base = std::iterator<std::random_access_iterator_tag, T const>;
-    using difference_type = typename base::difference_type;
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = T const;
+    using difference_type = ptrdiff_t;
+    using pointer = T*;
+    using reference = T;
+
     explicit TheoryIterator(clingo_theory_atoms_t const *atoms, clingo_id_t const* id)
     : elem_(atoms)
     , id_(id) { }
@@ -711,8 +723,8 @@ public:
         --*this;
         return t;
     }
-    TheoryIterator& operator+=(difference_type n) { id_ += n; return *this; }
-    TheoryIterator& operator-=(difference_type n) { id_ -= n; return *this; }
+    TheoryIterator& operator+=(difference_type n) { id_ += n; return *this; } // NOLINT
+    TheoryIterator& operator-=(difference_type n) { id_ -= n; return *this; } // NOLINT
     friend TheoryIterator operator+(TheoryIterator it, difference_type n) { return TheoryIterator{it.atoms(), it.id_ + n}; }
     friend TheoryIterator operator+(difference_type n, TheoryIterator it) { return TheoryIterator{it.atoms(), it.id_ + n}; }
     friend TheoryIterator operator-(TheoryIterator it, difference_type n) { return TheoryIterator{it.atoms(), it.id_ - n}; }
@@ -833,8 +845,14 @@ private:
 };
 std::ostream &operator<<(std::ostream &out, TheoryAtom term);
 
-class TheoryAtomIterator : private TheoryAtom, public std::iterator<TheoryAtom, std::random_access_iterator_tag, ptrdiff_t, TheoryAtom*, TheoryAtom> {
+class TheoryAtomIterator : private TheoryAtom {
 public:
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = TheoryAtom;
+    using difference_type = ptrdiff_t;
+    using pointer = TheoryAtom*;
+    using reference = TheoryAtom;
+
     explicit TheoryAtomIterator(clingo_theory_atoms_t const *atoms, clingo_id_t id)
     : TheoryAtom{atoms, id} { }
     TheoryAtomIterator& operator++() { ++id_; return *this; }
@@ -887,11 +905,14 @@ private:
 // {{{1 trail
 
 template <class T, class U, class I>
-class IndexIterator : public std::iterator<std::random_access_iterator_tag, typename T::value_type, I, typename T::value_type, typename T::value_type> {
+class IndexIterator {
 public:
+    using iterator_category = std::random_access_iterator_tag;
     using value_type = typename T::value_type;
-    using base = std::iterator<std::random_access_iterator_tag, value_type, I, value_type*, value_type>;
-    using difference_type = typename base::difference_type;
+    using difference_type = I;
+    using pointer = value_type*;
+    using reference = value_type;
+
     explicit IndexIterator(T *con = nullptr, U index = 0)
     : con_(con)
     , index_(index) { }
@@ -1452,8 +1473,14 @@ private:
 // {{{1 statistics
 
 template <class T>
-class KeyIterator : public std::iterator<std::random_access_iterator_tag, char const *, ptrdiff_t, ValuePointer<char const *>, char const *> {
+class KeyIterator {
 public:
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = char const *;
+    using difference_type = ptrdiff_t;
+    using pointer = ValuePointer<char const *>;
+    using reference = char const *;
+
     explicit KeyIterator(T const *map, size_t index = 0)
     : map_(map)
     , index_(index) { }
@@ -1604,8 +1631,14 @@ private:
     Detail::AssignOnce *exception_{nullptr};
 };
 
-class ModelIterator : public std::iterator<Model, std::input_iterator_tag> {
+class ModelIterator {
 public:
+    using iterator_category = std::input_iterator_tag;
+    using value_type = Model;
+    using difference_type = ptrdiff_t;
+    using pointer = Model const *;
+    using reference = Model const &;
+
     explicit ModelIterator(SolveHandle &iter)
     : iter_(&iter) { }
     ModelIterator() = default;

--- a/libclingo/src/astv2_str.cc
+++ b/libclingo/src/astv2_str.cc
@@ -512,13 +512,13 @@ std::ostream &operator<<(std::ostream &out, AST const &ast) {
         }
         case clingo_ast_type_disjoint_element: {
             out << print_list<AST::ASTVec>(ast, clingo_ast_attribute_terms, "", ",", "", false)
-                << ": " << print(ast, clingo_ast_attribute_term)
+                << ":" << print(ast, clingo_ast_attribute_term)
                 << print_list<AST::ASTVec>(ast, clingo_ast_attribute_condition, ": ", ", ", "", false);
             break;
         }
         case clingo_ast_type_disjoint: {
-            out << "#disjoint { "
-                << print_list<AST::ASTVec>(ast, clingo_ast_attribute_elements, "", "; ", "", false)
+            out << "#disjoint {"
+                << print_list<AST::ASTVec>(ast, clingo_ast_attribute_elements, " ", "; ", "", false)
                 << " }";
             break;
         }

--- a/libclingo/src/astv2_unpool.cc
+++ b/libclingo/src/astv2_unpool.cc
@@ -81,7 +81,8 @@ tl::optional<std::vector<AST::ASTVec>> unpool(AST::ASTVec &vec, clingo_ast_unpoo
     product.reserve(size);
     product.emplace_back();
     for (auto &pool : pools) {
-        for (auto jt = product.begin(), je = product.end(); jt != je; ++jt) {
+        auto jt = product.begin();
+        for (size_t i = 0, e = product.size(); i != e; ++i, ++jt) {
             assert(!pool->empty());
             auto kt = pool->begin();
             auto ke = pool->end();

--- a/libclingo/src/control.cc
+++ b/libclingo/src/control.cc
@@ -1201,7 +1201,7 @@ C(interval) { A(location, location), A(left, ast), A(right, ast) };
 C(function) { A(location, location), A(name, string), A(arguments, ast_array), A(external, number) };
 C(pool) { A(location, location), A(arguments, ast_array) };
 // csp terms
-C(csp_product) { A(location, location), A(coefficient, ast), A(variable, ast) };
+C(csp_product) { A(location, location), A(coefficient, ast), A(variable, optional_ast) };
 C(csp_sum) { A(location, location), A(terms, ast_array) };
 C(csp_guard) { A(comparison, number), A(term, ast) };
 // simple atoms

--- a/libclingo/src/control.cc
+++ b/libclingo/src/control.cc
@@ -884,7 +884,7 @@ extern "C" bool clingo_configuration_type(clingo_configuration_t const *conf, cl
         int map_size, array_size, value_size;
         conf->getKeyInfo(key, &map_size, &array_size, nullptr, &value_size);
         *ret = 0;
-        if (map_size >= 0)   { *ret |= clingo_configuration_type_map; }
+        if (map_size > 0) { *ret |= clingo_configuration_type_map; }
         if (array_size >= 0) { *ret |= clingo_configuration_type_array; }
         if (value_size >= 0) { *ret |= clingo_configuration_type_value; }
     }

--- a/libclingo/src/control.cc
+++ b/libclingo/src/control.cc
@@ -1202,8 +1202,8 @@ C(function) { A(location, location), A(name, string), A(arguments, ast_array), A
 C(pool) { A(location, location), A(arguments, ast_array) };
 // csp terms
 C(csp_product) { A(location, location), A(coefficient, ast), A(variable, ast) };
-C(csp_sum) { A(location, location), A(coefficient, ast), A(variable, ast) };
-C(csp_guard) { A(location, location), A(comparison, number), A(term, ast) };
+C(csp_sum) { A(location, location), A(terms, ast_array) };
+C(csp_guard) { A(comparison, number), A(term, ast) };
 // simple atoms
 C(boolean_constant) { A(value, number) };
 C(symbolic_atom) { A(symbol, ast) };

--- a/libclingo/tests/astv2.cc
+++ b/libclingo/tests/astv2.cc
@@ -158,7 +158,7 @@ TEST_CASE("parse-ast-v2", "[clingo]") {
         REQUIRE(parse(":-{a:b,c;e}2.") == "#false :- 2 >= { a: b, c; e }.");
         REQUIRE(parse(":-1#min{1,2:b,c;1:e}2.") == "#false :- 1 <= #min { 1,2: b, c; 1: e } <= 2.");
         REQUIRE(parse(":-&p { 1: a,b; 2: c }.") == "#false :- &p { 1: a, b; 2: c }.");
-        REQUIRE(parse(":-#disjoint {1,2:$x:a,b}.") == "#false :- #disjoint { 1,2: 1$*$x: a, b }.");
+        REQUIRE(parse(":-#disjoint {1,2:$x:a,b}.") == "#false :- #disjoint { 1,2:1$*$x: a, b }.");
     }
     SECTION("head literal") {
         REQUIRE(parse("a.") == "a.");
@@ -442,14 +442,14 @@ TEST_CASE("unpool-ast-v2", "[clingo]") {
             "1$*$a(2) $< a(4)$*$b(6).");
         REQUIRE(unpool("#disjoint { a(1;2): $a(3;4): a(5;6) }.") ==
             "#false :- not #disjoint { "
-            "a(1): 1$*$a(3): a(5); "
-            "a(1): 1$*$a(3): a(6); "
-            "a(1): 1$*$a(4): a(5); "
-            "a(1): 1$*$a(4): a(6); "
-            "a(2): 1$*$a(3): a(5); "
-            "a(2): 1$*$a(3): a(6); "
-            "a(2): 1$*$a(4): a(5); "
-            "a(2): 1$*$a(4): a(6) "
+            "a(1):1$*$a(3): a(5); "
+            "a(1):1$*$a(3): a(6); "
+            "a(1):1$*$a(4): a(5); "
+            "a(1):1$*$a(4): a(6); "
+            "a(2):1$*$a(3): a(5); "
+            "a(2):1$*$a(3): a(6); "
+            "a(2):1$*$a(4): a(5); "
+            "a(2):1$*$a(4): a(6) "
             "}.");
     }
     SECTION("head literal") {

--- a/libpyclingo/clingo/__init__.py
+++ b/libpyclingo/clingo/__init__.py
@@ -9,36 +9,43 @@ Terms
 Terms without variables and interpreted functions are called symbols in the
 following. They are wrapped in the `clingo.symbol.Symbol` class.
 
-Atoms and Literals
-------------------
-Atoms are also captured using the `clingo.symbol.Symbol` class. They must be of
-type `clingo.symbol.SymbolType.Function`. Some functions accept literals in
-form of pairs of symbols and Booleans. The Boolean stands for the sign of the
-literal (`True` for positive and `False` for negative).
+Symbolic Atoms and Literals
+---------------------------
+*Symbolic atoms* without variables and interpreted functions, which appear in
+ground logic programs, are captured using the `clingo.symbol.Symbol` class.
+They must be of type `clingo.symbol.SymbolType.Function`. Furthermore, some
+functions accept *symbolic literals*, which are represented as pairs of symbols
+and Booleans. The Boolean stands for the sign of the literal (`True` for
+positive and `False` for negative).
 
 Program Literals
 ----------------
-*Program literals* are non-zero integers associated with symbolic atoms, theory
-atoms, and also without any association if they are used to translate complex
-language constructs. The sign of a program literal is used to represent default
+When passing a ground logic program to a solver, clingo does not use a human
+readable textual representation but the aspif format. The literals in this
+format are called *program literals*. They are non-zero integers associated
+with symbolic atoms, theory atoms, and also without any association if they are
+used to translate complex language constructs not directly representable in
+aspif format. The sign of a program literal is used to represent default
 negation. Symbolic atoms can be mapped to program literals using the
-`clingo.symbolic_atoms` module, theory atoms using the `clingo.theory_atoms`
-module, and the `clingo.backend` can also be used to introduce fresh program
-literals.
+`clingo.symbolic_atoms` module and theory atoms using the `clingo.theory_atoms`
+module. Note that symbolic and theory atoms can share the same program
+literals. Finally, the `clingo.backend` module can also be used to introduce
+fresh symbolic atoms and program literals.
 
 Solver Literals
 ---------------
-Furthermore, there are non-zero integer *solver literals*. There is a
-surjective mapping from program atoms to solver literals. The
-`clingo.propagator.PropagateInit.solver_literal` function can be used to map
-program literals to solver literals.
+Before solving, programs in aspif format are translated to an internal solver
+representation, where program literals are again mapped to non-zero integers,
+so called *solver literals*. The `clingo.propagator.PropagateInit.solver_literal`
+function can be used to map program literals to solver literals. Note that
+different program literals can share the same solver literal.
 
 Embedded Python Code
 --------------------
 If the clingo application is build with Python support, clingo will also be
-able to execute Python code embedded in logic programs.  Functions defined in a
+able to execute Python code embedded in logic programs. Functions defined in a
 Python script block are callable during the instantiation process using
-`@`-syntax.  The default grounding/solving process can be customized if a main
+`@`-syntax. The default grounding/solving process can be customized if a main
 function is provided.
 
 ## Examples

--- a/libpyclingo/clingo/ast.py
+++ b/libpyclingo/clingo/ast.py
@@ -1283,7 +1283,7 @@ def Pool(location: Location, arguments: Sequence[AST]) -> AST:
         _ffi.cast('size_t', len(arguments))))
     return AST(p_ast[0])
 
-def CspProduct(location: Location, coefficient: AST, variable: AST) -> AST:
+def CspProduct(location: Location, coefficient: AST, variable: Optional[AST]) -> AST:
     '''
     Construct an AST node of type `ASTType.CspProduct`.
     '''
@@ -1293,7 +1293,7 @@ def CspProduct(location: Location, coefficient: AST, variable: AST) -> AST:
         _lib.clingo_ast_type_csp_product, p_ast,
         c_location[0],
         coefficient._rep,
-        variable._rep))
+        _ffi.NULL if variable is None else variable._rep))
     return AST(p_ast[0])
 
 def CspSum(location: Location, terms: Sequence[AST]) -> AST:
@@ -1305,7 +1305,8 @@ def CspSum(location: Location, terms: Sequence[AST]) -> AST:
     _handle_error(_lib.clingo_ast_build(
         _lib.clingo_ast_type_csp_sum, p_ast,
         c_location[0],
-        _ffi.new('clingo_ast_t*[]', [ x._rep for x in terms ])))
+        _ffi.new('clingo_ast_t*[]', [ x._rep for x in terms ]),
+        _ffi.cast('size_t', len(terms))))
     return AST(p_ast[0])
 
 def CspGuard(comparison: int, term: AST) -> AST:

--- a/libpyclingo/clingo/ast.py
+++ b/libpyclingo/clingo/ast.py
@@ -662,6 +662,13 @@ class ASTSequence(abc.MutableSequence):
     def insert(self, index, value):
         _handle_error(_lib.clingo_ast_attribute_insert_ast_at(self._rep, self._attribute, index, value._rep))
 
+    def clear(self):
+        '''
+        Remove all elements from the sequence.
+        '''
+        for i in range(len(self), 0, -1):
+            del self[i - 1]
+
     def __str__(self):
         return str(list(self))
 
@@ -714,6 +721,13 @@ class StrSequence(abc.MutableSequence):
 
     def insert(self, index, value):
         _handle_error(_lib.clingo_ast_attribute_insert_string_at(self._rep, self._attribute, index, value.encode()))
+
+    def clear(self):
+        '''
+        Remove all elements from the sequence.
+        '''
+        for i in range(len(self), 0, -1):
+            del self[i - 1]
 
     def __str__(self):
         return str(list(self))

--- a/libpyclingo/clingo/ast.py
+++ b/libpyclingo/clingo/ast.py
@@ -1296,7 +1296,7 @@ def CspProduct(location: Location, coefficient: AST, variable: AST) -> AST:
         variable._rep))
     return AST(p_ast[0])
 
-def CspSum(location: Location, coefficient: AST, variable: AST) -> AST:
+def CspSum(location: Location, terms: Sequence[AST]) -> AST:
     '''
     Construct an AST node of type `ASTType.CspSum`.
     '''
@@ -1305,19 +1305,16 @@ def CspSum(location: Location, coefficient: AST, variable: AST) -> AST:
     _handle_error(_lib.clingo_ast_build(
         _lib.clingo_ast_type_csp_sum, p_ast,
         c_location[0],
-        coefficient._rep,
-        variable._rep))
+        _ffi.new('clingo_ast_t*[]', [ x._rep for x in terms ])))
     return AST(p_ast[0])
 
-def CspGuard(location: Location, comparison: int, term: AST) -> AST:
+def CspGuard(comparison: int, term: AST) -> AST:
     '''
     Construct an AST node of type `ASTType.CspGuard`.
     '''
     p_ast = _ffi.new('clingo_ast_t**')
-    c_location = _c_location(location)
     _handle_error(_lib.clingo_ast_build(
         _lib.clingo_ast_type_csp_guard, p_ast,
-        c_location[0],
         _ffi.cast('int', comparison),
         term._rep))
     return AST(p_ast[0])

--- a/libpyclingo/clingo/configuration.py
+++ b/libpyclingo/clingo/configuration.py
@@ -50,11 +50,11 @@ class Configuration:
         config.group.subgroup[0].option = "value1"
         config.group.subgroup[1].option = "value2"
 
-    To list the subgroups of an option group, use the `Configuration.keys` member.
-    Array option groups, like solver, have a non-negative length and can be
-    iterated. Furthermore, there are meta options having key `configuration`.
-    Assigning a meta option sets a number of related options.  To get further
-    information about an option or option group, use `Configuration.description`.
+    To list the subgroups of an option group, use the `Configuration.keys`
+    member. Array option groups, like solver, can be iterated. Furthermore,
+    there are meta options having key `configuration`. Assigning a meta option
+    sets a number of related options.  To get further information about an
+    option or option group, use `Configuration.description`.
 
     Notes
     -----
@@ -73,6 +73,13 @@ class Configuration:
     @property
     def _type(self) -> int:
         return _c_call('clingo_configuration_type_bitset_t', _lib.clingo_configuration_type, self._rep, self._key)
+
+    @property
+    def is_array(self) -> bool:
+        '''
+        This property is true if the configuration option is an array.
+        '''
+        return bool(self._type & _lib.clingo_configuration_type_array)
 
     def _get_subkey(self, name: str) -> Optional[int]:
         if self._type & _lib.clingo_configuration_type_map:

--- a/libpyclingo/clingo/configuration.py
+++ b/libpyclingo/clingo/configuration.py
@@ -99,7 +99,7 @@ class Configuration:
         key = _c_call('clingo_id_t', _lib.clingo_configuration_array_at, self._rep, self._key, idx)
         return Configuration(self._rep, key)
 
-    def __getattr__(self, name: str) -> Union[None,str,'Configuration']:
+    def __getattr__(self, name: str) -> Union[None, str, 'Configuration']:
         key = self._get_subkey(name)
         if key is None:
             raise AttributeError(f'no attribute: {name}')

--- a/libpyclingo/clingo/control.py
+++ b/libpyclingo/clingo/control.py
@@ -471,11 +471,11 @@ class Control:
 
     def solve(self,
               assumptions: Sequence[Union[Tuple[Symbol,bool],int]]=[],
-              on_model: Callable[[Model],Optional[bool]]=None,
-              on_unsat: Callable[[Sequence[int]],None]=None,
-              on_statistics : Callable[[StatisticsMap,StatisticsMap],None]=None,
-              on_finish: Callable[[SolveResult],None]=None,
-              on_core: Callable[[Sequence[int]],None]=None,
+              on_model: Optional[Callable[[Model],Optional[bool]]]=None,
+              on_unsat: Optional[Callable[[Sequence[int]],None]]=None,
+              on_statistics : Optional[Callable[[StatisticsMap,StatisticsMap],None]]=None,
+              on_finish: Optional[Callable[[SolveResult],None]]=None,
+              on_core: Optional[Callable[[Sequence[int]],None]]=None,
               yield_: bool=False,
               async_: bool=False) -> Union[SolveHandle,SolveResult]:
         '''

--- a/libpyclingo/clingo/control.py
+++ b/libpyclingo/clingo/control.py
@@ -574,7 +574,7 @@ class Control:
                 p_ass, len(assumptions),
                 _lib.pyclingo_solve_event_callback, self._handler,
                 handler=data),
-            handler)
+            data)
 
         if not yield_ and not async_:
             with handle:

--- a/libpyclingo/clingo/propagator.py
+++ b/libpyclingo/clingo/propagator.py
@@ -778,6 +778,8 @@ class Propagator(metaclass=ABCMeta):
         decision. If all propagators return 0, then the fallback literal is
         used.
         '''
+        # pylint: disable=unused-argument
+        return fallback
 
 @_ffi.def_extern(onerror=_cb_error_handler('data'), name='pyclingo_propagator_init')
 def _pyclingo_propagator_init(init, data):

--- a/libpyclingo/clingo/solving.py
+++ b/libpyclingo/clingo/solving.py
@@ -246,6 +246,9 @@ class _SymbolSequence(Sequence[Symbol]):
     def __str__(self):
         return f'[{", ".join(str(sym) for sym in self)}]'
 
+    def __repr__(self):
+        return f'[{", ".join(repr(sym) for sym in self)}]'
+
 class Model:
     '''
     Provides access to a model during a solve call and provides a

--- a/libpyclingo/clingo/solving.py
+++ b/libpyclingo/clingo/solving.py
@@ -243,6 +243,9 @@ class _SymbolSequence(Sequence[Symbol]):
         for i in range(len(self)):
             yield Symbol(self._p_symbols[i])
 
+    def __str__(self):
+        return f'[{", ".join(str(sym) for sym in self)}]'
+
 class Model:
     '''
     Provides access to a model during a solve call and provides a

--- a/libpyclingo/clingo/symbol.py
+++ b/libpyclingo/clingo/symbol.py
@@ -20,7 +20,7 @@ Examples
     p(3)
 '''
 
-from typing import Callable, List, Sequence
+from typing import Callable, List, Optional, Sequence
 
 from enum import Enum
 from functools import total_ordering
@@ -256,7 +256,7 @@ _lib.clingo_symbol_create_supremum(_p_supremum)
 Infimum: Symbol = Symbol(_p_infimum[0])
 Supremum: Symbol = Symbol(_p_supremum[0])
 
-def parse_term(string: str, logger: Callable[[MessageCode,str],None]=None, message_limit: int=20) -> Symbol:
+def parse_term(string: str, logger: Optional[Callable[[MessageCode,str],None]]=None, message_limit: int=20) -> Symbol:
     '''
     Parse the given string using gringo's term parser for ground terms.
 

--- a/libpyclingo/clingo/symbolic_atoms.py
+++ b/libpyclingo/clingo/symbolic_atoms.py
@@ -28,10 +28,9 @@ Examples
     [('p(1)', True, False), ('p(3)', False, False), ('p(2)', False, True)]
 '''
 
-from typing import Iterator, List, Optional, Tuple
+from typing import Collection, Iterator, List, Optional, Tuple
 
 from ._internal import _c_call, _ffi, _handle_error, _lib, _to_str
-from .util import Lookup
 from .symbol import Symbol
 
 __all__ = [ 'SymbolicAtom', 'SymbolicAtoms' ]
@@ -97,7 +96,7 @@ class SymbolicAtom:
         '''
         return Symbol(_c_call('clingo_symbol_t', _lib.clingo_symbolic_atoms_symbol, self._rep, self._it))
 
-class SymbolicAtoms(Lookup[Symbol,SymbolicAtom]):
+class SymbolicAtoms(Collection[SymbolicAtom]):
     '''
     This class provides read-only access to the atom base of the grounder.
     '''

--- a/libpyclingo/clingo/tests/test_ast.py
+++ b/libpyclingo/clingo/tests/test_ast.py
@@ -289,6 +289,16 @@ class TestAST(TestCase):
                            &e/0: t, { =, !=, + }, t, any
                          }."""))
 
+    def test_csp(self):
+        '''
+        Test CSP constructs.
+        '''
+        self._str("#false :- #disjoint { }.")
+        self._str("#false :- #disjoint { a:2$*$x; b:3$*$y }.")
+        self._str("#false :- #disjoint { a:2$*$x: p; b:3$*$y: q, r }.")
+        self._str("0 $<= 1$*$(x;y;z) $<= 3.")
+        self._str("1$*$x$+1$*$y$+-1$*$z $<= -2.")
+
     def test_compare(self):
         """
         Test comparison and hashing.

--- a/libpyclingo/clingo/tests/test_atoms.py
+++ b/libpyclingo/clingo/tests/test_atoms.py
@@ -3,7 +3,9 @@ Tests for theory and symbolic atoms.
 '''
 
 from unittest import TestCase
+from typing import cast
 from clingo import Control, Function, Number, TheoryTermType
+from clingo.symbolic_atoms import SymbolicAtom
 
 THEORY = '''
 #theory test {
@@ -30,7 +32,7 @@ class TestAtoms(TestCase):
 
         atoms = self.ctl.symbolic_atoms
 
-        p1 = atoms[Function('p', [Number(1)])]
+        p1 = cast(SymbolicAtom, atoms[Function('p', [Number(1)])])
         self.assertIsNotNone(p1)
         self.assertTrue(p1.is_fact)
         self.assertFalse(p1.is_external)
@@ -39,7 +41,7 @@ class TestAtoms(TestCase):
         self.assertTrue(p1.match('p', 1, True))
         self.assertFalse(p1.match('p', 2, True))
 
-        p2 = atoms[Function('p', [Number(2)])]
+        p2 = cast(SymbolicAtom, atoms[Function('p', [Number(2)])])
         self.assertIsNotNone(p2)
         self.assertFalse(p2.is_fact)
         self.assertFalse(p2.is_external)
@@ -48,7 +50,7 @@ class TestAtoms(TestCase):
         self.assertTrue(p2.match('p', 1, True))
         self.assertFalse(p2.match('p', 2, True))
 
-        p3 = atoms[Function('p', [Number(3)])]
+        p3 = cast(SymbolicAtom, atoms[Function('p', [Number(3)])])
         self.assertIsNotNone(p3)
         self.assertFalse(p3.is_fact)
         self.assertTrue(p3.is_external)

--- a/libpyclingo/clingo/tests/test_conf.py
+++ b/libpyclingo/clingo/tests/test_conf.py
@@ -3,6 +3,7 @@ Tests for configuration and statistics.
 '''
 
 from unittest import TestCase
+from typing import cast
 from clingo import Configuration, Control
 
 class TestConfig(TestCase):
@@ -17,10 +18,11 @@ class TestConfig(TestCase):
         self.assertIn('solver', ctl.configuration.keys)
         self.assertEqual(len(ctl.configuration.solver), 2)
         self.assertIsInstance(ctl.configuration.solver[0], Configuration)
-        self.assertIsInstance(ctl.configuration.solver[0].heuristic, str)
-        self.assertIsInstance(ctl.configuration.solver[0].description('heuristic'), str)
-        ctl.configuration.solver[0].heuristic = 'berkmin'
-        self.assertTrue(ctl.configuration.solver[0].heuristic.startswith('berkmin'))
+        conf = cast(Configuration, ctl.configuration.solver[0])
+        self.assertIsInstance(conf.heuristic, str)
+        self.assertIsInstance(conf.description('heuristic'), str)
+        conf.heuristic = 'berkmin'
+        self.assertTrue(conf.heuristic.startswith('berkmin'))
 
     def test_simple_stats(self):
         '''

--- a/libpyclingo/clingo/tests/test_control.py
+++ b/libpyclingo/clingo/tests/test_control.py
@@ -2,7 +2,8 @@
 Tests control.
 '''
 from unittest import TestCase
-from clingo import Control, Function, Number
+from typing import cast
+from clingo import Control, Function, Number, SolveResult
 
 class TestError(Exception):
     '''
@@ -57,6 +58,6 @@ class TestControl(TestCase):
         ctl.add('base', [], '1 { p(X); q(X) } 1 :- X=1..3. #minimize { 1,p,X: p(X); 1,q,X: q(X) }.')
         ctl.ground([('base', [])])
         lower = []
-        self.assertTrue(ctl.solve(on_unsat=lower.append).satisfiable)
+        self.assertTrue(cast(SolveResult, ctl.solve(on_unsat=lower.append)).satisfiable)
         self.assertEqual(lower, [[1], [2], [3]])
         self.assertEqual(ctl.statistics['summary']['lower'], [3.0])

--- a/libpyclingo/clingo/tests/test_solving.py
+++ b/libpyclingo/clingo/tests/test_solving.py
@@ -36,7 +36,7 @@ class TestSolving(TestCase):
         '''
         self.ctl.add('base', [], 'a.')
         self.ctl.ground([('base', [])])
-        with self.ctl.solve(yield_=True) as hnd:
+        with cast(SolveHandle, self.ctl.solve(yield_=True)) as hnd:
             for mdl in hnd:
                 self.assertEqual(str(mdl), "a")
                 self.assertRegex(repr(mdl), "Model(.*)")
@@ -80,7 +80,7 @@ class TestSolving(TestCase):
         '''
         self.ctl.add("base", [], "1 {a; b} 1. c.")
         self.ctl.ground([("base", [])])
-        with self.ctl.solve(on_model=self.mcb.on_model, yield_=True, async_=True) as hnd:
+        with cast(SolveHandle, self.ctl.solve(on_model=self.mcb.on_model, yield_=True, async_=True)) as hnd:
             while True:
                 hnd.resume()
                 _ = hnd.wait()
@@ -98,13 +98,13 @@ class TestSolving(TestCase):
         '''
         self.ctl.add("base", [], "1 { p(P,H): H=1..99 } 1 :- P=1..100.\n1 { p(P,H): P=1..100 } 1 :- H=1..99.")
         self.ctl.ground([("base", [])])
-        with self.ctl.solve(async_=True) as hnd:
+        with cast(SolveHandle, self.ctl.solve(async_=True)) as hnd:
             hnd.resume()
             hnd.cancel()
             ret = hnd.get()
             self.assertTrue(ret.interrupted)
 
-        with self.ctl.solve(async_=True) as hnd:
+        with cast(SolveHandle, self.ctl.solve(async_=True)) as hnd:
             hnd.resume()
             self.ctl.interrupt()
             ret = hnd.get()

--- a/libpyclingo/clingo/theory.py
+++ b/libpyclingo/clingo/theory.py
@@ -56,6 +56,7 @@ typedef bool (*PREFIX_ast_callback_t)(clingo_ast_t *ast, void *data);
 
 bool PREFIX_create(PREFIX_theory_t **theory)
 bool PREFIX_destroy(PREFIX_theory_t *theory)
+bool PREFIX_version(PREFIX_theory_t **theory, int *major, int *minor, int *patch);
 bool PREFIX_register(PREFIX_theory_t *theory, clingo_control_t* control)
 bool PREFIX_rewrite_ast(PREFIX_theory_t *theory, clingo_ast_t *ast, PREFIX_ast_callback_t add, void *data);
 bool PREFIX_prepare(PREFIX_theory_t *theory, clingo_control_t* control)
@@ -177,6 +178,19 @@ class Theory:
         if self._theory is not None:
             self.__call0('destroy', self._theory)
             self._theory = None
+
+    def version(self) -> Tuple[int, int, int]:
+        '''
+        This function returns the version of the theory.
+
+        Returns
+        -------
+        A 3-tuple of integers representing major and minor version as well as
+        the patch level.
+        '''
+        p_version = self._ffi.new('int[3]')
+        self.__call('version', p_version, p_version + 1, p_version + 2)
+        return p_version[0], p_version[1], p_version[2]
 
     def configure(self, key: str, value: str) -> None:
         '''

--- a/libpyclingo/clingo/theory.py
+++ b/libpyclingo/clingo/theory.py
@@ -301,7 +301,7 @@ class Theory:
         Get the integer index of a symbol assigned by the theory when a
         model is found.
 
-        Using indices allows for efficent retreival of values.
+        Using indices allows for efficent retrieval of values.
 
         Arguments
         ---------

--- a/libpyclingo/clingo/util.py
+++ b/libpyclingo/clingo/util.py
@@ -2,21 +2,10 @@
 Utility functions and classes.
 """
 
-from typing import Collection, Generic, MutableSequence, Sequence, Optional, TypeVar
-from abc import abstractmethod
+from typing import Optional, cast
 from collections import abc
 
 # pylint: disable=too-many-ancestors
-
-Key = TypeVar('Key')
-Value = TypeVar('Value')
-class Lookup(Generic[Key, Value], Collection[Value]):
-    '''
-    A collection of values with additional lookup by key.
-    '''
-    @abstractmethod
-    def __getitem__(self, key: Key) -> Optional[Value]:
-        pass
 
 class Slice:
     '''
@@ -41,7 +30,7 @@ class SlicedSequence(abc.Sequence):
     '''
     Helper to slice sequences.
     '''
-    def __init__(self, seq: Sequence, slc: Slice):
+    def __init__(self, seq: abc.Sequence, slc: Slice):
         self._seq = seq
         self._slc = slc
         self._len = -1
@@ -78,18 +67,22 @@ class SlicedMutableSequence(SlicedSequence, abc.MutableSequence):
     '''
     Helper to slice sequences.
     '''
-    def __init__(self, seq: MutableSequence, slc: Slice):
+    def __init__(self, seq: abc.MutableSequence, slc: Slice):
         super().__init__(seq, slc)
+
+    @property
+    def _mut_seq(self):
+        return cast(abc.MutableSequence, self._seq)
 
     def __setitem__(self, index, ast):
         if isinstance(index, slice):
             raise TypeError('slicing not implemented')
-        self._seq[self._rng[index]] = ast
+        self._mut_seq[self._rng[index]] = ast
 
     def __delitem__(self, index):
         if isinstance(index, slice):
             raise TypeError('slicing not implemented')
-        del self._seq[self._rng[index]]
+        del self._mut_seq[self._rng[index]]
 
     def insert(self, index, value):
-        self._seq[self._rng[index]] = value
+        self._mut_seq[self._rng[index]] = value

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ if not site.ENABLE_USER_SITE and "--user" in sys.argv[1:]:
 
 setup(
     version = '5.5.0',
-    name = 'clingo-cffi',
+    name = 'clingo',
     description = 'CFFI-based bindings to the clingo solver.',
     long_description = dedent('''\
         This package provides CFFI-based bindings to the clingo solver.


### PR DESCRIPTION
- remove `std::iterator`
- address clang-tidy warnings