### PR TITLE
add option to preserve facts in symbol table

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -6,11 +6,13 @@
   * add function to change undo mode (#409)
   * add function to access priorities to API (#406)
   * add `Model::is_consequence` to API (#423)
+  * add option to preserve facts (#457)
   * improve hash table performance (#441)
   * fix `add_theory_atom_with_guard` in Python API
   * fix AST bugs (#403)
   * fix parsing of hexadecimal numbers (#421)
   * fix assignment aggregates (#436)
+  * fix build scripts for Python 3.12 (#452)
   * make sure `clingo_control_ground` is re-entrant (#418)
   * update clasp and dependencies
 

--- a/libclingo/clingo/clingocontrol.hh
+++ b/libclingo/clingo/clingocontrol.hh
@@ -84,7 +84,7 @@ private:
 // {{{1 declaration of ClingoOptions
 
 struct ClingoOptions {
-    using Foobar = std::vector<Sig>;
+    using SigVec = std::vector<Sig>;
     std::vector<std::string>      defines;
     Output::OutputOptions outputOptions;
     Output::OutputFormat  outputFormat          = Output::OutputFormat::INTERMEDIATE;
@@ -97,7 +97,7 @@ struct ClingoOptions {
     bool                          rewriteMinimize       = false;
     bool                          keepFacts             = false;
     bool                          singleShot            = false;
-    Foobar                        foobar;
+    SigVec                        sigvec;
 };
 
 inline void enableAll(ClingoOptions& out, bool enable) {
@@ -124,6 +124,14 @@ inline bool parseWarning(const std::string& str, ClingoOptions& out) {
     return false;
 }
 
+inline bool parsePreserveFacts(const std::string& str, ClingoOptions& out) {
+    if (str == "none")   { out.keepFacts = false; out.outputOptions.preserveFacts = false; return true; }
+    if (str == "body")   { out.keepFacts = true;  out.outputOptions.preserveFacts = false; return true; }
+    if (str == "symtab") { out.keepFacts = false; out.outputOptions.preserveFacts = true;  return true; }
+    if (str == "all")    { out.keepFacts = true;  out.outputOptions.preserveFacts = true;  return true; }
+    return false;
+}
+
 inline std::vector<std::string> split(std::string const &source, char const *delimiter = " ", bool keepEmpty = false) {
     std::vector<std::string> results;
     size_t prev = 0;
@@ -136,7 +144,7 @@ inline std::vector<std::string> split(std::string const &source, char const *del
     return results;
 }
 
-inline bool parseFoobar(const std::string& str, ClingoOptions::Foobar& foobar) {
+inline bool parseSigVec(const std::string& str, ClingoOptions::SigVec& sigvec) {
     for (auto &x : split(str, ",")) {
         auto y = split(x, "/");
         if (y.size() != 2) { return false; }
@@ -144,7 +152,7 @@ inline bool parseFoobar(const std::string& str, ClingoOptions::Foobar& foobar) {
         if (!Potassco::string_cast<unsigned>(y[1], a)) { return false; }
         bool sign = !y[0].empty() && y[0][0] == '-';
         if (sign) { y[0] = y[0].substr(1); }
-        foobar.emplace_back(y[0].c_str(), a, sign);
+        sigvec.emplace_back(y[0].c_str(), a, sign);
     }
     return true;
 }

--- a/libclingo/src/clingo_app.cc
+++ b/libclingo/src/clingo_app.cc
@@ -72,19 +72,26 @@ void ClingoApp::initOptions(Potassco::ProgramOptions::OptionContext& root) {
          "      translate: print translated rules as plain text (prefix %%%%)\n"
          "      all      : combines text and translate")
         ("warn,W,@1"                   , storeTo(grOpts_, parseWarning)->arg("<warn>")->composing(), "Enable/disable warnings:\n"
-         "      none:                     disable all warnings\n"
-         "      all:                      enable all warnings\n"
-         "      [no-]atom-undefined:      a :- b.\n"
-         "      [no-]file-included:       #include \"a.lp\". #include \"a.lp\".\n"
+         "      none                    : disable all warnings\n"
+         "      all                     : enable all warnings\n"
+         "      [no-]atom-undefined     : a :- b.\n"
+         "      [no-]file-included      : #include \"a.lp\". #include \"a.lp\".\n"
          "      [no-]operation-undefined: p(1/0).\n"
-         "      [no-]global-variable:     :- #count { X } = 1, X = 1.\n"
-         "      [no-]other:               clasp related and uncategorized warnings")
+         "      [no-]global-variable    : :- #count { X } = 1, X = 1.\n"
+         "      [no-]other              : clasp related and uncategorized warnings")
         ("rewrite-minimize,@1"      , flag(grOpts_.rewriteMinimize = false), "Rewrite minimize constraints into rules")
-        ("keep-facts,@1"            , flag(grOpts_.keepFacts = false), "Do not remove facts from normal rules")
+        // for backward compatibility
+        ("keep-facts,@3"            , flag(grOpts_.keepFacts = false), "Do not remove facts from normal rules")
+        ("preserve-facts,@1"        , storeTo(grOpts_, parsePreserveFacts),
+         "Preserve facts in output:\n"
+         "      none  : do not preserve\n"
+         "      body  : do not preserve\n"
+         "      symtab: do not preserve\n"
+         "      all   : preserve all facts")
         ("reify-sccs,@1"            , flag(grOpts_.outputOptions.reifySCCs = false), "Calculate SCCs for reified output")
         ("reify-steps,@1"           , flag(grOpts_.outputOptions.reifySteps = false), "Add step numbers to reified output")
+        ("show-preds,@1"            , storeTo(grOpts_.sigvec, parseSigVec), "Show the given signatures")
         ("single-shot,@2"           , flag(grOpts_.singleShot = false), "Force single-shot solving mode")
-        ("foobar,@4"                , storeTo(grOpts_.foobar, parseFoobar) , "Foobar")
         ;
     root.add(gringo);
 

--- a/libclingo/src/clingocontrol.cc
+++ b/libclingo/src/clingocontrol.cc
@@ -193,7 +193,7 @@ void ClingoControl::parse(const StringVec& files, const ClingoOptions& opts, Cla
     logger_.enable(Warnings::Other, !opts.wNoOther);
     verbose_ = opts.verbose;
     Output::OutputPredicates outPreds;
-    for (auto const &x : opts.foobar) {
+    for (auto const &x : opts.sigvec) {
         outPreds.add(Location("<cmd>",1,1,"<cmd>", 1,1), x, false);
     }
     if (claspOut != nullptr) {
@@ -913,26 +913,36 @@ void ClingoLib::initOptions(Potassco::ProgramOptions::OptionContext& root) {
     gringo.addOptions()
         ("verbose,V"                , flag(grOpts_.verbose = false), "Enable verbose output")
         ("const,c"                  , storeTo(grOpts_.defines, parseConst)->composing()->arg("<id>=<term>"), "Replace term occurrences of <id> with <term>")
-        ("output-debug", storeTo(grOpts_.outputOptions.debug = Output::OutputDebug::NONE, values<Output::OutputDebug>()
+        ("output-debug"             , storeTo(grOpts_.outputOptions.debug = Output::OutputDebug::NONE, values<Output::OutputDebug>()
           ("none", Output::OutputDebug::NONE)
           ("text", Output::OutputDebug::TEXT)
           ("translate", Output::OutputDebug::TRANSLATE)
-          ("all", Output::OutputDebug::ALL)), "Print debug information during output:\n"
+          ("all", Output::OutputDebug::ALL)),
+         "Print debug information during output:\n"
          "      none     : no additional info\n"
          "      text     : print rules as plain text (prefix %%)\n"
          "      translate: print translated rules as plain text (prefix %%%%)\n"
          "      all      : combines text and translate")
-        ("warn,W"                   , storeTo(grOpts_, parseWarning)->arg("<warn>")->composing(), "Enable/disable warnings:\n"
-         "      none:                     disable all warnings\n"
-         "      all:                      enable all warnings\n"
-         "      [no-]atom-undefined:      a :- b.\n"
-         "      [no-]file-included:       #include \"a.lp\". #include \"a.lp\".\n"
+        ("warn,W"                   , storeTo(grOpts_, parseWarning)->arg("<warn>")->composing(),
+         "Enable/disable warnings:\n"
+         "      none                    : disable all warnings\n"
+         "      all                     : enable all warnings\n"
+         "      [no-]atom-undefined     : a :- b.\n"
+         "      [no-]file-included      : #include \"a.lp\". #include \"a.lp\".\n"
          "      [no-]operation-undefined: p(1/0).\n"
-         "      [no-]global-variable:     :- #count { X } = 1, X = 1.\n"
-         "      [no-]other:               clasp related and uncategorized warnings")
+         "      [no-]global-variable    : :- #count { X } = 1, X = 1.\n"
+         "      [no-]other              : clasp related and uncategorized warnings")
         ("rewrite-minimize"         , flag(grOpts_.rewriteMinimize = false), "Rewrite minimize constraints into rules")
-        ("keep-facts"               , flag(grOpts_.keepFacts = false), "Do not remove facts from normal rules")
-        ("single-shot,@2"           , flag(grOpts_.singleShot = false), "Force single-shot solving mode")
+        // for backward compatibility
+        ("keep-facts"               , flag(grOpts_.keepFacts = false), "Preserve facts in rule bodies")
+        ("preserve-facts"           , storeTo(grOpts_, parsePreserveFacts),
+         "Preserve facts in output:\n"
+         "      none  : do not preserve\n"
+         "      body  : do not preserve\n"
+         "      symtab: do not preserve\n"
+         "      all   : preserve all facts")
+        ("single-shot"              , flag(grOpts_.singleShot = false), "Force single-shot solving mode")
+        ("show-preds"               , storeTo(grOpts_.sigvec, parseSigVec), "Show the given signatures")
         ;
     root.add(gringo);
     claspConfig_.addOptions(root);

--- a/libgringo/gringo/output/output.hh
+++ b/libgringo/gringo/output/output.hh
@@ -35,7 +35,7 @@ namespace Gringo { namespace Output {
 
 class TranslatorOutput : public AbstractOutput {
 public:
-    TranslatorOutput(UAbstractOutput out);
+    TranslatorOutput(UAbstractOutput out, bool preserveFacts);
     void output(DomainData &data, Statement &stm) override;
 private:
     Translator trans_;
@@ -60,9 +60,10 @@ private:
 };
 
 struct OutputOptions {
-    OutputDebug debug      = OutputDebug::NONE;
-    bool        reifySCCs  = false;
-    bool        reifySteps = false;
+    OutputDebug debug = OutputDebug::NONE;
+    bool reifySCCs  = false;
+    bool reifySteps = false;
+    bool preserveFacts = false;
 };
 
 class OutputPredicates {

--- a/libgringo/gringo/output/statements.hh
+++ b/libgringo/gringo/output/statements.hh
@@ -228,7 +228,7 @@ public:
     using ProjectionVec   = std::vector<std::pair<Potassco::Id_t, Potassco::Id_t>>;
     using TupleLitMap     = ordered_map<TupleId, LiteralId>;
 
-    Translator(UAbstractOutput out);
+    Translator(UAbstractOutput out, bool preserveFacts);
 
     void addMinimize(TupleId tuple, LiteralId cond);
     void atoms(DomainData &data, unsigned atomset, IsTrueLookup const &isTrue, SymVec &atoms, OutputPredicates const &outPreds);
@@ -282,6 +282,7 @@ private:
         static constexpr ClauseKey deleted = { 0xffffffff, 0x3fffffff, 1, 1, std::numeric_limits<uint64_t>::max() - 1 };
     };
     hash_set<ClauseKey, CallHash> clauses_;
+    bool preserveFacts_;
 };
 
 // {{{1 declaration of Minimize

--- a/libgringo/src/output/output.cc
+++ b/libgringo/src/output/output.cc
@@ -398,8 +398,8 @@ private:
 
 // {{{1 definition of TranslatorOutput
 
-TranslatorOutput::TranslatorOutput(UAbstractOutput out)
-: trans_(std::move(out)) { }
+TranslatorOutput::TranslatorOutput(UAbstractOutput out, bool preserveFacts)
+: trans_(std::move(out), preserveFacts) { }
 
 void TranslatorOutput::output(DomainData &data, Statement &stm) {
     stm.translate(data, trans_);
@@ -484,7 +484,7 @@ UAbstractOutput OutputBase::fromBackend(UBackend out, OutputOptions opts) {
     if (opts.debug == OutputDebug::TRANSLATE || opts.debug == OutputDebug::ALL) {
         output = gringo_make_unique<TextOutput>("%% ", std::cerr, std::move(output));
     }
-    output = gringo_make_unique<TranslatorOutput>(std::move(output));
+    output = gringo_make_unique<TranslatorOutput>(std::move(output), opts.preserveFacts);
     if (opts.debug == OutputDebug::TEXT || opts.debug == OutputDebug::ALL) {
         output = gringo_make_unique<TextOutput>("% ", std::cerr, std::move(output));
     }
@@ -641,6 +641,7 @@ void OutputBase::registerObserver(UBackend prg, bool replace) {
 void ASPIFOutBackend::initProgram(bool incremental) {
     static_cast<void>(incremental);
 }
+
 void ASPIFOutBackend::beginStep() {
     out_ = &beginOutput();
     bck_ = out_->backend();


### PR DESCRIPTION
This replaces option `--keep-facts` by option `--preserve-facts`, which accepts an argument to specify which facts to preserve in the output.
```
$ echo 'a. b:-a.' | clingo --text --preserve-facts=body 
a.
b:-a.

$ echo 'a. b.' | clingo --mode=gringo --preserve-facts=symtab | lpconvert --text
a.
b.
```

While at it, hidden option `--foobar` is now available as `--show-preds` to specify which predicates to show on the command line:
```
$ echo 'a. b. c.' | clingo -V0 --show-preds='a/0,b/0'
a b
SATISFIABLE
```