### PR TITLE
left guard attempt

### DIFF
--- a/libgringo/src/input/nongroundgrammar.yy
+++ b/libgringo/src/input/nongroundgrammar.yy
@@ -315,6 +315,7 @@ void NonGroundGrammar::parser::error(DefaultLocation const &l, std::string const
     STRING     "<STRING>"
     VARIABLE   "<VARIABLE>"
     THEORY_OP  "<THEORYOP>"
+    THEORY_OPL "<THEORYOPL>"
     NOT        "not"
     DEFAULT    "default"
     OVERRIDE   "override"
@@ -951,6 +952,10 @@ theory_atom
     : AND theory_atom_name[name] { $$ = BUILDER.theoryatom($name, BUILDER.theoryelems()); }
     | AND theory_atom_name[name] enable_theory_lexing LBRACE theory_atom_element_list[elems] enable_theory_lexing RBRACE                                     disable_theory_lexing { $$ = BUILDER.theoryatom($name, $elems); }
     | AND theory_atom_name[name] enable_theory_lexing LBRACE theory_atom_element_list[elems] enable_theory_lexing RBRACE theory_op[op] theory_opterm[opterm] disable_theory_lexing { $$ = BUILDER.theoryatom($name, $elems, String::fromRep($op), @opterm, $opterm); }
+    | term[opterm] THEORY_OPL[op] enable_theory_lexing theory_atom_name[name] LBRACE theory_atom_element_list[elems] enable_theory_lexing RBRACE disable_theory_lexing {
+        auto theory_term_value = BUILDER.theorytermvalue(@opterm, Symbol::createId("fixed_string"));
+        auto theory_term_op = BUILDER.theoryopterm(BUILDER.theoryops(), theory_term_value);
+        $$ = BUILDER.theoryatom($name, $elems, String::fromRep($op), @opterm, theory_term_op); }
     ;
 
 // {{{2 theory definition

--- a/libgringo/src/input/nongroundlexer.xch
+++ b/libgringo/src/input/nongroundlexer.xch
@@ -51,6 +51,7 @@
     SIG        = WSNL ([-$])? WSNL IDENTIFIER WSNL "/" WSNL NUMBER WSNL ".";
     SCRIPT     = "#script";
     THEORYOP   = [/!<=>+\-*\\?&@|:;~\^\.]+;
+    THEORYOPL  = THEORYOP WSNL "&";
     SUP        = "#sup"("remum")?;
     INF        = "#inf"("imum")?;
     KEYWORD    = "#" [a-zA-Z0-9_]*;
@@ -153,6 +154,7 @@ int Gringo::Input::NonGroundParser::lex_impl(void *pValue, Location &loc) {
         <normal> "$!="                               { return NonGroundGrammar::parser::token::CSP_NEQ; }
         <normal> "$<>"                               { return NonGroundGrammar::parser::token::CSP_NEQ; }
         <theory> THEORYOP                            { value.str = String::toRep(string()); return NonGroundGrammar::parser::token::THEORY_OP; }
+        <normal> THEORYOPL                           { value.str = String::toRep(string()); return NonGroundGrammar::parser::token::THEORY_OPL; }
         <normal,theory,definition,script> "%*"       => blockcomment { bc++; continue; }
         <normal,theory,definition,script> "%"        :=> comment
         <normal,theory,definition,script> "#!"       :=> comment

--- a/libgringo/tests/left_guard.py
+++ b/libgringo/tests/left_guard.py
@@ -1,0 +1,39 @@
+from typing import Callable, Container, List, Optional, Sequence, cast
+from pprint import pprint
+from clingo.ast import AST, Transformer, parse_string
+
+class Extractor(Transformer):
+    '''
+    Simple visitor returning the first theory term in a program.
+    '''
+    # pylint: disable=invalid-name
+    atom: Optional[AST]
+
+    def __init__(self):
+        self.atom = None
+
+    def visit_TheoryAtom(self, x: AST):
+        '''
+        Extract theory atom.
+        '''
+        self.atom = x
+        return x
+
+def last_stm(s: str) -> AST:
+    """
+    Convert string to rule.
+    """
+    v = Extractor()
+    stm = None
+
+    def set_stm(x):
+        nonlocal stm
+        stm = x
+        v(stm)
+
+    parse_string(s, set_stm)
+
+    return cast(AST, stm)
+
+
+pprint(repr(last_stm('a := &sum{ p(X) }.')), indent=4)


### PR DESCRIPTION
Hi,

I have looking at the left guard problem. I managed to parse a grammar of the form

term theory_op & theory_atom_name { ... }

term is a term not a theory term, but theory_op it is a theory operator.

libgringo/tests/left_guard.py

contains a test using the python api.

I have a question. I can parse the input, but I don't know how to create the appropriated theory atom. Right now I always create the same guard independently of what I parse. The constructor for a theory atom takes as input a theory term, but I have a regular term.



I assume that I will need to convert the term into a theory term. Does it make sense?