### PR TITLE
fix assignment aggregate handling

### DIFF
--- a/libgringo/gringo/input/aggregate.hh
+++ b/libgringo/gringo/input/aggregate.hh
@@ -120,7 +120,7 @@ void addVars(ChkLvlVec &levels, VarTermBoundVec &vars);
 // }}}
 // {{{ declaration of ToGroundArg
 
-using CreateLit     = std::function<void (Ground::ULitVec &, bool, bool)>;
+using CreateLit     = std::function<void (Ground::ULitVec &, bool)>;
 using CreateStm     = std::function<Ground::UStm (Ground::ULitVec &&)>;
 using CreateStmVec  = std::vector<CreateStm>;
 using CreateBody    = std::pair<CreateLit, CreateStmVec>;

--- a/libgringo/src/input/aggregates.cc
+++ b/libgringo/src/input/aggregates.cc
@@ -513,10 +513,8 @@ CreateBody TupleBodyAggregate::toGround(ToGroundArg &x, Ground::UStmVec &stms) c
                 return elem.toGround<Ground::BodyAggregateAccumulate>(x, completeRef, std::move(lits));
             });
         }
-        return {[&completeRef, this](Ground::ULitVec &lits, bool primary, bool auxiliary) {
-            if (primary) {
-                lits.emplace_back(gringo_make_unique<Ground::BodyAggregateLiteral>(completeRef, naf_, auxiliary));
-            }
+        return {[&completeRef, this](Ground::ULitVec &lits, bool auxiliary) {
+            lits.emplace_back(gringo_make_unique<Ground::BodyAggregateLiteral>(completeRef, naf_, auxiliary));
         }, std::move(split)};
     }
     assert(bounds_.size() == 1 && naf_ == NAF::POS);
@@ -548,10 +546,8 @@ CreateBody TupleBodyAggregate::toGround(ToGroundArg &x, Ground::UStmVec &stms) c
             return elem.toGround<Ground::AssignmentAggregateAccumulate>(x, completeRef, std::move(lits));
         });
     }
-    return {[&completeRef](Ground::ULitVec &lits, bool primary, bool auxiliary) {
-        if (primary) {
-            lits.emplace_back(gringo_make_unique<Ground::AssignmentAggregateLiteral>(completeRef, auxiliary));
-        }
+    return {[&completeRef](Ground::ULitVec &lits, bool auxiliary) {
+        lits.emplace_back(gringo_make_unique<Ground::AssignmentAggregateLiteral>(completeRef, auxiliary));
     }, std::move(split)};
 }
 
@@ -1011,10 +1007,8 @@ CreateBody ConjunctionElem::toGround(UTerm id, ToGroundArg &x, Ground::UStmVec &
         return std::move(ret);
     });
 
-    return {[&completeRef](Ground::ULitVec &lits, bool primary, bool auxiliary) {
-        if (primary) {
-            lits.emplace_back(gringo_make_unique<Ground::ConjunctionLiteral>(completeRef, auxiliary));
-        }
+    return {[&completeRef](Ground::ULitVec &lits, bool auxiliary) {
+        lits.emplace_back(gringo_make_unique<Ground::ConjunctionLiteral>(completeRef, auxiliary));
     }, std::move(split)};
 }
 
@@ -1244,7 +1238,7 @@ void SimpleBodyLiteral::replace(Defines &x) {
 
 CreateBody SimpleBodyLiteral::toGround(ToGroundArg &x, Ground::UStmVec &stms) const {
     static_cast<void>(stms);
-    return {[&](Ground::ULitVec &lits, bool /*unused*/, bool auxiliary) -> void {
+    return {[&](Ground::ULitVec &lits, bool auxiliary) -> void {
         lits.emplace_back(lit_->toGround(x.domains, auxiliary));
     }, CreateStmVec()};
 }

--- a/libgringo/src/input/statement.cc
+++ b/libgringo/src/input/statement.cc
@@ -321,13 +321,11 @@ void toGround(CreateHead &&head, UBodyAggrVec const &body, ToGroundArg &x, Groun
     }
     Ground::ULitVec lits;
     for (auto current = createVec.begin(), end = createVec.end(); current != end; ++current) {
-        current->first(lits, true, false);
+        current->first(lits, false);
         for (auto &z : current->second) {
             Ground::ULitVec splitLits;
-            for (auto it = createVec.begin(); it != end; ++it) {
-                if (it != current) {
-                    it->first(splitLits, it < current, true);
-                }
+            for (auto it = createVec.begin(); it < current; ++it) {
+                it->first(splitLits, true);
             }
             stms.emplace_back(z(std::move(splitLits)));
         }

--- a/libgringo/src/input/theory.cc
+++ b/libgringo/src/input/theory.cc
@@ -342,7 +342,7 @@ void TheoryAtom::rewriteArithmetics(Term::ArithmeticsMap &arith, AuxGen &auxGen)
 
 void TheoryAtom::initTheory(Location const &loc, TheoryDefs &defs, bool inBody, bool hasBody, Logger &log) {
     Sig sig = name_->getSig();
-    for (auto &def : defs) {
+    for (auto const &def : defs) {
         if (auto const *atomDef = def.getAtomDef(sig)) {
             type_ = atomDef->type();
             if (inBody) {
@@ -459,11 +459,9 @@ CreateBody TheoryAtom::toGroundBody(ToGroundArg &x, Ground::UStmVec &stms, NAF n
         });
     }
     bool aux1 = type_ != TheoryAtomType::Body;
-    return {[&completeRef, naf, aux1](Ground::ULitVec &lits, bool primary, bool aux2) {
-        if (primary) {
-            auto ret = gringo_make_unique<Ground::TheoryLiteral>(completeRef, naf, aux1 || aux2);
-            lits.emplace_back(std::move(ret));
-        }
+    return {[&completeRef, naf, aux1](Ground::ULitVec &lits, bool aux2) {
+        auto ret = gringo_make_unique<Ground::TheoryLiteral>(completeRef, naf, aux1 || aux2);
+        lits.emplace_back(std::move(ret));
     }, std::move(split)};
 }
 


### PR DESCRIPTION
The code now always uses the ordering of rule bodies. When grounding aggregate elements, only the literals preceeding the aggregate are used to ground them. This ensures that all variables are bound if assignment aggregates are used. Furthermore, it might make the intermediate rules to ground elements a bit shorter in some cases. However, it should not affect how typical rules with just one aggregate are grounded.