### PR TITLE
Do not set context in global object.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -5,6 +5,7 @@
   * add function to change undo mode (#409)
   * add function to access priorities to API (#406)
   * fix AST bugs (#403)
+  * make sure `clingo_control_ground` is re-entrant (#418)
 
 ## clingo 5.6.2
 

--- a/libclingo/clingo/scripts.hh
+++ b/libclingo/clingo/scripts.hh
@@ -46,8 +46,6 @@ public:
     SymVec call(Location const &loc, String name, SymSpan args, Logger &log) override;
     void main(Control &ctl);
     void registerScript(String type, UScript script);
-    void setContext(Context &ctx) { context_ = &ctx; }
-    void resetContext() { context_ = nullptr; }
     void exec(String type, Location loc, String code) override;
     char const *version(String type);
 
@@ -55,6 +53,31 @@ public:
 private:
     Context *context_ = nullptr;
     UScriptVec scripts_;
+};
+
+class ChainContext : public Context {
+public:
+    ChainContext(Context &a, Scripts &b)
+    : a_{a}, b_{b} { }
+
+    bool callable(String name) override {
+        return a_.callable(name) || b_.callable(name);
+    }
+
+    SymVec call(Location const &loc, String name, SymSpan args, Logger &log) override {
+        if (a_.callable(name)) {
+            return a_.call(loc, name, args, log);
+        }
+        return b_.call(loc, name, args, log);
+    }
+
+    void exec(String type, Location loc, String code) override {
+        b_.exec(type, loc, code);
+    }
+
+private:
+    Context &a_;
+    Scripts &b_;
 };
 
 Scripts &g_scripts();

--- a/libclingo/clingo/scripts.hh
+++ b/libclingo/clingo/scripts.hh
@@ -42,6 +42,8 @@ using UScriptVec = std::vector<std::tuple<String, bool, UScript>>;
 class Scripts : public Context {
 public:
     Scripts() = default;
+    ~Scripts() override;
+
     bool callable(String name) override;
     SymVec call(Location const &loc, String name, SymSpan args, Logger &log) override;
     void main(Control &ctl);
@@ -49,7 +51,8 @@ public:
     void exec(String type, Location loc, String code) override;
     char const *version(String type);
 
-    ~Scripts() override;
+    template <class F>
+    void withContext(Context *ctx, F f);
 private:
     Context *context_ = nullptr;
     UScriptVec scripts_;
@@ -81,6 +84,17 @@ private:
 };
 
 Scripts &g_scripts();
+
+template <class F>
+inline void Scripts::withContext(Context *ctx, F f) {
+    if (ctx == nullptr) {
+        f(*this);
+    }
+    else {
+        ChainContext cctx{*ctx, *this};
+        f(cctx);
+    }
+}
 
 } // namespace Gringo
 

--- a/libclingo/clingo/scripts.hh
+++ b/libclingo/clingo/scripts.hh
@@ -54,7 +54,6 @@ public:
     template <class F>
     void withContext(Context *ctx, F f);
 private:
-    Context *context_ = nullptr;
     UScriptVec scripts_;
 };
 

--- a/libclingo/src/clingocontrol.cc
+++ b/libclingo/src/clingocontrol.cc
@@ -265,13 +265,7 @@ void ClingoControl::ground(Control::GroundVec const &parts, Context *context) {
             << gPrg << std::endl;
         LOG << "************* grounded program *************" << std::endl;
         gPrg.prepare(params, *out_, logger_);
-        if (context != nullptr) {
-            ChainContext cc{*context, scripts_};
-            gPrg.ground(cc, *out_, logger_);
-        }
-        else {
-            gPrg.ground(scripts_, *out_, logger_);
-        }
+        scripts_.withContext(context, [&, this](Context &ctx) { gPrg.ground(ctx, *out_, logger_); });
     }
 }
 

--- a/libclingo/src/clingocontrol.cc
+++ b/libclingo/src/clingocontrol.cc
@@ -256,17 +256,22 @@ void ClingoControl::ground(Control::GroundVec const &parts, Context *context) {
     if (!parts.empty()) {
         Ground::Parameters params;
         std::set<Sig> sigs;
-        for (auto &x : parts) {
+        for (auto const &x : parts) {
             params.add(x.first, SymVec(x.second));
             sigs.emplace(x.first, numeric_cast<uint32_t>(x.second.size()), false);
         }
         auto gPrg = prg_.toGround(sigs, out_->data, logger_);
-        LOG << "*********** intermediate program ***********" << std::endl << gPrg << std::endl;
+        LOG << "*********** intermediate program ***********" << std::endl
+            << gPrg << std::endl;
         LOG << "************* grounded program *************" << std::endl;
-        auto exit = onExit([this]{ scripts_.resetContext(); });
-        if (context) { scripts_.setContext(*context); }
         gPrg.prepare(params, *out_, logger_);
-        gPrg.ground(scripts_, *out_, logger_);
+        if (context != nullptr) {
+            ChainContext cc{*context, scripts_};
+            gPrg.ground(cc, *out_, logger_);
+        }
+        else {
+            gPrg.ground(scripts_, *out_, logger_);
+        }
     }
 }
 

--- a/libclingo/src/gringo_app.cc
+++ b/libclingo/src/gringo_app.cc
@@ -185,13 +185,7 @@ struct IncrementalControl : Control, private Output::ASPIFOutBackend {
             LOG << "************* intermediate program *************" << std::endl << gPrg << std::endl;
             LOG << "*************** grounded program ***************" << std::endl;
             gPrg.prepare(params, out, logger_);
-            if (context != nullptr) {
-                ChainContext cc{*context, scripts};
-                gPrg.ground(cc, out, logger_);
-            }
-            else {
-                gPrg.ground(scripts, out, logger_);
-            }
+            scripts.withContext(context, [&, this](Context &ctx) { gPrg.ground(ctx, out, logger_); });
         }
     }
     void add(std::string const &name, StringVec const &params, std::string const &part) override {

--- a/libclingo/src/gringo_app.cc
+++ b/libclingo/src/gringo_app.cc
@@ -164,8 +164,6 @@ struct IncrementalControl : Control, private Output::ASPIFOutBackend {
     void ground(Control::GroundVec const &parts, Context *context) override {
         update();
         // NOTE: it would be cool to have assumptions in the lparse output
-        auto exit = onExit([this]{ scripts.resetContext(); });
-        if (context) { scripts.setContext(*context); }
         if (parsed) {
             LOG << "************** parsed program **************" << std::endl << prg;
             prg.rewrite(defs, logger_);
@@ -187,7 +185,13 @@ struct IncrementalControl : Control, private Output::ASPIFOutBackend {
             LOG << "************* intermediate program *************" << std::endl << gPrg << std::endl;
             LOG << "*************** grounded program ***************" << std::endl;
             gPrg.prepare(params, out, logger_);
-            gPrg.ground(scripts, out, logger_);
+            if (context != nullptr) {
+                ChainContext cc{*context, scripts};
+                gPrg.ground(cc, out, logger_);
+            }
+            else {
+                gPrg.ground(scripts, out, logger_);
+            }
         }
     }
     void add(std::string const &name, StringVec const &params, std::string const &part) override {

--- a/libclingo/src/scripts.cc
+++ b/libclingo/src/scripts.cc
@@ -28,7 +28,6 @@
 namespace Gringo {
 
 bool Scripts::callable(String name) {
-    if (context_ && context_->callable(name)) { return true; }
     for (auto &&script : scripts_) {
         if (std::get<1>(script) && std::get<2>(script)->callable(name)) {
             return true;
@@ -47,7 +46,6 @@ void Scripts::main(Control &ctl) {
 }
 
 SymVec Scripts::call(Location const &loc, String name, SymSpan args, Logger &log) {
-    if (context_ && context_->callable(name)) { return context_->call(loc, name, args, log); }
     for (auto &&script : scripts_) {
         if (std::get<1>(script) && std::get<2>(script)->callable(name)) {
             return std::get<2>(script)->call(loc, name, args, log);


### PR DESCRIPTION
The context to call external functions in programs was set in a global object. When grounding in parallel, the context could get swapped out during grounding leading to undesired behavior and segfaults.