### PR TITLE
extend add_theory_atom method of backend

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@
   * add `Model::is_consequence` to API (#423)
   * add option to preserve facts (#457)
   * improve hash table performance (#441)
+  * extend add_theory_atom method of backend (#461)
+    (breaks backward compatibility of the Python API)
   * fix `add_theory_atom_with_guard` in Python API
   * fix AST bugs (#403)
   * fix parsing of hexadecimal numbers (#421)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -9,7 +9,7 @@
   * add option to preserve facts (#457)
   * improve hash table performance (#441)
   * extend add_theory_atom method of backend (#461)
-    (breaks backward compatibility of the Python API)
+    (breaks backward compatibility of the API)
   * fix `add_theory_atom_with_guard` in Python API
   * fix AST bugs (#403)
   * fix parsing of hexadecimal numbers (#421)

--- a/app/pyclingo/_clingo.c
+++ b/app/pyclingo/_clingo.c
@@ -579,14 +579,14 @@ static void *_cffi_types[] = {
 /*  3 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28), // size_t
 /*  4 */ _CFFI_OP(_CFFI_OP_POINTER, 12), // int32_t const *
 /*  5 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/*  6 */ _CFFI_OP(_CFFI_OP_POINTER, 1314), // void *
+/*  6 */ _CFFI_OP(_CFFI_OP_POINTER, 1316), // void *
 /*  7 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /*  8 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(_Bool, uint32_t const *, size_t, int32_t, clingo_weighted_literal_t const *, size_t, void *)
 /*  9 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
 /* 10 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
 /* 11 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
 /* 12 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21), // int32_t
-/* 13 */ _CFFI_OP(_CFFI_OP_POINTER, 1276), // clingo_weighted_literal_t const *
+/* 13 */ _CFFI_OP(_CFFI_OP_POINTER, 1278), // clingo_weighted_literal_t const *
 /* 14 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
 /* 15 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
 /* 16 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
@@ -599,8 +599,8 @@ static void *_cffi_types[] = {
 /* 23 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
 /* 24 */ _CFFI_OP(_CFFI_OP_POINTER, 252), // _Bool(*)(clingo_ast_t *, void *)
 /* 25 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 26 */ _CFFI_OP(_CFFI_OP_POINTER, 1260), // clingo_control_t *
-/* 27 */ _CFFI_OP(_CFFI_OP_POINTER, 1198), // void(*)(int, char const *, void *)
+/* 26 */ _CFFI_OP(_CFFI_OP_POINTER, 1262), // clingo_control_t *
+/* 27 */ _CFFI_OP(_CFFI_OP_POINTER, 1200), // void(*)(int, char const *, void *)
 /* 28 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
 /* 29 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8), // unsigned int
 /* 30 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
@@ -613,7 +613,7 @@ static void *_cffi_types[] = {
 /* 37 */ _CFFI_OP(_CFFI_OP_POINTER, 26), // clingo_control_t * *
 /* 38 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 39 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(char const *, _Bool *, void *)
-/* 40 */ _CFFI_OP(_CFFI_OP_POINTER, 1248), // char const *
+/* 40 */ _CFFI_OP(_CFFI_OP_POINTER, 1250), // char const *
 /* 41 */ _CFFI_OP(_CFFI_OP_POINTER, 1), // _Bool *
 /* 42 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
 /* 43 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
@@ -637,7 +637,7 @@ static void *_cffi_types[] = {
 /* 61 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 62 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(char const *, clingo_script_t const *, void *)
 /* 63 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 64 */ _CFFI_OP(_CFFI_OP_POINTER, 1270), // clingo_script_t const *
+/* 64 */ _CFFI_OP(_CFFI_OP_POINTER, 1272), // clingo_script_t const *
 /* 65 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
 /* 66 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 67 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(char const *, uint32_t, _Bool, uint64_t *)
@@ -669,7 +669,7 @@ static void *_cffi_types[] = {
 /* 93 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
 /* 94 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 95 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_assignment_t const *)
-/* 96 */ _CFFI_OP(_CFFI_OP_POINTER, 1250), // clingo_assignment_t const *
+/* 96 */ _CFFI_OP(_CFFI_OP_POINTER, 1252), // clingo_assignment_t const *
 /* 97 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 98 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_assignment_t const *, int32_t)
 /* 99 */ _CFFI_OP(_CFFI_OP_NOOP, 96),
@@ -710,8 +710,8 @@ static void *_cffi_types[] = {
 /* 134 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
 /* 135 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 136 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_ast_t *, char *, size_t)
-/* 137 */ _CFFI_OP(_CFFI_OP_POINTER, 1257), // clingo_ast_t *
-/* 138 */ _CFFI_OP(_CFFI_OP_POINTER, 1248), // char *
+/* 137 */ _CFFI_OP(_CFFI_OP_POINTER, 1259), // clingo_ast_t *
+/* 138 */ _CFFI_OP(_CFFI_OP_POINTER, 1250), // char *
 /* 139 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
 /* 140 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 141 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_ast_t *, clingo_ast_t * *)
@@ -760,12 +760,12 @@ static void *_cffi_types[] = {
 /* 184 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_ast_t *, int, clingo_location_t *)
 /* 185 */ _CFFI_OP(_CFFI_OP_NOOP, 137),
 /* 186 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 187 */ _CFFI_OP(_CFFI_OP_POINTER, 1262), // clingo_location_t *
+/* 187 */ _CFFI_OP(_CFFI_OP_POINTER, 1264), // clingo_location_t *
 /* 188 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 189 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_ast_t *, int, clingo_location_t const *)
 /* 190 */ _CFFI_OP(_CFFI_OP_NOOP, 137),
 /* 191 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 192 */ _CFFI_OP(_CFFI_OP_POINTER, 1262), // clingo_location_t const *
+/* 192 */ _CFFI_OP(_CFFI_OP_POINTER, 1264), // clingo_location_t const *
 /* 193 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 194 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_ast_t *, int, int *)
 /* 195 */ _CFFI_OP(_CFFI_OP_NOOP, 137),
@@ -830,11 +830,11 @@ static void *_cffi_types[] = {
 /* 254 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
 /* 255 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 256 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_ast_t const *, void *)
-/* 257 */ _CFFI_OP(_CFFI_OP_POINTER, 1257), // clingo_ast_t const *
+/* 257 */ _CFFI_OP(_CFFI_OP_POINTER, 1259), // clingo_ast_t const *
 /* 258 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
 /* 259 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 260 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_backend_t *)
-/* 261 */ _CFFI_OP(_CFFI_OP_POINTER, 1258), // clingo_backend_t *
+/* 261 */ _CFFI_OP(_CFFI_OP_POINTER, 1260), // clingo_backend_t *
 /* 262 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 263 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_backend_t *, _Bool, uint32_t const *, size_t, int32_t const *, size_t)
 /* 264 */ _CFFI_OP(_CFFI_OP_NOOP, 261),
@@ -922,972 +922,974 @@ static void *_cffi_types[] = {
 /* 346 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
 /* 347 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
 /* 348 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 349 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_backend_t *, uint32_t, uint32_t, uint32_t const *, size_t)
+/* 349 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_backend_t *, uint32_t, uint32_t, uint32_t const *, size_t, char const *, uint32_t, uint32_t *)
 /* 350 */ _CFFI_OP(_CFFI_OP_NOOP, 261),
 /* 351 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
 /* 352 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
 /* 353 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
 /* 354 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 355 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 356 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_backend_t *, uint32_t, uint32_t, uint32_t const *, size_t, char const *, uint32_t)
-/* 357 */ _CFFI_OP(_CFFI_OP_NOOP, 261),
-/* 358 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 359 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 360 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
-/* 361 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 362 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 363 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 364 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 365 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_backend_t *, uint64_t *, uint32_t *)
-/* 366 */ _CFFI_OP(_CFFI_OP_NOOP, 261),
-/* 367 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 368 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
-/* 369 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 370 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_backend_t *, uint64_t, uint32_t *)
-/* 371 */ _CFFI_OP(_CFFI_OP_NOOP, 261),
-/* 372 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 373 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
-/* 374 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 375 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t *, uint32_t, char const *)
-/* 376 */ _CFFI_OP(_CFFI_OP_POINTER, 1259), // clingo_configuration_t *
-/* 377 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 378 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 379 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 380 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t *)
-/* 381 */ _CFFI_OP(_CFFI_OP_POINTER, 1259), // clingo_configuration_t const *
-/* 382 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
-/* 383 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 384 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, _Bool *)
-/* 385 */ _CFFI_OP(_CFFI_OP_NOOP, 381),
-/* 386 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 387 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 388 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 389 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, char *, size_t)
-/* 390 */ _CFFI_OP(_CFFI_OP_NOOP, 381),
-/* 391 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 392 */ _CFFI_OP(_CFFI_OP_NOOP, 138),
-/* 393 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 394 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 395 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, char const * *)
-/* 396 */ _CFFI_OP(_CFFI_OP_NOOP, 381),
-/* 397 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 398 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
-/* 399 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 400 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, char const *, _Bool *)
-/* 401 */ _CFFI_OP(_CFFI_OP_NOOP, 381),
-/* 402 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 403 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 404 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 405 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 406 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, char const *, uint32_t *)
-/* 407 */ _CFFI_OP(_CFFI_OP_NOOP, 381),
-/* 408 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 409 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 410 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
-/* 411 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 412 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, size_t *)
-/* 413 */ _CFFI_OP(_CFFI_OP_NOOP, 381),
-/* 414 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 415 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 416 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 417 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, size_t, char const * *)
-/* 418 */ _CFFI_OP(_CFFI_OP_NOOP, 381),
-/* 419 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 420 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 421 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
-/* 422 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 423 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, size_t, uint32_t *)
-/* 424 */ _CFFI_OP(_CFFI_OP_NOOP, 381),
-/* 425 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 426 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 427 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
-/* 428 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 429 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, unsigned int *)
-/* 430 */ _CFFI_OP(_CFFI_OP_NOOP, 381),
-/* 431 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 432 */ _CFFI_OP(_CFFI_OP_POINTER, 29), // unsigned int *
-/* 433 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 434 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *)
-/* 435 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 436 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 437 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, _Bool)
-/* 438 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 439 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
-/* 440 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 441 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, char const * const *, size_t, void *)
-/* 442 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 443 */ _CFFI_OP(_CFFI_OP_NOOP, 22),
-/* 444 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 445 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 446 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 447 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, char const *)
-/* 448 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 449 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 450 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 451 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, char const *, char const * const *, size_t, char const *)
-/* 452 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 453 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 454 */ _CFFI_OP(_CFFI_OP_NOOP, 22),
-/* 455 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 456 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 457 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 458 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_backend_t * *)
-/* 459 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 460 */ _CFFI_OP(_CFFI_OP_POINTER, 261), // clingo_backend_t * *
-/* 461 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 462 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_configuration_t * *)
-/* 463 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 464 */ _CFFI_OP(_CFFI_OP_POINTER, 376), // clingo_configuration_t * *
-/* 465 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 466 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_ground_program_observer_t const *, _Bool, void *)
-/* 467 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 468 */ _CFFI_OP(_CFFI_OP_POINTER, 1261), // clingo_ground_program_observer_t const *
-/* 469 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
-/* 470 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 471 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 472 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_part_t const *, size_t, _Bool(*)(clingo_location_t const *, char const *, uint64_t const *, size_t, void *, _Bool(*)(uint64_t const *, size_t, void *), void *), void *)
-/* 473 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 474 */ _CFFI_OP(_CFFI_OP_POINTER, 1265), // clingo_part_t const *
-/* 475 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 476 */ _CFFI_OP(_CFFI_OP_POINTER, 563), // _Bool(*)(clingo_location_t const *, char const *, uint64_t const *, size_t, void *, _Bool(*)(uint64_t const *, size_t, void *), void *)
-/* 477 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 478 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 479 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_program_builder_t * *)
-/* 480 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 481 */ _CFFI_OP(_CFFI_OP_POINTER, 670), // clingo_program_builder_t * *
-/* 482 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 483 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_propagator_t const *, void *, _Bool)
-/* 484 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 485 */ _CFFI_OP(_CFFI_OP_POINTER, 1269), // clingo_propagator_t const *
-/* 486 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 487 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
-/* 488 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 489 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, int32_t)
-/* 490 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 491 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 492 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 493 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, int32_t, int)
-/* 494 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 495 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 496 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 497 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 498 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, unsigned int, int32_t const *, size_t, _Bool(*)(unsigned int, void *, void *, _Bool *), void *, clingo_solve_handle_t * *)
-/* 499 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 500 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8),
-/* 501 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
-/* 502 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 503 */ _CFFI_OP(_CFFI_OP_POINTER, 1082), // _Bool(*)(unsigned int, void *, void *, _Bool *)
-/* 504 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 505 */ _CFFI_OP(_CFFI_OP_POINTER, 776), // clingo_solve_handle_t * *
-/* 506 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 507 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, void * *)
-/* 508 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 509 */ _CFFI_OP(_CFFI_OP_POINTER, 6), // void * *
-/* 510 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 511 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, void *)
-/* 512 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 513 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 514 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 515 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *)
-/* 516 */ _CFFI_OP(_CFFI_OP_POINTER, 1260), // clingo_control_t const *
-/* 517 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 518 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *, char const *, _Bool *)
-/* 519 */ _CFFI_OP(_CFFI_OP_NOOP, 516),
-/* 520 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 521 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 522 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 523 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *, char const *, uint64_t *)
-/* 524 */ _CFFI_OP(_CFFI_OP_NOOP, 516),
-/* 525 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 526 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 527 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 528 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *, clingo_statistics_t const * *)
-/* 529 */ _CFFI_OP(_CFFI_OP_NOOP, 516),
-/* 530 */ _CFFI_OP(_CFFI_OP_POINTER, 810), // clingo_statistics_t const * *
-/* 531 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 532 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *, clingo_symbolic_atoms_t const * *)
-/* 533 */ _CFFI_OP(_CFFI_OP_NOOP, 516),
-/* 534 */ _CFFI_OP(_CFFI_OP_POINTER, 853), // clingo_symbolic_atoms_t const * *
-/* 535 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 536 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *, clingo_theory_atoms_t const * *)
-/* 537 */ _CFFI_OP(_CFFI_OP_NOOP, 516),
-/* 538 */ _CFFI_OP(_CFFI_OP_POINTER, 892), // clingo_theory_atoms_t const * *
-/* 539 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 540 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_location_t *, char const *, void *)
-/* 541 */ _CFFI_OP(_CFFI_OP_NOOP, 187),
-/* 542 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 543 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 544 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 545 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_location_t *, char const *, void *, size_t, void *, void *, void *)
-/* 546 */ _CFFI_OP(_CFFI_OP_NOOP, 187),
-/* 547 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 548 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 549 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 355 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 356 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 357 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
+/* 358 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 359 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_backend_t *, uint32_t, uint32_t, uint32_t const *, size_t, uint32_t *)
+/* 360 */ _CFFI_OP(_CFFI_OP_NOOP, 261),
+/* 361 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 362 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 363 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
+/* 364 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 365 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
+/* 366 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 367 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_backend_t *, uint64_t *, uint32_t *)
+/* 368 */ _CFFI_OP(_CFFI_OP_NOOP, 261),
+/* 369 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 370 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
+/* 371 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 372 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_backend_t *, uint64_t, uint32_t *)
+/* 373 */ _CFFI_OP(_CFFI_OP_NOOP, 261),
+/* 374 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 375 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
+/* 376 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 377 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t *, uint32_t, char const *)
+/* 378 */ _CFFI_OP(_CFFI_OP_POINTER, 1261), // clingo_configuration_t *
+/* 379 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 380 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 381 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 382 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t *)
+/* 383 */ _CFFI_OP(_CFFI_OP_POINTER, 1261), // clingo_configuration_t const *
+/* 384 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
+/* 385 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 386 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, _Bool *)
+/* 387 */ _CFFI_OP(_CFFI_OP_NOOP, 383),
+/* 388 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 389 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 390 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 391 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, char *, size_t)
+/* 392 */ _CFFI_OP(_CFFI_OP_NOOP, 383),
+/* 393 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 394 */ _CFFI_OP(_CFFI_OP_NOOP, 138),
+/* 395 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 396 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 397 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, char const * *)
+/* 398 */ _CFFI_OP(_CFFI_OP_NOOP, 383),
+/* 399 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 400 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
+/* 401 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 402 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, char const *, _Bool *)
+/* 403 */ _CFFI_OP(_CFFI_OP_NOOP, 383),
+/* 404 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 405 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 406 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 407 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 408 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, char const *, uint32_t *)
+/* 409 */ _CFFI_OP(_CFFI_OP_NOOP, 383),
+/* 410 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 411 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 412 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
+/* 413 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 414 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, size_t *)
+/* 415 */ _CFFI_OP(_CFFI_OP_NOOP, 383),
+/* 416 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 417 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 418 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 419 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, size_t, char const * *)
+/* 420 */ _CFFI_OP(_CFFI_OP_NOOP, 383),
+/* 421 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 422 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 423 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
+/* 424 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 425 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, size_t, uint32_t *)
+/* 426 */ _CFFI_OP(_CFFI_OP_NOOP, 383),
+/* 427 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 428 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 429 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
+/* 430 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 431 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, unsigned int *)
+/* 432 */ _CFFI_OP(_CFFI_OP_NOOP, 383),
+/* 433 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 434 */ _CFFI_OP(_CFFI_OP_POINTER, 29), // unsigned int *
+/* 435 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 436 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *)
+/* 437 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 438 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 439 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, _Bool)
+/* 440 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 441 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
+/* 442 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 443 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, char const * const *, size_t, void *)
+/* 444 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 445 */ _CFFI_OP(_CFFI_OP_NOOP, 22),
+/* 446 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 447 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 448 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 449 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, char const *)
+/* 450 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 451 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 452 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 453 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, char const *, char const * const *, size_t, char const *)
+/* 454 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 455 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 456 */ _CFFI_OP(_CFFI_OP_NOOP, 22),
+/* 457 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 458 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 459 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 460 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_backend_t * *)
+/* 461 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 462 */ _CFFI_OP(_CFFI_OP_POINTER, 261), // clingo_backend_t * *
+/* 463 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 464 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_configuration_t * *)
+/* 465 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 466 */ _CFFI_OP(_CFFI_OP_POINTER, 378), // clingo_configuration_t * *
+/* 467 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 468 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_ground_program_observer_t const *, _Bool, void *)
+/* 469 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 470 */ _CFFI_OP(_CFFI_OP_POINTER, 1263), // clingo_ground_program_observer_t const *
+/* 471 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
+/* 472 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 473 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 474 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_part_t const *, size_t, _Bool(*)(clingo_location_t const *, char const *, uint64_t const *, size_t, void *, _Bool(*)(uint64_t const *, size_t, void *), void *), void *)
+/* 475 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 476 */ _CFFI_OP(_CFFI_OP_POINTER, 1267), // clingo_part_t const *
+/* 477 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 478 */ _CFFI_OP(_CFFI_OP_POINTER, 565), // _Bool(*)(clingo_location_t const *, char const *, uint64_t const *, size_t, void *, _Bool(*)(uint64_t const *, size_t, void *), void *)
+/* 479 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 480 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 481 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_program_builder_t * *)
+/* 482 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 483 */ _CFFI_OP(_CFFI_OP_POINTER, 672), // clingo_program_builder_t * *
+/* 484 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 485 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_propagator_t const *, void *, _Bool)
+/* 486 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 487 */ _CFFI_OP(_CFFI_OP_POINTER, 1271), // clingo_propagator_t const *
+/* 488 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 489 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
+/* 490 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 491 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, int32_t)
+/* 492 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 493 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 494 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 495 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, int32_t, int)
+/* 496 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 497 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 498 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 499 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 500 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, unsigned int, int32_t const *, size_t, _Bool(*)(unsigned int, void *, void *, _Bool *), void *, clingo_solve_handle_t * *)
+/* 501 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 502 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8),
+/* 503 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 504 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 505 */ _CFFI_OP(_CFFI_OP_POINTER, 1084), // _Bool(*)(unsigned int, void *, void *, _Bool *)
+/* 506 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 507 */ _CFFI_OP(_CFFI_OP_POINTER, 778), // clingo_solve_handle_t * *
+/* 508 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 509 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, void * *)
+/* 510 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 511 */ _CFFI_OP(_CFFI_OP_POINTER, 6), // void * *
+/* 512 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 513 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, void *)
+/* 514 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 515 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 516 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 517 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *)
+/* 518 */ _CFFI_OP(_CFFI_OP_POINTER, 1262), // clingo_control_t const *
+/* 519 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 520 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *, char const *, _Bool *)
+/* 521 */ _CFFI_OP(_CFFI_OP_NOOP, 518),
+/* 522 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 523 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 524 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 525 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *, char const *, uint64_t *)
+/* 526 */ _CFFI_OP(_CFFI_OP_NOOP, 518),
+/* 527 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 528 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 529 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 530 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *, clingo_statistics_t const * *)
+/* 531 */ _CFFI_OP(_CFFI_OP_NOOP, 518),
+/* 532 */ _CFFI_OP(_CFFI_OP_POINTER, 812), // clingo_statistics_t const * *
+/* 533 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 534 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *, clingo_symbolic_atoms_t const * *)
+/* 535 */ _CFFI_OP(_CFFI_OP_NOOP, 518),
+/* 536 */ _CFFI_OP(_CFFI_OP_POINTER, 855), // clingo_symbolic_atoms_t const * *
+/* 537 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 538 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *, clingo_theory_atoms_t const * *)
+/* 539 */ _CFFI_OP(_CFFI_OP_NOOP, 518),
+/* 540 */ _CFFI_OP(_CFFI_OP_POINTER, 894), // clingo_theory_atoms_t const * *
+/* 541 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 542 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_location_t *, char const *, void *)
+/* 543 */ _CFFI_OP(_CFFI_OP_NOOP, 187),
+/* 544 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 545 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 546 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 547 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_location_t *, char const *, void *, size_t, void *, void *, void *)
+/* 548 */ _CFFI_OP(_CFFI_OP_NOOP, 187),
+/* 549 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
 /* 550 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 551 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 551 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
 /* 552 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 553 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 554 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_location_t const *, char const *, uint64_t const *, size_t, _Bool(*)(uint64_t const *, size_t, void *), void *, void *)
-/* 555 */ _CFFI_OP(_CFFI_OP_NOOP, 192),
-/* 556 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 557 */ _CFFI_OP(_CFFI_OP_NOOP, 79),
-/* 558 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 559 */ _CFFI_OP(_CFFI_OP_POINTER, 1033), // _Bool(*)(uint64_t const *, size_t, void *)
-/* 560 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 561 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 562 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 563 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_location_t const *, char const *, uint64_t const *, size_t, void *, _Bool(*)(uint64_t const *, size_t, void *), void *)
-/* 564 */ _CFFI_OP(_CFFI_OP_NOOP, 192),
-/* 565 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 566 */ _CFFI_OP(_CFFI_OP_NOOP, 79),
-/* 567 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 568 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 569 */ _CFFI_OP(_CFFI_OP_NOOP, 559),
+/* 553 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 554 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 555 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 556 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_location_t const *, char const *, uint64_t const *, size_t, _Bool(*)(uint64_t const *, size_t, void *), void *, void *)
+/* 557 */ _CFFI_OP(_CFFI_OP_NOOP, 192),
+/* 558 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 559 */ _CFFI_OP(_CFFI_OP_NOOP, 79),
+/* 560 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 561 */ _CFFI_OP(_CFFI_OP_POINTER, 1035), // _Bool(*)(uint64_t const *, size_t, void *)
+/* 562 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 563 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 564 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 565 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_location_t const *, char const *, uint64_t const *, size_t, void *, _Bool(*)(uint64_t const *, size_t, void *), void *)
+/* 566 */ _CFFI_OP(_CFFI_OP_NOOP, 192),
+/* 567 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 568 */ _CFFI_OP(_CFFI_OP_NOOP, 79),
+/* 569 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
 /* 570 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 571 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 572 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_location_t const *, char const *, void *)
-/* 573 */ _CFFI_OP(_CFFI_OP_NOOP, 192),
-/* 574 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 575 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 576 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 577 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t *, uint64_t const *, size_t)
-/* 578 */ _CFFI_OP(_CFFI_OP_POINTER, 1263), // clingo_model_t *
-/* 579 */ _CFFI_OP(_CFFI_OP_NOOP, 79),
-/* 580 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 581 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 582 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, _Bool *)
-/* 583 */ _CFFI_OP(_CFFI_OP_POINTER, 1263), // clingo_model_t const *
-/* 584 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 585 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 586 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, _Bool(*)(void *), void *, void *)
-/* 587 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 588 */ _CFFI_OP(_CFFI_OP_POINTER, 1088), // _Bool(*)(void *)
-/* 589 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 590 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 591 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 592 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, clingo_solve_control_t * *)
-/* 593 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 594 */ _CFFI_OP(_CFFI_OP_POINTER, 767), // clingo_solve_control_t * *
-/* 595 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 596 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, int *)
-/* 597 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 598 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
-/* 599 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 600 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, int32_t *, size_t)
-/* 601 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 602 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
-/* 603 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 604 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 605 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, int32_t, _Bool *)
-/* 606 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 607 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 608 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 609 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 610 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, int32_t, int *)
-/* 611 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 612 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 613 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
-/* 614 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 615 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, int64_t *, size_t)
-/* 616 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 617 */ _CFFI_OP(_CFFI_OP_POINTER, 1310), // int64_t *
-/* 618 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 619 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 620 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, size_t *)
-/* 621 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 622 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 623 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 624 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, uint32_t *)
-/* 625 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 626 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
-/* 627 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 628 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, uint64_t *)
-/* 629 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 630 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 631 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 632 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, uint64_t, _Bool *)
-/* 633 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 634 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 635 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 636 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 637 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, unsigned int, size_t *)
-/* 638 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 639 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8),
-/* 640 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 641 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 642 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, unsigned int, uint64_t *, size_t)
-/* 643 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 644 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8),
-/* 645 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 646 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 647 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 648 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_options_t *, char const *, char const *, char const *, _Bool *)
-/* 649 */ _CFFI_OP(_CFFI_OP_POINTER, 1264), // clingo_options_t *
-/* 650 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 651 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 571 */ _CFFI_OP(_CFFI_OP_NOOP, 561),
+/* 572 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 573 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 574 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_location_t const *, char const *, void *)
+/* 575 */ _CFFI_OP(_CFFI_OP_NOOP, 192),
+/* 576 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 577 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 578 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 579 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t *, uint64_t const *, size_t)
+/* 580 */ _CFFI_OP(_CFFI_OP_POINTER, 1265), // clingo_model_t *
+/* 581 */ _CFFI_OP(_CFFI_OP_NOOP, 79),
+/* 582 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 583 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 584 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, _Bool *)
+/* 585 */ _CFFI_OP(_CFFI_OP_POINTER, 1265), // clingo_model_t const *
+/* 586 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 587 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 588 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, _Bool(*)(void *), void *, void *)
+/* 589 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 590 */ _CFFI_OP(_CFFI_OP_POINTER, 1090), // _Bool(*)(void *)
+/* 591 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 592 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 593 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 594 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, clingo_solve_control_t * *)
+/* 595 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 596 */ _CFFI_OP(_CFFI_OP_POINTER, 769), // clingo_solve_control_t * *
+/* 597 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 598 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, int *)
+/* 599 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 600 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
+/* 601 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 602 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, int32_t *, size_t)
+/* 603 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 604 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
+/* 605 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 606 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 607 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, int32_t, _Bool *)
+/* 608 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 609 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 610 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 611 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 612 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, int32_t, int *)
+/* 613 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 614 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 615 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
+/* 616 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 617 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, int64_t *, size_t)
+/* 618 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 619 */ _CFFI_OP(_CFFI_OP_POINTER, 1312), // int64_t *
+/* 620 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 621 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 622 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, size_t *)
+/* 623 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 624 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 625 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 626 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, uint32_t *)
+/* 627 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 628 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
+/* 629 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 630 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, uint64_t *)
+/* 631 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 632 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 633 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 634 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, uint64_t, _Bool *)
+/* 635 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 636 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 637 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 638 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 639 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, unsigned int, size_t *)
+/* 640 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 641 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8),
+/* 642 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 643 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 644 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, unsigned int, uint64_t *, size_t)
+/* 645 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 646 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8),
+/* 647 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 648 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 649 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 650 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_options_t *, char const *, char const *, char const *, _Bool *)
+/* 651 */ _CFFI_OP(_CFFI_OP_POINTER, 1266), // clingo_options_t *
 /* 652 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 653 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 654 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 655 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_options_t *, char const *, char const *, char const *, _Bool(*)(char const *, void *), void *, _Bool, char const *)
-/* 656 */ _CFFI_OP(_CFFI_OP_NOOP, 649),
-/* 657 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 658 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 653 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 654 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 655 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 656 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 657 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_options_t *, char const *, char const *, char const *, _Bool(*)(char const *, void *), void *, _Bool, char const *)
+/* 658 */ _CFFI_OP(_CFFI_OP_NOOP, 651),
 /* 659 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 660 */ _CFFI_OP(_CFFI_OP_POINTER, 84), // _Bool(*)(char const *, void *)
-/* 661 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 662 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
-/* 663 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 664 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 665 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_options_t *, void *)
-/* 666 */ _CFFI_OP(_CFFI_OP_NOOP, 649),
-/* 667 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 668 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 669 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_program_builder_t *)
-/* 670 */ _CFFI_OP(_CFFI_OP_POINTER, 1266), // clingo_program_builder_t *
-/* 671 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 672 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_program_builder_t *, clingo_ast_t *)
-/* 673 */ _CFFI_OP(_CFFI_OP_NOOP, 670),
-/* 674 */ _CFFI_OP(_CFFI_OP_NOOP, 137),
-/* 675 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 676 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, _Bool *)
-/* 677 */ _CFFI_OP(_CFFI_OP_POINTER, 1267), // clingo_propagate_control_t *
-/* 678 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 679 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 680 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, int32_t *)
-/* 681 */ _CFFI_OP(_CFFI_OP_NOOP, 677),
-/* 682 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
-/* 683 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 684 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, int32_t const *, size_t, int, _Bool *)
-/* 685 */ _CFFI_OP(_CFFI_OP_NOOP, 677),
-/* 686 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
-/* 687 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 688 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 689 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 690 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 691 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, int32_t const *, size_t, void *)
-/* 692 */ _CFFI_OP(_CFFI_OP_NOOP, 677),
-/* 693 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
-/* 694 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 695 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 696 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 697 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, int32_t)
-/* 698 */ _CFFI_OP(_CFFI_OP_NOOP, 677),
-/* 699 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 700 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 701 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, void *)
-/* 702 */ _CFFI_OP(_CFFI_OP_NOOP, 677),
-/* 703 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 704 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 705 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t const *, int32_t)
-/* 706 */ _CFFI_OP(_CFFI_OP_POINTER, 1267), // clingo_propagate_control_t const *
-/* 707 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 708 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 709 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, _Bool *)
-/* 710 */ _CFFI_OP(_CFFI_OP_POINTER, 1268), // clingo_propagate_init_t *
-/* 711 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 712 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 713 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, _Bool, int32_t *)
-/* 714 */ _CFFI_OP(_CFFI_OP_NOOP, 710),
-/* 715 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
-/* 716 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
-/* 717 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 718 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, int32_t const *, size_t, _Bool *)
-/* 719 */ _CFFI_OP(_CFFI_OP_NOOP, 710),
-/* 720 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
-/* 721 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 722 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 723 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 724 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, int32_t)
-/* 725 */ _CFFI_OP(_CFFI_OP_NOOP, 710),
-/* 726 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 727 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 728 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, int32_t, clingo_weighted_literal_t const *, size_t, int32_t, int, _Bool, _Bool *)
-/* 729 */ _CFFI_OP(_CFFI_OP_NOOP, 710),
-/* 730 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 731 */ _CFFI_OP(_CFFI_OP_NOOP, 13),
-/* 732 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 733 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 734 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 735 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
-/* 736 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 737 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 738 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, int32_t, int32_t, int32_t)
-/* 739 */ _CFFI_OP(_CFFI_OP_NOOP, 710),
-/* 740 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 741 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 660 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 661 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 662 */ _CFFI_OP(_CFFI_OP_POINTER, 84), // _Bool(*)(char const *, void *)
+/* 663 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 664 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
+/* 665 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 666 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 667 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_options_t *, void *)
+/* 668 */ _CFFI_OP(_CFFI_OP_NOOP, 651),
+/* 669 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 670 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 671 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_program_builder_t *)
+/* 672 */ _CFFI_OP(_CFFI_OP_POINTER, 1268), // clingo_program_builder_t *
+/* 673 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 674 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_program_builder_t *, clingo_ast_t *)
+/* 675 */ _CFFI_OP(_CFFI_OP_NOOP, 672),
+/* 676 */ _CFFI_OP(_CFFI_OP_NOOP, 137),
+/* 677 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 678 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, _Bool *)
+/* 679 */ _CFFI_OP(_CFFI_OP_POINTER, 1269), // clingo_propagate_control_t *
+/* 680 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 681 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 682 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, int32_t *)
+/* 683 */ _CFFI_OP(_CFFI_OP_NOOP, 679),
+/* 684 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
+/* 685 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 686 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, int32_t const *, size_t, int, _Bool *)
+/* 687 */ _CFFI_OP(_CFFI_OP_NOOP, 679),
+/* 688 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 689 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 690 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 691 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 692 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 693 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, int32_t const *, size_t, void *)
+/* 694 */ _CFFI_OP(_CFFI_OP_NOOP, 679),
+/* 695 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 696 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 697 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 698 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 699 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, int32_t)
+/* 700 */ _CFFI_OP(_CFFI_OP_NOOP, 679),
+/* 701 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 702 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 703 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, void *)
+/* 704 */ _CFFI_OP(_CFFI_OP_NOOP, 679),
+/* 705 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 706 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 707 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t const *, int32_t)
+/* 708 */ _CFFI_OP(_CFFI_OP_POINTER, 1269), // clingo_propagate_control_t const *
+/* 709 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 710 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 711 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, _Bool *)
+/* 712 */ _CFFI_OP(_CFFI_OP_POINTER, 1270), // clingo_propagate_init_t *
+/* 713 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 714 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 715 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, _Bool, int32_t *)
+/* 716 */ _CFFI_OP(_CFFI_OP_NOOP, 712),
+/* 717 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
+/* 718 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
+/* 719 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 720 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, int32_t const *, size_t, _Bool *)
+/* 721 */ _CFFI_OP(_CFFI_OP_NOOP, 712),
+/* 722 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 723 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 724 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 725 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 726 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, int32_t)
+/* 727 */ _CFFI_OP(_CFFI_OP_NOOP, 712),
+/* 728 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 729 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 730 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, int32_t, clingo_weighted_literal_t const *, size_t, int32_t, int, _Bool, _Bool *)
+/* 731 */ _CFFI_OP(_CFFI_OP_NOOP, 712),
+/* 732 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 733 */ _CFFI_OP(_CFFI_OP_NOOP, 13),
+/* 734 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 735 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 736 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 737 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
+/* 738 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 739 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 740 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, int32_t, int32_t, int32_t)
+/* 741 */ _CFFI_OP(_CFFI_OP_NOOP, 712),
 /* 742 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 743 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 744 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, int32_t, uint32_t)
-/* 745 */ _CFFI_OP(_CFFI_OP_NOOP, 710),
-/* 746 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 747 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 748 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 749 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, void *)
-/* 750 */ _CFFI_OP(_CFFI_OP_NOOP, 710),
-/* 751 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 752 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 753 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t const *, clingo_symbolic_atoms_t const * *)
-/* 754 */ _CFFI_OP(_CFFI_OP_POINTER, 1268), // clingo_propagate_init_t const *
-/* 755 */ _CFFI_OP(_CFFI_OP_NOOP, 534),
-/* 756 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 757 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t const *, clingo_theory_atoms_t const * *)
-/* 758 */ _CFFI_OP(_CFFI_OP_NOOP, 754),
-/* 759 */ _CFFI_OP(_CFFI_OP_NOOP, 538),
-/* 760 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 761 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t const *, int32_t, int32_t *)
-/* 762 */ _CFFI_OP(_CFFI_OP_NOOP, 754),
-/* 763 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 764 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
-/* 765 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 766 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_control_t *, int32_t const *, size_t)
-/* 767 */ _CFFI_OP(_CFFI_OP_POINTER, 1271), // clingo_solve_control_t *
-/* 768 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
-/* 769 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 770 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 771 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_control_t const *, clingo_symbolic_atoms_t const * *)
-/* 772 */ _CFFI_OP(_CFFI_OP_POINTER, 1271), // clingo_solve_control_t const *
-/* 773 */ _CFFI_OP(_CFFI_OP_NOOP, 534),
-/* 774 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 775 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_handle_t *)
-/* 776 */ _CFFI_OP(_CFFI_OP_POINTER, 1272), // clingo_solve_handle_t *
-/* 777 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 778 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_handle_t *, clingo_model_t const * *)
-/* 779 */ _CFFI_OP(_CFFI_OP_NOOP, 776),
-/* 780 */ _CFFI_OP(_CFFI_OP_POINTER, 583), // clingo_model_t const * *
-/* 781 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 782 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_handle_t *, int32_t const * *, size_t *)
-/* 783 */ _CFFI_OP(_CFFI_OP_NOOP, 776),
-/* 784 */ _CFFI_OP(_CFFI_OP_POINTER, 4), // int32_t const * *
-/* 785 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 786 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 787 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_handle_t *, unsigned int *)
-/* 788 */ _CFFI_OP(_CFFI_OP_NOOP, 776),
-/* 789 */ _CFFI_OP(_CFFI_OP_NOOP, 432),
-/* 790 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 791 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t *, uint64_t, char const *, int, uint64_t *)
-/* 792 */ _CFFI_OP(_CFFI_OP_POINTER, 1273), // clingo_statistics_t *
-/* 793 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 794 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 795 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 796 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 797 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 798 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t *, uint64_t, double)
-/* 799 */ _CFFI_OP(_CFFI_OP_NOOP, 792),
-/* 800 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 801 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 14), // double
-/* 802 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 803 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t *, uint64_t, int, uint64_t *)
-/* 804 */ _CFFI_OP(_CFFI_OP_NOOP, 792),
-/* 805 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 806 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 807 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 808 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 809 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t *)
-/* 810 */ _CFFI_OP(_CFFI_OP_POINTER, 1273), // clingo_statistics_t const *
-/* 811 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 812 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 813 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, char const *, _Bool *)
-/* 814 */ _CFFI_OP(_CFFI_OP_NOOP, 810),
-/* 815 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 816 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 817 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 818 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 819 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, char const *, uint64_t *)
-/* 820 */ _CFFI_OP(_CFFI_OP_NOOP, 810),
-/* 821 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 822 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 823 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 824 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 825 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, double *)
-/* 826 */ _CFFI_OP(_CFFI_OP_NOOP, 810),
-/* 827 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 828 */ _CFFI_OP(_CFFI_OP_POINTER, 801), // double *
-/* 829 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 830 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, int *)
-/* 831 */ _CFFI_OP(_CFFI_OP_NOOP, 810),
-/* 832 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 833 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
-/* 834 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 835 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, size_t *)
-/* 836 */ _CFFI_OP(_CFFI_OP_NOOP, 810),
-/* 837 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 838 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 839 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 840 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, size_t, char const * *)
-/* 841 */ _CFFI_OP(_CFFI_OP_NOOP, 810),
-/* 842 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 843 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 844 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
-/* 845 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 846 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, size_t, uint64_t *)
-/* 847 */ _CFFI_OP(_CFFI_OP_NOOP, 810),
-/* 848 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 849 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 850 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 851 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 852 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, size_t *)
-/* 853 */ _CFFI_OP(_CFFI_OP_POINTER, 1274), // clingo_symbolic_atoms_t const *
-/* 854 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 855 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 856 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t *)
-/* 857 */ _CFFI_OP(_CFFI_OP_NOOP, 853),
-/* 858 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 859 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 860 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t *, size_t)
-/* 861 */ _CFFI_OP(_CFFI_OP_NOOP, 853),
-/* 862 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 863 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 864 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 865 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t const *, uint64_t *)
-/* 866 */ _CFFI_OP(_CFFI_OP_NOOP, 853),
-/* 867 */ _CFFI_OP(_CFFI_OP_NOOP, 79),
-/* 868 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 869 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 870 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t, _Bool *)
-/* 871 */ _CFFI_OP(_CFFI_OP_NOOP, 853),
-/* 872 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 873 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 874 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 875 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t, int32_t *)
-/* 876 */ _CFFI_OP(_CFFI_OP_NOOP, 853),
-/* 877 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 878 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
-/* 879 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 880 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t, uint64_t *)
-/* 881 */ _CFFI_OP(_CFFI_OP_NOOP, 853),
-/* 882 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 883 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 884 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 885 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t, uint64_t, _Bool *)
-/* 886 */ _CFFI_OP(_CFFI_OP_NOOP, 853),
-/* 887 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 888 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 889 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 890 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 891 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, size_t *)
-/* 892 */ _CFFI_OP(_CFFI_OP_POINTER, 1275), // clingo_theory_atoms_t const *
-/* 893 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 894 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 895 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, _Bool *)
-/* 896 */ _CFFI_OP(_CFFI_OP_NOOP, 892),
-/* 897 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 898 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 899 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 900 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, char *, size_t)
-/* 901 */ _CFFI_OP(_CFFI_OP_NOOP, 892),
-/* 902 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 903 */ _CFFI_OP(_CFFI_OP_NOOP, 138),
-/* 904 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 905 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 906 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, char const * *)
-/* 907 */ _CFFI_OP(_CFFI_OP_NOOP, 892),
-/* 908 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 909 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
-/* 910 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 911 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, char const * *, uint32_t *)
-/* 912 */ _CFFI_OP(_CFFI_OP_NOOP, 892),
-/* 913 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 914 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
-/* 915 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
-/* 916 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 917 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, int *)
-/* 918 */ _CFFI_OP(_CFFI_OP_NOOP, 892),
-/* 919 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 920 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
-/* 921 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 922 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, int32_t *)
-/* 923 */ _CFFI_OP(_CFFI_OP_NOOP, 892),
-/* 924 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 925 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
-/* 926 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 927 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, int32_t const * *, size_t *)
-/* 928 */ _CFFI_OP(_CFFI_OP_NOOP, 892),
-/* 929 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 930 */ _CFFI_OP(_CFFI_OP_NOOP, 784),
-/* 931 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 932 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 933 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, size_t *)
-/* 934 */ _CFFI_OP(_CFFI_OP_NOOP, 892),
-/* 935 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 936 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 937 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 938 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, uint32_t *)
-/* 939 */ _CFFI_OP(_CFFI_OP_NOOP, 892),
-/* 940 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 941 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
-/* 942 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 943 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, uint32_t const * *, size_t *)
-/* 944 */ _CFFI_OP(_CFFI_OP_NOOP, 892),
-/* 945 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 946 */ _CFFI_OP(_CFFI_OP_POINTER, 2), // uint32_t const * *
-/* 947 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 948 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 949 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(int, clingo_ast_t * *, ...)
-/* 950 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 951 */ _CFFI_OP(_CFFI_OP_NOOP, 143),
-/* 952 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 1),
-/* 953 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(int, int, int32_t const *, size_t, void *)
-/* 954 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 955 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 956 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
-/* 957 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 958 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 959 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 960 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(int32_t const *, size_t, void *)
-/* 961 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
-/* 962 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 963 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 964 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 965 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(int32_t, clingo_weighted_literal_t const *, size_t, void *)
-/* 966 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 967 */ _CFFI_OP(_CFFI_OP_NOOP, 13),
-/* 968 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 969 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 970 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 971 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t const *, size_t, void *)
-/* 972 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
-/* 973 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 974 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 975 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 976 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, char const *, void *)
-/* 977 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 978 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 979 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 980 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 981 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, clingo_assignment_t const *, int32_t, void *, int32_t *)
-/* 982 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 983 */ _CFFI_OP(_CFFI_OP_NOOP, 96),
-/* 984 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 985 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 986 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
-/* 987 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 988 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, int, int, unsigned int, int32_t const *, size_t, void *)
-/* 989 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 990 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 991 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 992 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8),
-/* 993 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
-/* 994 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 995 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 996 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 997 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, int, uint32_t const *, size_t, void *)
-/* 998 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 999 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 1000 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
-/* 1001 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 1002 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1003 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1004 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, int, void *)
-/* 1005 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 1006 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 1007 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1008 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1009 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, uint32_t const *, size_t, int32_t const *, size_t, void *)
-/* 1010 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 1011 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
-/* 1012 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 1013 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 743 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 744 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 745 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 746 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, int32_t, uint32_t)
+/* 747 */ _CFFI_OP(_CFFI_OP_NOOP, 712),
+/* 748 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 749 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 750 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 751 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, void *)
+/* 752 */ _CFFI_OP(_CFFI_OP_NOOP, 712),
+/* 753 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 754 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 755 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t const *, clingo_symbolic_atoms_t const * *)
+/* 756 */ _CFFI_OP(_CFFI_OP_POINTER, 1270), // clingo_propagate_init_t const *
+/* 757 */ _CFFI_OP(_CFFI_OP_NOOP, 536),
+/* 758 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 759 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t const *, clingo_theory_atoms_t const * *)
+/* 760 */ _CFFI_OP(_CFFI_OP_NOOP, 756),
+/* 761 */ _CFFI_OP(_CFFI_OP_NOOP, 540),
+/* 762 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 763 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t const *, int32_t, int32_t *)
+/* 764 */ _CFFI_OP(_CFFI_OP_NOOP, 756),
+/* 765 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 766 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
+/* 767 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 768 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_control_t *, int32_t const *, size_t)
+/* 769 */ _CFFI_OP(_CFFI_OP_POINTER, 1273), // clingo_solve_control_t *
+/* 770 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 771 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 772 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 773 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_control_t const *, clingo_symbolic_atoms_t const * *)
+/* 774 */ _CFFI_OP(_CFFI_OP_POINTER, 1273), // clingo_solve_control_t const *
+/* 775 */ _CFFI_OP(_CFFI_OP_NOOP, 536),
+/* 776 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 777 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_handle_t *)
+/* 778 */ _CFFI_OP(_CFFI_OP_POINTER, 1274), // clingo_solve_handle_t *
+/* 779 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 780 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_handle_t *, clingo_model_t const * *)
+/* 781 */ _CFFI_OP(_CFFI_OP_NOOP, 778),
+/* 782 */ _CFFI_OP(_CFFI_OP_POINTER, 585), // clingo_model_t const * *
+/* 783 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 784 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_handle_t *, int32_t const * *, size_t *)
+/* 785 */ _CFFI_OP(_CFFI_OP_NOOP, 778),
+/* 786 */ _CFFI_OP(_CFFI_OP_POINTER, 4), // int32_t const * *
+/* 787 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 788 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 789 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_handle_t *, unsigned int *)
+/* 790 */ _CFFI_OP(_CFFI_OP_NOOP, 778),
+/* 791 */ _CFFI_OP(_CFFI_OP_NOOP, 434),
+/* 792 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 793 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t *, uint64_t, char const *, int, uint64_t *)
+/* 794 */ _CFFI_OP(_CFFI_OP_POINTER, 1275), // clingo_statistics_t *
+/* 795 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 796 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 797 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 798 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 799 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 800 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t *, uint64_t, double)
+/* 801 */ _CFFI_OP(_CFFI_OP_NOOP, 794),
+/* 802 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 803 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 14), // double
+/* 804 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 805 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t *, uint64_t, int, uint64_t *)
+/* 806 */ _CFFI_OP(_CFFI_OP_NOOP, 794),
+/* 807 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 808 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 809 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 810 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 811 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t *)
+/* 812 */ _CFFI_OP(_CFFI_OP_POINTER, 1275), // clingo_statistics_t const *
+/* 813 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 814 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 815 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, char const *, _Bool *)
+/* 816 */ _CFFI_OP(_CFFI_OP_NOOP, 812),
+/* 817 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 818 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 819 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 820 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 821 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, char const *, uint64_t *)
+/* 822 */ _CFFI_OP(_CFFI_OP_NOOP, 812),
+/* 823 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 824 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 825 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 826 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 827 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, double *)
+/* 828 */ _CFFI_OP(_CFFI_OP_NOOP, 812),
+/* 829 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 830 */ _CFFI_OP(_CFFI_OP_POINTER, 803), // double *
+/* 831 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 832 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, int *)
+/* 833 */ _CFFI_OP(_CFFI_OP_NOOP, 812),
+/* 834 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 835 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
+/* 836 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 837 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, size_t *)
+/* 838 */ _CFFI_OP(_CFFI_OP_NOOP, 812),
+/* 839 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 840 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 841 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 842 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, size_t, char const * *)
+/* 843 */ _CFFI_OP(_CFFI_OP_NOOP, 812),
+/* 844 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 845 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 846 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
+/* 847 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 848 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, size_t, uint64_t *)
+/* 849 */ _CFFI_OP(_CFFI_OP_NOOP, 812),
+/* 850 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 851 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 852 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 853 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 854 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, size_t *)
+/* 855 */ _CFFI_OP(_CFFI_OP_POINTER, 1276), // clingo_symbolic_atoms_t const *
+/* 856 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 857 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 858 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t *)
+/* 859 */ _CFFI_OP(_CFFI_OP_NOOP, 855),
+/* 860 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 861 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 862 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t *, size_t)
+/* 863 */ _CFFI_OP(_CFFI_OP_NOOP, 855),
+/* 864 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 865 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 866 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 867 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t const *, uint64_t *)
+/* 868 */ _CFFI_OP(_CFFI_OP_NOOP, 855),
+/* 869 */ _CFFI_OP(_CFFI_OP_NOOP, 79),
+/* 870 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 871 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 872 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t, _Bool *)
+/* 873 */ _CFFI_OP(_CFFI_OP_NOOP, 855),
+/* 874 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 875 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 876 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 877 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t, int32_t *)
+/* 878 */ _CFFI_OP(_CFFI_OP_NOOP, 855),
+/* 879 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 880 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
+/* 881 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 882 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t, uint64_t *)
+/* 883 */ _CFFI_OP(_CFFI_OP_NOOP, 855),
+/* 884 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 885 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 886 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 887 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t, uint64_t, _Bool *)
+/* 888 */ _CFFI_OP(_CFFI_OP_NOOP, 855),
+/* 889 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 890 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 891 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 892 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 893 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, size_t *)
+/* 894 */ _CFFI_OP(_CFFI_OP_POINTER, 1277), // clingo_theory_atoms_t const *
+/* 895 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 896 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 897 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, _Bool *)
+/* 898 */ _CFFI_OP(_CFFI_OP_NOOP, 894),
+/* 899 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 900 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 901 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 902 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, char *, size_t)
+/* 903 */ _CFFI_OP(_CFFI_OP_NOOP, 894),
+/* 904 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 905 */ _CFFI_OP(_CFFI_OP_NOOP, 138),
+/* 906 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 907 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 908 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, char const * *)
+/* 909 */ _CFFI_OP(_CFFI_OP_NOOP, 894),
+/* 910 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 911 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
+/* 912 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 913 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, char const * *, uint32_t *)
+/* 914 */ _CFFI_OP(_CFFI_OP_NOOP, 894),
+/* 915 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 916 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
+/* 917 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
+/* 918 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 919 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, int *)
+/* 920 */ _CFFI_OP(_CFFI_OP_NOOP, 894),
+/* 921 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 922 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
+/* 923 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 924 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, int32_t *)
+/* 925 */ _CFFI_OP(_CFFI_OP_NOOP, 894),
+/* 926 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 927 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
+/* 928 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 929 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, int32_t const * *, size_t *)
+/* 930 */ _CFFI_OP(_CFFI_OP_NOOP, 894),
+/* 931 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 932 */ _CFFI_OP(_CFFI_OP_NOOP, 786),
+/* 933 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 934 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 935 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, size_t *)
+/* 936 */ _CFFI_OP(_CFFI_OP_NOOP, 894),
+/* 937 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 938 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 939 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 940 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, uint32_t *)
+/* 941 */ _CFFI_OP(_CFFI_OP_NOOP, 894),
+/* 942 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 943 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
+/* 944 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 945 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, uint32_t const * *, size_t *)
+/* 946 */ _CFFI_OP(_CFFI_OP_NOOP, 894),
+/* 947 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 948 */ _CFFI_OP(_CFFI_OP_POINTER, 2), // uint32_t const * *
+/* 949 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 950 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 951 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(int, clingo_ast_t * *, ...)
+/* 952 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 953 */ _CFFI_OP(_CFFI_OP_NOOP, 143),
+/* 954 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 1),
+/* 955 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(int, int, int32_t const *, size_t, void *)
+/* 956 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 957 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 958 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 959 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 960 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 961 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 962 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(int32_t const *, size_t, void *)
+/* 963 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 964 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 965 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 966 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 967 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(int32_t, clingo_weighted_literal_t const *, size_t, void *)
+/* 968 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 969 */ _CFFI_OP(_CFFI_OP_NOOP, 13),
+/* 970 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 971 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 972 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 973 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t const *, size_t, void *)
+/* 974 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
+/* 975 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 976 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 977 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 978 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, char const *, void *)
+/* 979 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 980 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 981 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 982 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 983 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, clingo_assignment_t const *, int32_t, void *, int32_t *)
+/* 984 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 985 */ _CFFI_OP(_CFFI_OP_NOOP, 96),
+/* 986 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 987 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 988 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
+/* 989 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 990 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, int, int, unsigned int, int32_t const *, size_t, void *)
+/* 991 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 992 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 993 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 994 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8),
+/* 995 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 996 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 997 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 998 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 999 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, int, uint32_t const *, size_t, void *)
+/* 1000 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 1001 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 1002 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
+/* 1003 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 1004 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1005 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1006 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, int, void *)
+/* 1007 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 1008 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 1009 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1010 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1011 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, uint32_t const *, size_t, int32_t const *, size_t, void *)
+/* 1012 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 1013 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
 /* 1014 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 1015 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1016 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1017 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, uint32_t, uint32_t const *, size_t, uint32_t, uint32_t, void *)
-/* 1018 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 1019 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 1020 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
-/* 1021 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 1022 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 1023 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 1024 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1025 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1026 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, uint32_t, uint32_t const *, size_t, void *)
-/* 1027 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 1028 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 1029 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
-/* 1030 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 1031 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1032 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1033 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t const *, size_t, void *)
-/* 1034 */ _CFFI_OP(_CFFI_OP_NOOP, 79),
-/* 1035 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 1036 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1037 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1038 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t)
-/* 1039 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1040 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1041 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, _Bool *)
-/* 1042 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1043 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 1044 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1045 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, char *, size_t)
-/* 1046 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1047 */ _CFFI_OP(_CFFI_OP_NOOP, 138),
-/* 1048 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 1049 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1050 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, char const * *)
-/* 1051 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1052 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
-/* 1053 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1054 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, int *)
-/* 1055 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1056 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
-/* 1057 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1058 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, int32_t const *, size_t, void *)
-/* 1059 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1060 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
-/* 1061 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 1062 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1063 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1064 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, size_t *)
-/* 1065 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1066 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 1067 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1068 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, uint32_t, void *)
-/* 1069 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1070 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 1071 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1072 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1073 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, uint64_t const * *, size_t *)
-/* 1074 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1075 */ _CFFI_OP(_CFFI_OP_POINTER, 79), // uint64_t const * *
-/* 1076 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 1077 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1078 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, uint64_t)
-/* 1079 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1080 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1081 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1082 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(unsigned int, void *, void *, _Bool *)
-/* 1083 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8),
-/* 1084 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1085 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1086 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 1087 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1088 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(void *)
-/* 1089 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1090 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1091 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(void *, char const *, void *)
-/* 1092 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1093 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 1015 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 1016 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 1017 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1018 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1019 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, uint32_t, uint32_t const *, size_t, uint32_t, uint32_t, void *)
+/* 1020 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 1021 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 1022 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
+/* 1023 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 1024 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 1025 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 1026 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1027 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1028 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, uint32_t, uint32_t const *, size_t, void *)
+/* 1029 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 1030 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 1031 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
+/* 1032 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 1033 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1034 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1035 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t const *, size_t, void *)
+/* 1036 */ _CFFI_OP(_CFFI_OP_NOOP, 79),
+/* 1037 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 1038 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1039 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1040 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t)
+/* 1041 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1042 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1043 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, _Bool *)
+/* 1044 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1045 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 1046 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1047 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, char *, size_t)
+/* 1048 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1049 */ _CFFI_OP(_CFFI_OP_NOOP, 138),
+/* 1050 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 1051 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1052 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, char const * *)
+/* 1053 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1054 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
+/* 1055 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1056 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, int *)
+/* 1057 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1058 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
+/* 1059 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1060 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, int32_t const *, size_t, void *)
+/* 1061 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1062 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 1063 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 1064 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1065 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1066 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, size_t *)
+/* 1067 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1068 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 1069 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1070 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, uint32_t, void *)
+/* 1071 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1072 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 1073 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1074 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1075 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, uint64_t const * *, size_t *)
+/* 1076 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1077 */ _CFFI_OP(_CFFI_OP_POINTER, 79), // uint64_t const * *
+/* 1078 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 1079 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1080 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, uint64_t)
+/* 1081 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1082 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1083 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1084 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(unsigned int, void *, void *, _Bool *)
+/* 1085 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8),
+/* 1086 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1087 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1088 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 1089 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1090 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(void *)
+/* 1091 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1092 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1093 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(void *, char const *, void *)
 /* 1094 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1095 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1096 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(void *, char const *, void *, size_t, void *, void *, void *)
-/* 1097 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1098 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 1095 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 1096 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1097 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1098 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(void *, char const *, void *, size_t, void *, void *, void *)
 /* 1099 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1100 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 1100 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
 /* 1101 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1102 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1102 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
 /* 1103 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1104 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1105 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(void *, void *)
-/* 1106 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1107 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1108 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1109 */ _CFFI_OP(_CFFI_OP_FUNCTION, 40), // char const *()(char const *)
-/* 1110 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 1111 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1112 */ _CFFI_OP(_CFFI_OP_FUNCTION, 40), // char const *()(int)
-/* 1113 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 1114 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1115 */ _CFFI_OP(_CFFI_OP_FUNCTION, 40), // char const *()(uint64_t)
-/* 1116 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1117 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1118 */ _CFFI_OP(_CFFI_OP_FUNCTION, 40), // char const *()(void *)
-/* 1119 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1120 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1121 */ _CFFI_OP(_CFFI_OP_FUNCTION, 40), // char const *()(void)
+/* 1104 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1105 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1106 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1107 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(void *, void *)
+/* 1108 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1109 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1110 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1111 */ _CFFI_OP(_CFFI_OP_FUNCTION, 40), // char const *()(char const *)
+/* 1112 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 1113 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1114 */ _CFFI_OP(_CFFI_OP_FUNCTION, 40), // char const *()(int)
+/* 1115 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 1116 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1117 */ _CFFI_OP(_CFFI_OP_FUNCTION, 40), // char const *()(uint64_t)
+/* 1118 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1119 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1120 */ _CFFI_OP(_CFFI_OP_FUNCTION, 40), // char const *()(void *)
+/* 1121 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
 /* 1122 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1123 */ _CFFI_OP(_CFFI_OP_FUNCTION, 96), // clingo_assignment_t const *()(clingo_propagate_control_t const *)
-/* 1124 */ _CFFI_OP(_CFFI_OP_NOOP, 706),
-/* 1125 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1126 */ _CFFI_OP(_CFFI_OP_FUNCTION, 96), // clingo_assignment_t const *()(clingo_propagate_init_t const *)
-/* 1127 */ _CFFI_OP(_CFFI_OP_NOOP, 754),
-/* 1128 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1129 */ _CFFI_OP(_CFFI_OP_FUNCTION, 155), // int()(clingo_application_t *, char const * const *, size_t, void *)
-/* 1130 */ _CFFI_OP(_CFFI_OP_POINTER, 1249), // clingo_application_t *
-/* 1131 */ _CFFI_OP(_CFFI_OP_NOOP, 22),
-/* 1132 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 1133 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1134 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1135 */ _CFFI_OP(_CFFI_OP_FUNCTION, 155), // int()(clingo_propagate_init_t const *)
-/* 1136 */ _CFFI_OP(_CFFI_OP_NOOP, 754),
-/* 1137 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1138 */ _CFFI_OP(_CFFI_OP_FUNCTION, 155), // int()(uint64_t)
-/* 1139 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1140 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1141 */ _CFFI_OP(_CFFI_OP_FUNCTION, 155), // int()(void)
+/* 1123 */ _CFFI_OP(_CFFI_OP_FUNCTION, 40), // char const *()(void)
+/* 1124 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1125 */ _CFFI_OP(_CFFI_OP_FUNCTION, 96), // clingo_assignment_t const *()(clingo_propagate_control_t const *)
+/* 1126 */ _CFFI_OP(_CFFI_OP_NOOP, 708),
+/* 1127 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1128 */ _CFFI_OP(_CFFI_OP_FUNCTION, 96), // clingo_assignment_t const *()(clingo_propagate_init_t const *)
+/* 1129 */ _CFFI_OP(_CFFI_OP_NOOP, 756),
+/* 1130 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1131 */ _CFFI_OP(_CFFI_OP_FUNCTION, 155), // int()(clingo_application_t *, char const * const *, size_t, void *)
+/* 1132 */ _CFFI_OP(_CFFI_OP_POINTER, 1251), // clingo_application_t *
+/* 1133 */ _CFFI_OP(_CFFI_OP_NOOP, 22),
+/* 1134 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 1135 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1136 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1137 */ _CFFI_OP(_CFFI_OP_FUNCTION, 155), // int()(clingo_propagate_init_t const *)
+/* 1138 */ _CFFI_OP(_CFFI_OP_NOOP, 756),
+/* 1139 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1140 */ _CFFI_OP(_CFFI_OP_FUNCTION, 155), // int()(uint64_t)
+/* 1141 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
 /* 1142 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1143 */ _CFFI_OP(_CFFI_OP_FUNCTION, 3), // size_t()(clingo_assignment_t const *)
-/* 1144 */ _CFFI_OP(_CFFI_OP_NOOP, 96),
-/* 1145 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1146 */ _CFFI_OP(_CFFI_OP_FUNCTION, 3), // size_t()(clingo_ast_t *)
-/* 1147 */ _CFFI_OP(_CFFI_OP_NOOP, 137),
-/* 1148 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1149 */ _CFFI_OP(_CFFI_OP_FUNCTION, 3), // size_t()(uint64_t)
-/* 1150 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1151 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1152 */ _CFFI_OP(_CFFI_OP_FUNCTION, 69), // uint32_t()(clingo_assignment_t const *)
-/* 1153 */ _CFFI_OP(_CFFI_OP_NOOP, 96),
-/* 1154 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1155 */ _CFFI_OP(_CFFI_OP_FUNCTION, 69), // uint32_t()(clingo_propagate_control_t const *)
-/* 1156 */ _CFFI_OP(_CFFI_OP_NOOP, 706),
-/* 1157 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1158 */ _CFFI_OP(_CFFI_OP_FUNCTION, 69), // uint32_t()(uint64_t)
-/* 1159 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1160 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1161 */ _CFFI_OP(_CFFI_OP_FUNCTION, 29), // unsigned int()(void *)
-/* 1162 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1163 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1164 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(clingo_ast_t *)
-/* 1165 */ _CFFI_OP(_CFFI_OP_NOOP, 137),
-/* 1166 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1167 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(clingo_control_t *)
-/* 1168 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 1169 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1170 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(clingo_propagate_control_t *, int32_t)
-/* 1171 */ _CFFI_OP(_CFFI_OP_NOOP, 677),
-/* 1172 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 1173 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1174 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(clingo_propagate_control_t const *, int32_t const *, size_t, void *)
-/* 1175 */ _CFFI_OP(_CFFI_OP_NOOP, 706),
-/* 1176 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
-/* 1177 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 1178 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1179 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1180 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(clingo_propagate_init_t *, int)
-/* 1181 */ _CFFI_OP(_CFFI_OP_NOOP, 710),
-/* 1182 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 1183 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1184 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(clingo_solve_handle_t *, double, _Bool *)
-/* 1185 */ _CFFI_OP(_CFFI_OP_NOOP, 776),
-/* 1186 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 14),
-/* 1187 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 1188 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1189 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(int *, int *, int *)
-/* 1190 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
-/* 1191 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
+/* 1143 */ _CFFI_OP(_CFFI_OP_FUNCTION, 155), // int()(void)
+/* 1144 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1145 */ _CFFI_OP(_CFFI_OP_FUNCTION, 3), // size_t()(clingo_assignment_t const *)
+/* 1146 */ _CFFI_OP(_CFFI_OP_NOOP, 96),
+/* 1147 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1148 */ _CFFI_OP(_CFFI_OP_FUNCTION, 3), // size_t()(clingo_ast_t *)
+/* 1149 */ _CFFI_OP(_CFFI_OP_NOOP, 137),
+/* 1150 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1151 */ _CFFI_OP(_CFFI_OP_FUNCTION, 3), // size_t()(uint64_t)
+/* 1152 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1153 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1154 */ _CFFI_OP(_CFFI_OP_FUNCTION, 69), // uint32_t()(clingo_assignment_t const *)
+/* 1155 */ _CFFI_OP(_CFFI_OP_NOOP, 96),
+/* 1156 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1157 */ _CFFI_OP(_CFFI_OP_FUNCTION, 69), // uint32_t()(clingo_propagate_control_t const *)
+/* 1158 */ _CFFI_OP(_CFFI_OP_NOOP, 708),
+/* 1159 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1160 */ _CFFI_OP(_CFFI_OP_FUNCTION, 69), // uint32_t()(uint64_t)
+/* 1161 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1162 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1163 */ _CFFI_OP(_CFFI_OP_FUNCTION, 29), // unsigned int()(void *)
+/* 1164 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1165 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1166 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(clingo_ast_t *)
+/* 1167 */ _CFFI_OP(_CFFI_OP_NOOP, 137),
+/* 1168 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1169 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(clingo_control_t *)
+/* 1170 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 1171 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1172 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(clingo_propagate_control_t *, int32_t)
+/* 1173 */ _CFFI_OP(_CFFI_OP_NOOP, 679),
+/* 1174 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 1175 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1176 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(clingo_propagate_control_t const *, int32_t const *, size_t, void *)
+/* 1177 */ _CFFI_OP(_CFFI_OP_NOOP, 708),
+/* 1178 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 1179 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 1180 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1181 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1182 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(clingo_propagate_init_t *, int)
+/* 1183 */ _CFFI_OP(_CFFI_OP_NOOP, 712),
+/* 1184 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 1185 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1186 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(clingo_solve_handle_t *, double, _Bool *)
+/* 1187 */ _CFFI_OP(_CFFI_OP_NOOP, 778),
+/* 1188 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 14),
+/* 1189 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 1190 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1191 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(int *, int *, int *)
 /* 1192 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
-/* 1193 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1194 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(int, char const *)
-/* 1195 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 1196 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 1197 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1198 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(int, char const *, void *)
-/* 1199 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 1200 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 1201 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1202 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1203 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(int, uint64_t *)
-/* 1204 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 1205 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 1206 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1207 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(uint64_t *)
-/* 1208 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 1209 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1210 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(void *)
-/* 1211 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1212 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1213 */ _CFFI_OP(_CFFI_OP_POINTER, 0), // _Bool(*)(_Bool, uint32_t const *, size_t, int32_t const *, size_t, void *)
-/* 1214 */ _CFFI_OP(_CFFI_OP_POINTER, 8), // _Bool(*)(_Bool, uint32_t const *, size_t, int32_t, clingo_weighted_literal_t const *, size_t, void *)
-/* 1215 */ _CFFI_OP(_CFFI_OP_POINTER, 17), // _Bool(*)(_Bool, void *)
-/* 1216 */ _CFFI_OP(_CFFI_OP_POINTER, 39), // _Bool(*)(char const *, _Bool *, void *)
-/* 1217 */ _CFFI_OP(_CFFI_OP_POINTER, 256), // _Bool(*)(clingo_ast_t const *, void *)
-/* 1218 */ _CFFI_OP(_CFFI_OP_POINTER, 441), // _Bool(*)(clingo_control_t *, char const * const *, size_t, void *)
-/* 1219 */ _CFFI_OP(_CFFI_OP_POINTER, 511), // _Bool(*)(clingo_control_t *, void *)
-/* 1220 */ _CFFI_OP(_CFFI_OP_POINTER, 540), // _Bool(*)(clingo_location_t *, char const *, void *)
-/* 1221 */ _CFFI_OP(_CFFI_OP_POINTER, 545), // _Bool(*)(clingo_location_t *, char const *, void *, size_t, void *, void *, void *)
-/* 1222 */ _CFFI_OP(_CFFI_OP_POINTER, 554), // _Bool(*)(clingo_location_t const *, char const *, uint64_t const *, size_t, _Bool(*)(uint64_t const *, size_t, void *), void *, void *)
-/* 1223 */ _CFFI_OP(_CFFI_OP_POINTER, 572), // _Bool(*)(clingo_location_t const *, char const *, void *)
-/* 1224 */ _CFFI_OP(_CFFI_OP_POINTER, 586), // _Bool(*)(clingo_model_t const *, _Bool(*)(void *), void *, void *)
-/* 1225 */ _CFFI_OP(_CFFI_OP_POINTER, 665), // _Bool(*)(clingo_options_t *, void *)
-/* 1226 */ _CFFI_OP(_CFFI_OP_POINTER, 691), // _Bool(*)(clingo_propagate_control_t *, int32_t const *, size_t, void *)
-/* 1227 */ _CFFI_OP(_CFFI_OP_POINTER, 701), // _Bool(*)(clingo_propagate_control_t *, void *)
-/* 1228 */ _CFFI_OP(_CFFI_OP_POINTER, 749), // _Bool(*)(clingo_propagate_init_t *, void *)
-/* 1229 */ _CFFI_OP(_CFFI_OP_POINTER, 949), // _Bool(*)(int, clingo_ast_t * *, ...)
-/* 1230 */ _CFFI_OP(_CFFI_OP_POINTER, 953), // _Bool(*)(int, int, int32_t const *, size_t, void *)
-/* 1231 */ _CFFI_OP(_CFFI_OP_POINTER, 960), // _Bool(*)(int32_t const *, size_t, void *)
-/* 1232 */ _CFFI_OP(_CFFI_OP_POINTER, 965), // _Bool(*)(int32_t, clingo_weighted_literal_t const *, size_t, void *)
-/* 1233 */ _CFFI_OP(_CFFI_OP_POINTER, 971), // _Bool(*)(uint32_t const *, size_t, void *)
-/* 1234 */ _CFFI_OP(_CFFI_OP_POINTER, 976), // _Bool(*)(uint32_t, char const *, void *)
-/* 1235 */ _CFFI_OP(_CFFI_OP_POINTER, 981), // _Bool(*)(uint32_t, clingo_assignment_t const *, int32_t, void *, int32_t *)
-/* 1236 */ _CFFI_OP(_CFFI_OP_POINTER, 988), // _Bool(*)(uint32_t, int, int, unsigned int, int32_t const *, size_t, void *)
-/* 1237 */ _CFFI_OP(_CFFI_OP_POINTER, 997), // _Bool(*)(uint32_t, int, uint32_t const *, size_t, void *)
-/* 1238 */ _CFFI_OP(_CFFI_OP_POINTER, 1004), // _Bool(*)(uint32_t, int, void *)
-/* 1239 */ _CFFI_OP(_CFFI_OP_POINTER, 1009), // _Bool(*)(uint32_t, uint32_t const *, size_t, int32_t const *, size_t, void *)
-/* 1240 */ _CFFI_OP(_CFFI_OP_POINTER, 1017), // _Bool(*)(uint32_t, uint32_t, uint32_t const *, size_t, uint32_t, uint32_t, void *)
-/* 1241 */ _CFFI_OP(_CFFI_OP_POINTER, 1026), // _Bool(*)(uint32_t, uint32_t, uint32_t const *, size_t, void *)
-/* 1242 */ _CFFI_OP(_CFFI_OP_POINTER, 1058), // _Bool(*)(uint64_t, int32_t const *, size_t, void *)
-/* 1243 */ _CFFI_OP(_CFFI_OP_POINTER, 1068), // _Bool(*)(uint64_t, uint32_t, void *)
-/* 1244 */ _CFFI_OP(_CFFI_OP_POINTER, 1091), // _Bool(*)(void *, char const *, void *)
-/* 1245 */ _CFFI_OP(_CFFI_OP_POINTER, 1096), // _Bool(*)(void *, char const *, void *, size_t, void *, void *, void *)
-/* 1246 */ _CFFI_OP(_CFFI_OP_POINTER, 1105), // _Bool(*)(void *, void *)
-/* 1247 */ _CFFI_OP(_CFFI_OP_POINTER, 1118), // char const *(*)(void *)
-/* 1248 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 2), // char
-/* 1249 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 0), // clingo_application_t
-/* 1250 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 1), // clingo_assignment_t
-/* 1251 */ _CFFI_OP(_CFFI_OP_POINTER, 1252), // clingo_ast_argument_t const *
-/* 1252 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 3), // clingo_ast_argument_t
-/* 1253 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 4), // clingo_ast_attribute_names_t
-/* 1254 */ _CFFI_OP(_CFFI_OP_POINTER, 1255), // clingo_ast_constructor_t const *
-/* 1255 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 5), // clingo_ast_constructor_t
-/* 1256 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 6), // clingo_ast_constructors_t
-/* 1257 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 2), // clingo_ast_t
-/* 1258 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 7), // clingo_backend_t
-/* 1259 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 8), // clingo_configuration_t
-/* 1260 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 9), // clingo_control_t
-/* 1261 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 10), // clingo_ground_program_observer_t
-/* 1262 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 11), // clingo_location_t
-/* 1263 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 12), // clingo_model_t
-/* 1264 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 13), // clingo_options_t
-/* 1265 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 14), // clingo_part_t
-/* 1266 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 15), // clingo_program_builder_t
-/* 1267 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 16), // clingo_propagate_control_t
-/* 1268 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 17), // clingo_propagate_init_t
-/* 1269 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 18), // clingo_propagator_t
-/* 1270 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 19), // clingo_script_t
-/* 1271 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 20), // clingo_solve_control_t
-/* 1272 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 21), // clingo_solve_handle_t
-/* 1273 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 22), // clingo_statistics_t
-/* 1274 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 23), // clingo_symbolic_atoms_t
-/* 1275 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 24), // clingo_theory_atoms_t
-/* 1276 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 25), // clingo_weighted_literal_t
-/* 1277 */ _CFFI_OP(_CFFI_OP_ENUM, 0), // enum clingo_ast_aggregate_function_e
-/* 1278 */ _CFFI_OP(_CFFI_OP_ENUM, 1), // enum clingo_ast_attribute_e
-/* 1279 */ _CFFI_OP(_CFFI_OP_ENUM, 2), // enum clingo_ast_attribute_type_e
-/* 1280 */ _CFFI_OP(_CFFI_OP_ENUM, 3), // enum clingo_ast_binary_operator_e
-/* 1281 */ _CFFI_OP(_CFFI_OP_ENUM, 4), // enum clingo_ast_comparison_operator_e
-/* 1282 */ _CFFI_OP(_CFFI_OP_ENUM, 5), // enum clingo_ast_sign_e
-/* 1283 */ _CFFI_OP(_CFFI_OP_ENUM, 6), // enum clingo_ast_theory_atom_definition_type_e
-/* 1284 */ _CFFI_OP(_CFFI_OP_ENUM, 7), // enum clingo_ast_theory_operator_type_e
-/* 1285 */ _CFFI_OP(_CFFI_OP_ENUM, 8), // enum clingo_ast_theory_sequence_type_e
-/* 1286 */ _CFFI_OP(_CFFI_OP_ENUM, 9), // enum clingo_ast_type_e
-/* 1287 */ _CFFI_OP(_CFFI_OP_ENUM, 10), // enum clingo_ast_unary_operator_e
-/* 1288 */ _CFFI_OP(_CFFI_OP_ENUM, 11), // enum clingo_ast_unpool_type_e
-/* 1289 */ _CFFI_OP(_CFFI_OP_ENUM, 12), // enum clingo_clause_type_e
-/* 1290 */ _CFFI_OP(_CFFI_OP_ENUM, 13), // enum clingo_comment_type_e
-/* 1291 */ _CFFI_OP(_CFFI_OP_ENUM, 14), // enum clingo_configuration_type_e
-/* 1292 */ _CFFI_OP(_CFFI_OP_ENUM, 15), // enum clingo_consequence_e
-/* 1293 */ _CFFI_OP(_CFFI_OP_ENUM, 16), // enum clingo_error_e
-/* 1294 */ _CFFI_OP(_CFFI_OP_ENUM, 17), // enum clingo_external_type_e
-/* 1295 */ _CFFI_OP(_CFFI_OP_ENUM, 18), // enum clingo_heuristic_type_e
-/* 1296 */ _CFFI_OP(_CFFI_OP_ENUM, 19), // enum clingo_model_type_e
-/* 1297 */ _CFFI_OP(_CFFI_OP_ENUM, 20), // enum clingo_propagator_check_mode_e
-/* 1298 */ _CFFI_OP(_CFFI_OP_ENUM, 21), // enum clingo_propagator_undo_mode_e
-/* 1299 */ _CFFI_OP(_CFFI_OP_ENUM, 22), // enum clingo_show_type_e
-/* 1300 */ _CFFI_OP(_CFFI_OP_ENUM, 23), // enum clingo_solve_event_type_e
-/* 1301 */ _CFFI_OP(_CFFI_OP_ENUM, 24), // enum clingo_solve_mode_e
-/* 1302 */ _CFFI_OP(_CFFI_OP_ENUM, 25), // enum clingo_solve_result_e
-/* 1303 */ _CFFI_OP(_CFFI_OP_ENUM, 26), // enum clingo_statistics_type_e
-/* 1304 */ _CFFI_OP(_CFFI_OP_ENUM, 27), // enum clingo_symbol_type_e
-/* 1305 */ _CFFI_OP(_CFFI_OP_ENUM, 28), // enum clingo_theory_sequence_type_e
-/* 1306 */ _CFFI_OP(_CFFI_OP_ENUM, 29), // enum clingo_theory_term_type_e
-/* 1307 */ _CFFI_OP(_CFFI_OP_ENUM, 30), // enum clingo_truth_value_e
-/* 1308 */ _CFFI_OP(_CFFI_OP_ENUM, 31), // enum clingo_warning_e
-/* 1309 */ _CFFI_OP(_CFFI_OP_ENUM, 32), // enum clingo_weight_constraint_type_e
-/* 1310 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 23), // int64_t
-/* 1311 */ _CFFI_OP(_CFFI_OP_POINTER, 1161), // unsigned int(*)(void *)
-/* 1312 */ _CFFI_OP(_CFFI_OP_POINTER, 1174), // void(*)(clingo_propagate_control_t const *, int32_t const *, size_t, void *)
-/* 1313 */ _CFFI_OP(_CFFI_OP_POINTER, 1210), // void(*)(void *)
-/* 1314 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 0), // void
+/* 1193 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
+/* 1194 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
+/* 1195 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1196 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(int, char const *)
+/* 1197 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 1198 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 1199 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1200 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(int, char const *, void *)
+/* 1201 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 1202 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 1203 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1204 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1205 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(int, uint64_t *)
+/* 1206 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 1207 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 1208 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1209 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(uint64_t *)
+/* 1210 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 1211 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1212 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(void *)
+/* 1213 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1214 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1215 */ _CFFI_OP(_CFFI_OP_POINTER, 0), // _Bool(*)(_Bool, uint32_t const *, size_t, int32_t const *, size_t, void *)
+/* 1216 */ _CFFI_OP(_CFFI_OP_POINTER, 8), // _Bool(*)(_Bool, uint32_t const *, size_t, int32_t, clingo_weighted_literal_t const *, size_t, void *)
+/* 1217 */ _CFFI_OP(_CFFI_OP_POINTER, 17), // _Bool(*)(_Bool, void *)
+/* 1218 */ _CFFI_OP(_CFFI_OP_POINTER, 39), // _Bool(*)(char const *, _Bool *, void *)
+/* 1219 */ _CFFI_OP(_CFFI_OP_POINTER, 256), // _Bool(*)(clingo_ast_t const *, void *)
+/* 1220 */ _CFFI_OP(_CFFI_OP_POINTER, 443), // _Bool(*)(clingo_control_t *, char const * const *, size_t, void *)
+/* 1221 */ _CFFI_OP(_CFFI_OP_POINTER, 513), // _Bool(*)(clingo_control_t *, void *)
+/* 1222 */ _CFFI_OP(_CFFI_OP_POINTER, 542), // _Bool(*)(clingo_location_t *, char const *, void *)
+/* 1223 */ _CFFI_OP(_CFFI_OP_POINTER, 547), // _Bool(*)(clingo_location_t *, char const *, void *, size_t, void *, void *, void *)
+/* 1224 */ _CFFI_OP(_CFFI_OP_POINTER, 556), // _Bool(*)(clingo_location_t const *, char const *, uint64_t const *, size_t, _Bool(*)(uint64_t const *, size_t, void *), void *, void *)
+/* 1225 */ _CFFI_OP(_CFFI_OP_POINTER, 574), // _Bool(*)(clingo_location_t const *, char const *, void *)
+/* 1226 */ _CFFI_OP(_CFFI_OP_POINTER, 588), // _Bool(*)(clingo_model_t const *, _Bool(*)(void *), void *, void *)
+/* 1227 */ _CFFI_OP(_CFFI_OP_POINTER, 667), // _Bool(*)(clingo_options_t *, void *)
+/* 1228 */ _CFFI_OP(_CFFI_OP_POINTER, 693), // _Bool(*)(clingo_propagate_control_t *, int32_t const *, size_t, void *)
+/* 1229 */ _CFFI_OP(_CFFI_OP_POINTER, 703), // _Bool(*)(clingo_propagate_control_t *, void *)
+/* 1230 */ _CFFI_OP(_CFFI_OP_POINTER, 751), // _Bool(*)(clingo_propagate_init_t *, void *)
+/* 1231 */ _CFFI_OP(_CFFI_OP_POINTER, 951), // _Bool(*)(int, clingo_ast_t * *, ...)
+/* 1232 */ _CFFI_OP(_CFFI_OP_POINTER, 955), // _Bool(*)(int, int, int32_t const *, size_t, void *)
+/* 1233 */ _CFFI_OP(_CFFI_OP_POINTER, 962), // _Bool(*)(int32_t const *, size_t, void *)
+/* 1234 */ _CFFI_OP(_CFFI_OP_POINTER, 967), // _Bool(*)(int32_t, clingo_weighted_literal_t const *, size_t, void *)
+/* 1235 */ _CFFI_OP(_CFFI_OP_POINTER, 973), // _Bool(*)(uint32_t const *, size_t, void *)
+/* 1236 */ _CFFI_OP(_CFFI_OP_POINTER, 978), // _Bool(*)(uint32_t, char const *, void *)
+/* 1237 */ _CFFI_OP(_CFFI_OP_POINTER, 983), // _Bool(*)(uint32_t, clingo_assignment_t const *, int32_t, void *, int32_t *)
+/* 1238 */ _CFFI_OP(_CFFI_OP_POINTER, 990), // _Bool(*)(uint32_t, int, int, unsigned int, int32_t const *, size_t, void *)
+/* 1239 */ _CFFI_OP(_CFFI_OP_POINTER, 999), // _Bool(*)(uint32_t, int, uint32_t const *, size_t, void *)
+/* 1240 */ _CFFI_OP(_CFFI_OP_POINTER, 1006), // _Bool(*)(uint32_t, int, void *)
+/* 1241 */ _CFFI_OP(_CFFI_OP_POINTER, 1011), // _Bool(*)(uint32_t, uint32_t const *, size_t, int32_t const *, size_t, void *)
+/* 1242 */ _CFFI_OP(_CFFI_OP_POINTER, 1019), // _Bool(*)(uint32_t, uint32_t, uint32_t const *, size_t, uint32_t, uint32_t, void *)
+/* 1243 */ _CFFI_OP(_CFFI_OP_POINTER, 1028), // _Bool(*)(uint32_t, uint32_t, uint32_t const *, size_t, void *)
+/* 1244 */ _CFFI_OP(_CFFI_OP_POINTER, 1060), // _Bool(*)(uint64_t, int32_t const *, size_t, void *)
+/* 1245 */ _CFFI_OP(_CFFI_OP_POINTER, 1070), // _Bool(*)(uint64_t, uint32_t, void *)
+/* 1246 */ _CFFI_OP(_CFFI_OP_POINTER, 1093), // _Bool(*)(void *, char const *, void *)
+/* 1247 */ _CFFI_OP(_CFFI_OP_POINTER, 1098), // _Bool(*)(void *, char const *, void *, size_t, void *, void *, void *)
+/* 1248 */ _CFFI_OP(_CFFI_OP_POINTER, 1107), // _Bool(*)(void *, void *)
+/* 1249 */ _CFFI_OP(_CFFI_OP_POINTER, 1120), // char const *(*)(void *)
+/* 1250 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 2), // char
+/* 1251 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 0), // clingo_application_t
+/* 1252 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 1), // clingo_assignment_t
+/* 1253 */ _CFFI_OP(_CFFI_OP_POINTER, 1254), // clingo_ast_argument_t const *
+/* 1254 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 3), // clingo_ast_argument_t
+/* 1255 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 4), // clingo_ast_attribute_names_t
+/* 1256 */ _CFFI_OP(_CFFI_OP_POINTER, 1257), // clingo_ast_constructor_t const *
+/* 1257 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 5), // clingo_ast_constructor_t
+/* 1258 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 6), // clingo_ast_constructors_t
+/* 1259 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 2), // clingo_ast_t
+/* 1260 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 7), // clingo_backend_t
+/* 1261 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 8), // clingo_configuration_t
+/* 1262 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 9), // clingo_control_t
+/* 1263 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 10), // clingo_ground_program_observer_t
+/* 1264 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 11), // clingo_location_t
+/* 1265 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 12), // clingo_model_t
+/* 1266 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 13), // clingo_options_t
+/* 1267 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 14), // clingo_part_t
+/* 1268 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 15), // clingo_program_builder_t
+/* 1269 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 16), // clingo_propagate_control_t
+/* 1270 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 17), // clingo_propagate_init_t
+/* 1271 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 18), // clingo_propagator_t
+/* 1272 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 19), // clingo_script_t
+/* 1273 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 20), // clingo_solve_control_t
+/* 1274 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 21), // clingo_solve_handle_t
+/* 1275 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 22), // clingo_statistics_t
+/* 1276 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 23), // clingo_symbolic_atoms_t
+/* 1277 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 24), // clingo_theory_atoms_t
+/* 1278 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 25), // clingo_weighted_literal_t
+/* 1279 */ _CFFI_OP(_CFFI_OP_ENUM, 0), // enum clingo_ast_aggregate_function_e
+/* 1280 */ _CFFI_OP(_CFFI_OP_ENUM, 1), // enum clingo_ast_attribute_e
+/* 1281 */ _CFFI_OP(_CFFI_OP_ENUM, 2), // enum clingo_ast_attribute_type_e
+/* 1282 */ _CFFI_OP(_CFFI_OP_ENUM, 3), // enum clingo_ast_binary_operator_e
+/* 1283 */ _CFFI_OP(_CFFI_OP_ENUM, 4), // enum clingo_ast_comparison_operator_e
+/* 1284 */ _CFFI_OP(_CFFI_OP_ENUM, 5), // enum clingo_ast_sign_e
+/* 1285 */ _CFFI_OP(_CFFI_OP_ENUM, 6), // enum clingo_ast_theory_atom_definition_type_e
+/* 1286 */ _CFFI_OP(_CFFI_OP_ENUM, 7), // enum clingo_ast_theory_operator_type_e
+/* 1287 */ _CFFI_OP(_CFFI_OP_ENUM, 8), // enum clingo_ast_theory_sequence_type_e
+/* 1288 */ _CFFI_OP(_CFFI_OP_ENUM, 9), // enum clingo_ast_type_e
+/* 1289 */ _CFFI_OP(_CFFI_OP_ENUM, 10), // enum clingo_ast_unary_operator_e
+/* 1290 */ _CFFI_OP(_CFFI_OP_ENUM, 11), // enum clingo_ast_unpool_type_e
+/* 1291 */ _CFFI_OP(_CFFI_OP_ENUM, 12), // enum clingo_clause_type_e
+/* 1292 */ _CFFI_OP(_CFFI_OP_ENUM, 13), // enum clingo_comment_type_e
+/* 1293 */ _CFFI_OP(_CFFI_OP_ENUM, 14), // enum clingo_configuration_type_e
+/* 1294 */ _CFFI_OP(_CFFI_OP_ENUM, 15), // enum clingo_consequence_e
+/* 1295 */ _CFFI_OP(_CFFI_OP_ENUM, 16), // enum clingo_error_e
+/* 1296 */ _CFFI_OP(_CFFI_OP_ENUM, 17), // enum clingo_external_type_e
+/* 1297 */ _CFFI_OP(_CFFI_OP_ENUM, 18), // enum clingo_heuristic_type_e
+/* 1298 */ _CFFI_OP(_CFFI_OP_ENUM, 19), // enum clingo_model_type_e
+/* 1299 */ _CFFI_OP(_CFFI_OP_ENUM, 20), // enum clingo_propagator_check_mode_e
+/* 1300 */ _CFFI_OP(_CFFI_OP_ENUM, 21), // enum clingo_propagator_undo_mode_e
+/* 1301 */ _CFFI_OP(_CFFI_OP_ENUM, 22), // enum clingo_show_type_e
+/* 1302 */ _CFFI_OP(_CFFI_OP_ENUM, 23), // enum clingo_solve_event_type_e
+/* 1303 */ _CFFI_OP(_CFFI_OP_ENUM, 24), // enum clingo_solve_mode_e
+/* 1304 */ _CFFI_OP(_CFFI_OP_ENUM, 25), // enum clingo_solve_result_e
+/* 1305 */ _CFFI_OP(_CFFI_OP_ENUM, 26), // enum clingo_statistics_type_e
+/* 1306 */ _CFFI_OP(_CFFI_OP_ENUM, 27), // enum clingo_symbol_type_e
+/* 1307 */ _CFFI_OP(_CFFI_OP_ENUM, 28), // enum clingo_theory_sequence_type_e
+/* 1308 */ _CFFI_OP(_CFFI_OP_ENUM, 29), // enum clingo_theory_term_type_e
+/* 1309 */ _CFFI_OP(_CFFI_OP_ENUM, 30), // enum clingo_truth_value_e
+/* 1310 */ _CFFI_OP(_CFFI_OP_ENUM, 31), // enum clingo_warning_e
+/* 1311 */ _CFFI_OP(_CFFI_OP_ENUM, 32), // enum clingo_weight_constraint_type_e
+/* 1312 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 23), // int64_t
+/* 1313 */ _CFFI_OP(_CFFI_OP_POINTER, 1163), // unsigned int(*)(void *)
+/* 1314 */ _CFFI_OP(_CFFI_OP_POINTER, 1176), // void(*)(clingo_propagate_control_t const *, int32_t const *, size_t, void *)
+/* 1315 */ _CFFI_OP(_CFFI_OP_POINTER, 1212), // void(*)(void *)
+/* 1316 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 0), // void
 };
 
 static int _cffi_const_clingo_ast_aggregate_function_count(unsigned long long *o)
@@ -3290,17 +3292,17 @@ static int _cffi_const_clingo_theory_sequence_type_tuple(unsigned long long *o)
   return n;
 }
 
-static int _cffi_const_clingo_theory_sequence_type_list(unsigned long long *o)
-{
-  int n = (clingo_theory_sequence_type_list) <= 0;
-  *o = (unsigned long long)((clingo_theory_sequence_type_list) | 0);  /* check that clingo_theory_sequence_type_list is an integer */
-  return n;
-}
-
 static int _cffi_const_clingo_theory_sequence_type_set(unsigned long long *o)
 {
   int n = (clingo_theory_sequence_type_set) <= 0;
   *o = (unsigned long long)((clingo_theory_sequence_type_set) | 0);  /* check that clingo_theory_sequence_type_set is an integer */
+  return n;
+}
+
+static int _cffi_const_clingo_theory_sequence_type_list(unsigned long long *o)
+{
+  int n = (clingo_theory_sequence_type_list) <= 0;
+  *o = (unsigned long long)((clingo_theory_sequence_type_list) | 0);  /* check that clingo_theory_sequence_type_list is an integer */
   return n;
 }
 
@@ -7817,9 +7819,9 @@ _cffi_f_clingo_backend_rule(PyObject *self, PyObject *args)
 #  define _cffi_f_clingo_backend_rule _cffi_d_clingo_backend_rule
 #endif
 
-static _Bool _cffi_d_clingo_backend_theory_atom(clingo_backend_t * x0, uint32_t x1, uint32_t x2, uint32_t const * x3, size_t x4)
+static _Bool _cffi_d_clingo_backend_theory_atom(clingo_backend_t * x0, uint32_t x1, uint32_t x2, uint32_t const * x3, size_t x4, uint32_t * x5)
 {
-  return clingo_backend_theory_atom(x0, x1, x2, x3, x4);
+  return clingo_backend_theory_atom(x0, x1, x2, x3, x4, x5);
 }
 #ifndef PYPY_VERSION
 static PyObject *
@@ -7830,6 +7832,7 @@ _cffi_f_clingo_backend_theory_atom(PyObject *self, PyObject *args)
   uint32_t x2;
   uint32_t const * x3;
   size_t x4;
+  uint32_t * x5;
   Py_ssize_t datasize;
   struct _cffi_freeme_s *large_args_free = NULL;
   _Bool result;
@@ -7839,8 +7842,9 @@ _cffi_f_clingo_backend_theory_atom(PyObject *self, PyObject *args)
   PyObject *arg2;
   PyObject *arg3;
   PyObject *arg4;
+  PyObject *arg5;
 
-  if (!PyArg_UnpackTuple(args, "clingo_backend_theory_atom", 5, 5, &arg0, &arg1, &arg2, &arg3, &arg4))
+  if (!PyArg_UnpackTuple(args, "clingo_backend_theory_atom", 6, 6, &arg0, &arg1, &arg2, &arg3, &arg4, &arg5))
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
@@ -7873,9 +7877,18 @@ _cffi_f_clingo_backend_theory_atom(PyObject *self, PyObject *args)
   if (x4 == (size_t)-1 && PyErr_Occurred())
     return NULL;
 
+  datasize = _cffi_prepare_pointer_call_argument(
+      _cffi_type(115), arg5, (char **)&x5);
+  if (datasize != 0) {
+    x5 = ((size_t)datasize) <= 640 ? (uint32_t *)alloca((size_t)datasize) : NULL;
+    if (_cffi_convert_array_argument(_cffi_type(115), arg5, (char **)&x5,
+            datasize, &large_args_free) < 0)
+      return NULL;
+  }
+
   Py_BEGIN_ALLOW_THREADS
   _cffi_restore_errno();
-  { result = clingo_backend_theory_atom(x0, x1, x2, x3, x4); }
+  { result = clingo_backend_theory_atom(x0, x1, x2, x3, x4, x5); }
   _cffi_save_errno();
   Py_END_ALLOW_THREADS
 
@@ -7888,9 +7901,9 @@ _cffi_f_clingo_backend_theory_atom(PyObject *self, PyObject *args)
 #  define _cffi_f_clingo_backend_theory_atom _cffi_d_clingo_backend_theory_atom
 #endif
 
-static _Bool _cffi_d_clingo_backend_theory_atom_with_guard(clingo_backend_t * x0, uint32_t x1, uint32_t x2, uint32_t const * x3, size_t x4, char const * x5, uint32_t x6)
+static _Bool _cffi_d_clingo_backend_theory_atom_with_guard(clingo_backend_t * x0, uint32_t x1, uint32_t x2, uint32_t const * x3, size_t x4, char const * x5, uint32_t x6, uint32_t * x7)
 {
-  return clingo_backend_theory_atom_with_guard(x0, x1, x2, x3, x4, x5, x6);
+  return clingo_backend_theory_atom_with_guard(x0, x1, x2, x3, x4, x5, x6, x7);
 }
 #ifndef PYPY_VERSION
 static PyObject *
@@ -7903,6 +7916,7 @@ _cffi_f_clingo_backend_theory_atom_with_guard(PyObject *self, PyObject *args)
   size_t x4;
   char const * x5;
   uint32_t x6;
+  uint32_t * x7;
   Py_ssize_t datasize;
   struct _cffi_freeme_s *large_args_free = NULL;
   _Bool result;
@@ -7914,8 +7928,9 @@ _cffi_f_clingo_backend_theory_atom_with_guard(PyObject *self, PyObject *args)
   PyObject *arg4;
   PyObject *arg5;
   PyObject *arg6;
+  PyObject *arg7;
 
-  if (!PyArg_UnpackTuple(args, "clingo_backend_theory_atom_with_guard", 7, 7, &arg0, &arg1, &arg2, &arg3, &arg4, &arg5, &arg6))
+  if (!PyArg_UnpackTuple(args, "clingo_backend_theory_atom_with_guard", 8, 8, &arg0, &arg1, &arg2, &arg3, &arg4, &arg5, &arg6, &arg7))
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
@@ -7961,9 +7976,18 @@ _cffi_f_clingo_backend_theory_atom_with_guard(PyObject *self, PyObject *args)
   if (x6 == (uint32_t)-1 && PyErr_Occurred())
     return NULL;
 
+  datasize = _cffi_prepare_pointer_call_argument(
+      _cffi_type(115), arg7, (char **)&x7);
+  if (datasize != 0) {
+    x7 = ((size_t)datasize) <= 640 ? (uint32_t *)alloca((size_t)datasize) : NULL;
+    if (_cffi_convert_array_argument(_cffi_type(115), arg7, (char **)&x7,
+            datasize, &large_args_free) < 0)
+      return NULL;
+  }
+
   Py_BEGIN_ALLOW_THREADS
   _cffi_restore_errno();
-  { result = clingo_backend_theory_atom_with_guard(x0, x1, x2, x3, x4, x5, x6); }
+  { result = clingo_backend_theory_atom_with_guard(x0, x1, x2, x3, x4, x5, x6, x7); }
   _cffi_save_errno();
   Py_END_ALLOW_THREADS
 
@@ -8515,10 +8539,10 @@ _cffi_f_clingo_configuration_array_at(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -8578,10 +8602,10 @@ _cffi_f_clingo_configuration_array_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -8637,10 +8661,10 @@ _cffi_f_clingo_configuration_description(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -8698,10 +8722,10 @@ _cffi_f_clingo_configuration_map_at(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -8768,10 +8792,10 @@ _cffi_f_clingo_configuration_map_has_subkey(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -8836,10 +8860,10 @@ _cffi_f_clingo_configuration_map_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -8897,10 +8921,10 @@ _cffi_f_clingo_configuration_map_subkey_name(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -8958,10 +8982,10 @@ _cffi_f_clingo_configuration_root(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9013,10 +9037,10 @@ _cffi_f_clingo_configuration_type(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9026,10 +9050,10 @@ _cffi_f_clingo_configuration_type(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(432), arg2, (char **)&x2);
+      _cffi_type(434), arg2, (char **)&x2);
   if (datasize != 0) {
     x2 = ((size_t)datasize) <= 640 ? (unsigned int *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(432), arg2, (char **)&x2,
+    if (_cffi_convert_array_argument(_cffi_type(434), arg2, (char **)&x2,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9074,10 +9098,10 @@ _cffi_f_clingo_configuration_value_get(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9137,10 +9161,10 @@ _cffi_f_clingo_configuration_value_get_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9196,10 +9220,10 @@ _cffi_f_clingo_configuration_value_is_assigned(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9255,10 +9279,10 @@ _cffi_f_clingo_configuration_value_set(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(376), arg0, (char **)&x0);
+      _cffi_type(378), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(376), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(378), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9456,10 +9480,10 @@ _cffi_f_clingo_control_backend(PyObject *self, PyObject *args)
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(460), arg1, (char **)&x1);
+      _cffi_type(462), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_backend_t * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(460), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(462), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9509,10 +9533,10 @@ _cffi_f_clingo_control_clasp_facade(PyObject *self, PyObject *args)
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(509), arg1, (char **)&x1);
+      _cffi_type(511), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (void * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(509), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(511), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9600,10 +9624,10 @@ _cffi_f_clingo_control_configuration(PyObject *self, PyObject *args)
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(464), arg1, (char **)&x1);
+      _cffi_type(466), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_configuration_t * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(464), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(466), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9682,10 +9706,10 @@ _cffi_f_clingo_control_get_const(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(516), arg0, (char **)&x0);
+      _cffi_type(518), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_control_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(516), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(518), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9835,10 +9859,10 @@ _cffi_f_clingo_control_ground(PyObject *self, PyObject *args)
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(474), arg1, (char **)&x1);
+      _cffi_type(476), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_part_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(474), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(476), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9847,7 +9871,7 @@ _cffi_f_clingo_control_ground(PyObject *self, PyObject *args)
   if (x2 == (size_t)-1 && PyErr_Occurred())
     return NULL;
 
-  x3 = (_Bool(*)(clingo_location_t const *, char const *, uint64_t const *, size_t, void *, _Bool(*)(uint64_t const *, size_t, void *), void *))_cffi_to_c_pointer(arg3, _cffi_type(476));
+  x3 = (_Bool(*)(clingo_location_t const *, char const *, uint64_t const *, size_t, void *, _Bool(*)(uint64_t const *, size_t, void *), void *))_cffi_to_c_pointer(arg3, _cffi_type(478));
   if (x3 == (_Bool(*)(clingo_location_t const *, char const *, uint64_t const *, size_t, void *, _Bool(*)(uint64_t const *, size_t, void *), void *))NULL && PyErr_Occurred())
     return NULL;
 
@@ -9898,10 +9922,10 @@ _cffi_f_clingo_control_has_const(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(516), arg0, (char **)&x0);
+      _cffi_type(518), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_control_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(516), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(518), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9990,10 +10014,10 @@ _cffi_f_clingo_control_is_conflicting(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(516), arg0, (char **)&x0);
+      _cffi_type(518), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_control_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(516), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(518), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -10182,10 +10206,10 @@ _cffi_f_clingo_control_register_observer(PyObject *self, PyObject *args)
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(468), arg1, (char **)&x1);
+      _cffi_type(470), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_ground_program_observer_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(468), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(470), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -10252,10 +10276,10 @@ _cffi_f_clingo_control_register_propagator(PyObject *self, PyObject *args)
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(485), arg1, (char **)&x1);
+      _cffi_type(487), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_propagator_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(485), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(487), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -10488,7 +10512,7 @@ _cffi_f_clingo_control_solve(PyObject *self, PyObject *args)
   if (x3 == (size_t)-1 && PyErr_Occurred())
     return NULL;
 
-  x4 = (_Bool(*)(unsigned int, void *, void *, _Bool *))_cffi_to_c_pointer(arg4, _cffi_type(503));
+  x4 = (_Bool(*)(unsigned int, void *, void *, _Bool *))_cffi_to_c_pointer(arg4, _cffi_type(505));
   if (x4 == (_Bool(*)(unsigned int, void *, void *, _Bool *))NULL && PyErr_Occurred())
     return NULL;
 
@@ -10502,10 +10526,10 @@ _cffi_f_clingo_control_solve(PyObject *self, PyObject *args)
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(505), arg6, (char **)&x6);
+      _cffi_type(507), arg6, (char **)&x6);
   if (datasize != 0) {
     x6 = ((size_t)datasize) <= 640 ? (clingo_solve_handle_t * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(505), arg6, (char **)&x6,
+    if (_cffi_convert_array_argument(_cffi_type(507), arg6, (char **)&x6,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -10546,19 +10570,19 @@ _cffi_f_clingo_control_statistics(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(516), arg0, (char **)&x0);
+      _cffi_type(518), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_control_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(516), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(518), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(530), arg1, (char **)&x1);
+      _cffi_type(532), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_statistics_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(530), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(532), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -10599,19 +10623,19 @@ _cffi_f_clingo_control_symbolic_atoms(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(516), arg0, (char **)&x0);
+      _cffi_type(518), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_control_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(516), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(518), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(534), arg1, (char **)&x1);
+      _cffi_type(536), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(534), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(536), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -10652,19 +10676,19 @@ _cffi_f_clingo_control_theory_atoms(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(516), arg0, (char **)&x0);
+      _cffi_type(518), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_control_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(516), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(518), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(538), arg1, (char **)&x1);
+      _cffi_type(540), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(538), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(540), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -10791,10 +10815,10 @@ _cffi_f_clingo_main(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(1130), arg0, (char **)&x0);
+      _cffi_type(1132), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_application_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(1130), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(1132), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -10859,10 +10883,10 @@ _cffi_f_clingo_model_contains(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -10916,19 +10940,19 @@ _cffi_f_clingo_model_context(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(594), arg1, (char **)&x1);
+      _cffi_type(596), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_solve_control_t * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(594), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(596), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -10971,19 +10995,19 @@ _cffi_f_clingo_model_cost(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(617), arg1, (char **)&x1);
+      _cffi_type(619), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (int64_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(617), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(619), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11028,10 +11052,10 @@ _cffi_f_clingo_model_cost_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11083,10 +11107,10 @@ _cffi_f_clingo_model_extend(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(578), arg0, (char **)&x0);
+      _cffi_type(580), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(578), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(580), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11142,10 +11166,10 @@ _cffi_f_clingo_model_is_consequence(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11201,10 +11225,10 @@ _cffi_f_clingo_model_is_true(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11258,10 +11282,10 @@ _cffi_f_clingo_model_number(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11311,10 +11335,10 @@ _cffi_f_clingo_model_optimality_proven(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11366,10 +11390,10 @@ _cffi_f_clingo_model_priority(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11427,10 +11451,10 @@ _cffi_f_clingo_model_symbols(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11490,10 +11514,10 @@ _cffi_f_clingo_model_symbols_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11547,10 +11571,10 @@ _cffi_f_clingo_model_thread_id(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11600,10 +11624,10 @@ _cffi_f_clingo_model_type(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11665,10 +11689,10 @@ _cffi_f_clingo_options_add(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(649), arg0, (char **)&x0);
+      _cffi_type(651), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_options_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(649), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(651), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11700,7 +11724,7 @@ _cffi_f_clingo_options_add(PyObject *self, PyObject *args)
       return NULL;
   }
 
-  x4 = (_Bool(*)(char const *, void *))_cffi_to_c_pointer(arg4, _cffi_type(660));
+  x4 = (_Bool(*)(char const *, void *))_cffi_to_c_pointer(arg4, _cffi_type(662));
   if (x4 == (_Bool(*)(char const *, void *))NULL && PyErr_Occurred())
     return NULL;
 
@@ -11768,10 +11792,10 @@ _cffi_f_clingo_options_add_flag(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(649), arg0, (char **)&x0);
+      _cffi_type(651), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_options_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(649), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(651), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11924,10 +11948,10 @@ _cffi_f_clingo_program_builder_add(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(670), arg0, (char **)&x0);
+      _cffi_type(672), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_program_builder_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(670), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(672), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11971,10 +11995,10 @@ _cffi_f_clingo_program_builder_begin(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(670), arg0, (char **)&x0);
+      _cffi_type(672), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_program_builder_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(670), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(672), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12009,10 +12033,10 @@ _cffi_f_clingo_program_builder_end(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(670), arg0, (char **)&x0);
+      _cffi_type(672), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_program_builder_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(670), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(672), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12062,10 +12086,10 @@ _cffi_f_clingo_program_builder_init(PyObject *self, PyObject *args)
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(481), arg1, (char **)&x1);
+      _cffi_type(483), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_program_builder_t * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(481), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(483), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12112,10 +12136,10 @@ _cffi_f_clingo_propagate_control_add_clause(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(677), arg0, (char **)&x0);
+      _cffi_type(679), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_control_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(677), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(679), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12182,10 +12206,10 @@ _cffi_f_clingo_propagate_control_add_literal(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(677), arg0, (char **)&x0);
+      _cffi_type(679), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_control_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(677), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(679), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12235,10 +12259,10 @@ _cffi_f_clingo_propagate_control_add_watch(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(677), arg0, (char **)&x0);
+      _cffi_type(679), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_control_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(677), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(679), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12277,10 +12301,10 @@ _cffi_f_clingo_propagate_control_assignment(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(706), arg0, (char **)&x0);
+      _cffi_type(708), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_control_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(706), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(708), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12321,10 +12345,10 @@ _cffi_f_clingo_propagate_control_has_watch(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(706), arg0, (char **)&x0);
+      _cffi_type(708), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_control_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(706), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(708), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12369,10 +12393,10 @@ _cffi_f_clingo_propagate_control_propagate(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(677), arg0, (char **)&x0);
+      _cffi_type(679), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_control_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(677), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(679), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12420,10 +12444,10 @@ _cffi_f_clingo_propagate_control_remove_watch(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(677), arg0, (char **)&x0);
+      _cffi_type(679), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_control_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(677), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(679), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12462,10 +12486,10 @@ _cffi_f_clingo_propagate_control_thread_id(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(706), arg0, (char **)&x0);
+      _cffi_type(708), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_control_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(706), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(708), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12510,10 +12534,10 @@ _cffi_f_clingo_propagate_init_add_clause(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12578,10 +12602,10 @@ _cffi_f_clingo_propagate_init_add_literal(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12639,10 +12663,10 @@ _cffi_f_clingo_propagate_init_add_minimize(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12695,10 +12719,10 @@ _cffi_f_clingo_propagate_init_add_watch(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12745,10 +12769,10 @@ _cffi_f_clingo_propagate_init_add_watch_to_thread(PyObject *self, PyObject *args
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12809,10 +12833,10 @@ _cffi_f_clingo_propagate_init_add_weight_constraint(PyObject *self, PyObject *ar
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12885,10 +12909,10 @@ _cffi_f_clingo_propagate_init_assignment(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(754), arg0, (char **)&x0);
+      _cffi_type(756), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(754), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(756), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12929,10 +12953,10 @@ _cffi_f_clingo_propagate_init_freeze_literal(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12971,10 +12995,10 @@ _cffi_f_clingo_propagate_init_get_check_mode(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(754), arg0, (char **)&x0);
+      _cffi_type(756), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(754), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(756), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13009,10 +13033,10 @@ _cffi_f_clingo_propagate_init_get_undo_mode(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(754), arg0, (char **)&x0);
+      _cffi_type(756), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(754), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(756), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13047,10 +13071,10 @@ _cffi_f_clingo_propagate_init_number_of_threads(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(754), arg0, (char **)&x0);
+      _cffi_type(756), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(754), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(756), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13091,10 +13115,10 @@ _cffi_f_clingo_propagate_init_propagate(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13144,10 +13168,10 @@ _cffi_f_clingo_propagate_init_remove_watch(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13194,10 +13218,10 @@ _cffi_f_clingo_propagate_init_remove_watch_from_thread(PyObject *self, PyObject 
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13244,10 +13268,10 @@ _cffi_f_clingo_propagate_init_set_check_mode(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13290,10 +13314,10 @@ _cffi_f_clingo_propagate_init_set_undo_mode(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13340,10 +13364,10 @@ _cffi_f_clingo_propagate_init_solver_literal(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(754), arg0, (char **)&x0);
+      _cffi_type(756), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(754), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(756), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13397,19 +13421,19 @@ _cffi_f_clingo_propagate_init_symbolic_atoms(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(754), arg0, (char **)&x0);
+      _cffi_type(756), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(754), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(756), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(534), arg1, (char **)&x1);
+      _cffi_type(536), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(534), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(536), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13450,19 +13474,19 @@ _cffi_f_clingo_propagate_init_theory_atoms(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(754), arg0, (char **)&x0);
+      _cffi_type(756), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(754), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(756), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(538), arg1, (char **)&x1);
+      _cffi_type(540), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(538), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(540), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13948,10 +13972,10 @@ _cffi_f_clingo_solve_control_add_clause(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(767), arg0, (char **)&x0);
+      _cffi_type(769), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_solve_control_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(767), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(769), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14005,19 +14029,19 @@ _cffi_f_clingo_solve_control_symbolic_atoms(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(772), arg0, (char **)&x0);
+      _cffi_type(774), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_solve_control_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(772), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(774), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(534), arg1, (char **)&x1);
+      _cffi_type(536), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(534), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(536), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14052,10 +14076,10 @@ _cffi_f_clingo_solve_handle_cancel(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(776), arg0, (char **)&x0);
+      _cffi_type(778), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_solve_handle_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(776), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(778), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14090,10 +14114,10 @@ _cffi_f_clingo_solve_handle_close(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(776), arg0, (char **)&x0);
+      _cffi_type(778), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_solve_handle_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(776), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(778), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14136,19 +14160,19 @@ _cffi_f_clingo_solve_handle_core(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(776), arg0, (char **)&x0);
+      _cffi_type(778), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_solve_handle_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(776), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(778), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(784), arg1, (char **)&x1);
+      _cffi_type(786), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (int32_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(784), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(786), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14198,19 +14222,19 @@ _cffi_f_clingo_solve_handle_get(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(776), arg0, (char **)&x0);
+      _cffi_type(778), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_solve_handle_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(776), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(778), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(432), arg1, (char **)&x1);
+      _cffi_type(434), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (unsigned int *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(432), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(434), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14251,19 +14275,19 @@ _cffi_f_clingo_solve_handle_model(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(776), arg0, (char **)&x0);
+      _cffi_type(778), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_solve_handle_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(776), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(778), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(780), arg1, (char **)&x1);
+      _cffi_type(782), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_model_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(780), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(782), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14298,10 +14322,10 @@ _cffi_f_clingo_solve_handle_resume(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(776), arg0, (char **)&x0);
+      _cffi_type(778), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_solve_handle_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(776), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(778), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14342,10 +14366,10 @@ _cffi_f_clingo_solve_handle_wait(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(776), arg0, (char **)&x0);
+      _cffi_type(778), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_solve_handle_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(776), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(778), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14403,10 +14427,10 @@ _cffi_f_clingo_statistics_array_at(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(810), arg0, (char **)&x0);
+      _cffi_type(812), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(810), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(812), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14468,10 +14492,10 @@ _cffi_f_clingo_statistics_array_push(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(792), arg0, (char **)&x0);
+      _cffi_type(794), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(792), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(794), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14531,10 +14555,10 @@ _cffi_f_clingo_statistics_array_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(810), arg0, (char **)&x0);
+      _cffi_type(812), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(810), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(812), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14594,10 +14618,10 @@ _cffi_f_clingo_statistics_map_add_subkey(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(792), arg0, (char **)&x0);
+      _cffi_type(794), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(792), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(794), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14668,10 +14692,10 @@ _cffi_f_clingo_statistics_map_at(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(810), arg0, (char **)&x0);
+      _cffi_type(812), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(810), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(812), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14738,10 +14762,10 @@ _cffi_f_clingo_statistics_map_has_subkey(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(810), arg0, (char **)&x0);
+      _cffi_type(812), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(810), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(812), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14806,10 +14830,10 @@ _cffi_f_clingo_statistics_map_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(810), arg0, (char **)&x0);
+      _cffi_type(812), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(810), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(812), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14867,10 +14891,10 @@ _cffi_f_clingo_statistics_map_subkey_name(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(810), arg0, (char **)&x0);
+      _cffi_type(812), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(810), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(812), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14928,10 +14952,10 @@ _cffi_f_clingo_statistics_root(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(810), arg0, (char **)&x0);
+      _cffi_type(812), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(810), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(812), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14983,10 +15007,10 @@ _cffi_f_clingo_statistics_type(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(810), arg0, (char **)&x0);
+      _cffi_type(812), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(810), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(812), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -15042,10 +15066,10 @@ _cffi_f_clingo_statistics_value_get(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(810), arg0, (char **)&x0);
+      _cffi_type(812), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(810), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(812), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -15055,10 +15079,10 @@ _cffi_f_clingo_statistics_value_get(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(828), arg2, (char **)&x2);
+      _cffi_type(830), arg2, (char **)&x2);
   if (datasize != 0) {
     x2 = ((size_t)datasize) <= 640 ? (double *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(828), arg2, (char **)&x2,
+    if (_cffi_convert_array_argument(_cffi_type(830), arg2, (char **)&x2,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -15101,10 +15125,10 @@ _cffi_f_clingo_statistics_value_set(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(792), arg0, (char **)&x0);
+      _cffi_type(794), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(792), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(794), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -15159,10 +15183,10 @@ _cffi_f_clingo_symbol_arguments(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(1075), arg1, (char **)&x1);
+      _cffi_type(1077), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (uint64_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(1075), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(1077), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16002,10 +16026,10 @@ _cffi_f_clingo_symbolic_atoms_begin(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16064,10 +16088,10 @@ _cffi_f_clingo_symbolic_atoms_end(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16119,10 +16143,10 @@ _cffi_f_clingo_symbolic_atoms_find(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16178,10 +16202,10 @@ _cffi_f_clingo_symbolic_atoms_is_external(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16237,10 +16261,10 @@ _cffi_f_clingo_symbolic_atoms_is_fact(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16296,10 +16320,10 @@ _cffi_f_clingo_symbolic_atoms_is_valid(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16357,10 +16381,10 @@ _cffi_f_clingo_symbolic_atoms_iterator_is_equal_to(PyObject *self, PyObject *arg
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16420,10 +16444,10 @@ _cffi_f_clingo_symbolic_atoms_literal(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16479,10 +16503,10 @@ _cffi_f_clingo_symbolic_atoms_next(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16538,10 +16562,10 @@ _cffi_f_clingo_symbolic_atoms_signatures(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16595,10 +16619,10 @@ _cffi_f_clingo_symbolic_atoms_signatures_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16648,10 +16672,10 @@ _cffi_f_clingo_symbolic_atoms_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16703,10 +16727,10 @@ _cffi_f_clingo_symbolic_atoms_symbol(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16764,10 +16788,10 @@ _cffi_f_clingo_theory_atoms_atom_elements(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16777,10 +16801,10 @@ _cffi_f_clingo_theory_atoms_atom_elements(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(946), arg2, (char **)&x2);
+      _cffi_type(948), arg2, (char **)&x2);
   if (datasize != 0) {
     x2 = ((size_t)datasize) <= 640 ? (uint32_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(946), arg2, (char **)&x2,
+    if (_cffi_convert_array_argument(_cffi_type(948), arg2, (char **)&x2,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16834,10 +16858,10 @@ _cffi_f_clingo_theory_atoms_atom_guard(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16902,10 +16926,10 @@ _cffi_f_clingo_theory_atoms_atom_has_guard(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16961,10 +16985,10 @@ _cffi_f_clingo_theory_atoms_atom_literal(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17020,10 +17044,10 @@ _cffi_f_clingo_theory_atoms_atom_term(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17081,10 +17105,10 @@ _cffi_f_clingo_theory_atoms_atom_to_string(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17144,10 +17168,10 @@ _cffi_f_clingo_theory_atoms_atom_to_string_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17205,10 +17229,10 @@ _cffi_f_clingo_theory_atoms_element_condition(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17218,10 +17242,10 @@ _cffi_f_clingo_theory_atoms_element_condition(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(784), arg2, (char **)&x2);
+      _cffi_type(786), arg2, (char **)&x2);
   if (datasize != 0) {
     x2 = ((size_t)datasize) <= 640 ? (int32_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(784), arg2, (char **)&x2,
+    if (_cffi_convert_array_argument(_cffi_type(786), arg2, (char **)&x2,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17273,10 +17297,10 @@ _cffi_f_clingo_theory_atoms_element_condition_id(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17334,10 +17358,10 @@ _cffi_f_clingo_theory_atoms_element_to_string(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17397,10 +17421,10 @@ _cffi_f_clingo_theory_atoms_element_to_string_size(PyObject *self, PyObject *arg
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17458,10 +17482,10 @@ _cffi_f_clingo_theory_atoms_element_tuple(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17471,10 +17495,10 @@ _cffi_f_clingo_theory_atoms_element_tuple(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(946), arg2, (char **)&x2);
+      _cffi_type(948), arg2, (char **)&x2);
   if (datasize != 0) {
     x2 = ((size_t)datasize) <= 640 ? (uint32_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(946), arg2, (char **)&x2,
+    if (_cffi_convert_array_argument(_cffi_type(948), arg2, (char **)&x2,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17524,10 +17548,10 @@ _cffi_f_clingo_theory_atoms_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17581,10 +17605,10 @@ _cffi_f_clingo_theory_atoms_term_arguments(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17594,10 +17618,10 @@ _cffi_f_clingo_theory_atoms_term_arguments(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(946), arg2, (char **)&x2);
+      _cffi_type(948), arg2, (char **)&x2);
   if (datasize != 0) {
     x2 = ((size_t)datasize) <= 640 ? (uint32_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(946), arg2, (char **)&x2,
+    if (_cffi_convert_array_argument(_cffi_type(948), arg2, (char **)&x2,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17649,10 +17673,10 @@ _cffi_f_clingo_theory_atoms_term_name(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17708,10 +17732,10 @@ _cffi_f_clingo_theory_atoms_term_number(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17769,10 +17793,10 @@ _cffi_f_clingo_theory_atoms_term_to_string(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17832,10 +17856,10 @@ _cffi_f_clingo_theory_atoms_term_to_string_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17891,10 +17915,10 @@ _cffi_f_clingo_theory_atoms_term_type(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -18179,7 +18203,7 @@ static const struct _cffi_global_s _cffi_globals[] = {
   { "clingo_add_string", (void *)_cffi_f_clingo_add_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 58), (void *)_cffi_d_clingo_add_string },
   { "clingo_assignment_at", (void *)_cffi_f_clingo_assignment_at, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 117), (void *)_cffi_d_clingo_assignment_at },
   { "clingo_assignment_decision", (void *)_cffi_f_clingo_assignment_decision, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 126), (void *)_cffi_d_clingo_assignment_decision },
-  { "clingo_assignment_decision_level", (void *)_cffi_f_clingo_assignment_decision_level, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1152), (void *)_cffi_d_clingo_assignment_decision_level },
+  { "clingo_assignment_decision_level", (void *)_cffi_f_clingo_assignment_decision_level, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1154), (void *)_cffi_d_clingo_assignment_decision_level },
   { "clingo_assignment_has_conflict", (void *)_cffi_f_clingo_assignment_has_conflict, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 95), (void *)_cffi_d_clingo_assignment_has_conflict },
   { "clingo_assignment_has_literal", (void *)_cffi_f_clingo_assignment_has_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 98), (void *)_cffi_d_clingo_assignment_has_literal },
   { "clingo_assignment_is_false", (void *)_cffi_f_clingo_assignment_is_false, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 102), (void *)_cffi_d_clingo_assignment_is_false },
@@ -18187,14 +18211,14 @@ static const struct _cffi_global_s _cffi_globals[] = {
   { "clingo_assignment_is_total", (void *)_cffi_f_clingo_assignment_is_total, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 95), (void *)_cffi_d_clingo_assignment_is_total },
   { "clingo_assignment_is_true", (void *)_cffi_f_clingo_assignment_is_true, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 102), (void *)_cffi_d_clingo_assignment_is_true },
   { "clingo_assignment_level", (void *)_cffi_f_clingo_assignment_level, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 112), (void *)_cffi_d_clingo_assignment_level },
-  { "clingo_assignment_root_level", (void *)_cffi_f_clingo_assignment_root_level, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1152), (void *)_cffi_d_clingo_assignment_root_level },
-  { "clingo_assignment_size", (void *)_cffi_f_clingo_assignment_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1143), (void *)_cffi_d_clingo_assignment_size },
+  { "clingo_assignment_root_level", (void *)_cffi_f_clingo_assignment_root_level, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1154), (void *)_cffi_d_clingo_assignment_root_level },
+  { "clingo_assignment_size", (void *)_cffi_f_clingo_assignment_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1145), (void *)_cffi_d_clingo_assignment_size },
   { "clingo_assignment_trail_at", (void *)_cffi_f_clingo_assignment_trail_at, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 126), (void *)_cffi_d_clingo_assignment_trail_at },
   { "clingo_assignment_trail_begin", (void *)_cffi_f_clingo_assignment_trail_begin, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 131), (void *)_cffi_d_clingo_assignment_trail_begin },
   { "clingo_assignment_trail_end", (void *)_cffi_f_clingo_assignment_trail_end, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 131), (void *)_cffi_d_clingo_assignment_trail_end },
   { "clingo_assignment_trail_size", (void *)_cffi_f_clingo_assignment_trail_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 122), (void *)_cffi_d_clingo_assignment_trail_size },
   { "clingo_assignment_truth_value", (void *)_cffi_f_clingo_assignment_truth_value, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 107), (void *)_cffi_d_clingo_assignment_truth_value },
-  { "clingo_ast_acquire", (void *)_cffi_f_clingo_ast_acquire, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1164), (void *)_cffi_d_clingo_ast_acquire },
+  { "clingo_ast_acquire", (void *)_cffi_f_clingo_ast_acquire, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1166), (void *)_cffi_d_clingo_ast_acquire },
   { "clingo_ast_aggregate_function_count", (void *)_cffi_const_clingo_ast_aggregate_function_count, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_ast_aggregate_function_max", (void *)_cffi_const_clingo_ast_aggregate_function_max, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_ast_aggregate_function_min", (void *)_cffi_const_clingo_ast_aggregate_function_min, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
@@ -18285,7 +18309,7 @@ static const struct _cffi_global_s _cffi_globals[] = {
   { "clingo_ast_binary_operator_plus", (void *)_cffi_const_clingo_ast_binary_operator_plus, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_ast_binary_operator_power", (void *)_cffi_const_clingo_ast_binary_operator_power, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_ast_binary_operator_xor", (void *)_cffi_const_clingo_ast_binary_operator_xor, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_ast_build", (void *)_cffi_const_clingo_ast_build, _CFFI_OP(_CFFI_OP_CONSTANT, 1229), (void *)0 },
+  { "clingo_ast_build", (void *)_cffi_const_clingo_ast_build, _CFFI_OP(_CFFI_OP_CONSTANT, 1231), (void *)0 },
   { "clingo_ast_comparison_operator_equal", (void *)_cffi_const_clingo_ast_comparison_operator_equal, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_ast_comparison_operator_greater_equal", (void *)_cffi_const_clingo_ast_comparison_operator_greater_equal, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_ast_comparison_operator_greater_than", (void *)_cffi_const_clingo_ast_comparison_operator_greater_than, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
@@ -18297,11 +18321,11 @@ static const struct _cffi_global_s _cffi_globals[] = {
   { "clingo_ast_equal", (void *)_cffi_f_clingo_ast_equal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 145), (void *)_cffi_d_clingo_ast_equal },
   { "clingo_ast_get_type", (void *)_cffi_f_clingo_ast_get_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 149), (void *)_cffi_d_clingo_ast_get_type },
   { "clingo_ast_has_attribute", (void *)_cffi_f_clingo_ast_has_attribute, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 153), (void *)_cffi_d_clingo_ast_has_attribute },
-  { "clingo_ast_hash", (void *)_cffi_f_clingo_ast_hash, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1146), (void *)_cffi_d_clingo_ast_hash },
+  { "clingo_ast_hash", (void *)_cffi_f_clingo_ast_hash, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1148), (void *)_cffi_d_clingo_ast_hash },
   { "clingo_ast_less_than", (void *)_cffi_f_clingo_ast_less_than, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 145), (void *)_cffi_d_clingo_ast_less_than },
   { "clingo_ast_parse_files", (void *)_cffi_f_clingo_ast_parse_files, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 21), (void *)_cffi_d_clingo_ast_parse_files },
   { "clingo_ast_parse_string", (void *)_cffi_f_clingo_ast_parse_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 44), (void *)_cffi_d_clingo_ast_parse_string },
-  { "clingo_ast_release", (void *)_cffi_f_clingo_ast_release, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1164), (void *)_cffi_d_clingo_ast_release },
+  { "clingo_ast_release", (void *)_cffi_f_clingo_ast_release, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1166), (void *)_cffi_d_clingo_ast_release },
   { "clingo_ast_sign_double_negation", (void *)_cffi_const_clingo_ast_sign_double_negation, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_ast_sign_negation", (void *)_cffi_const_clingo_ast_sign_negation, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_ast_sign_no_sign", (void *)_cffi_const_clingo_ast_sign_no_sign, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
@@ -18371,7 +18395,7 @@ static const struct _cffi_global_s _cffi_globals[] = {
   { "clingo_ast_unpool_type_condition", (void *)_cffi_const_clingo_ast_unpool_type_condition, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_ast_unpool_type_other", (void *)_cffi_const_clingo_ast_unpool_type_other, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_backend_acyc_edge", (void *)_cffi_f_clingo_backend_acyc_edge, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 292), (void *)_cffi_d_clingo_backend_acyc_edge },
-  { "clingo_backend_add_atom", (void *)_cffi_f_clingo_backend_add_atom, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 365), (void *)_cffi_d_clingo_backend_add_atom },
+  { "clingo_backend_add_atom", (void *)_cffi_f_clingo_backend_add_atom, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 367), (void *)_cffi_d_clingo_backend_add_atom },
   { "clingo_backend_assume", (void *)_cffi_f_clingo_backend_assume, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 311), (void *)_cffi_d_clingo_backend_assume },
   { "clingo_backend_begin", (void *)_cffi_f_clingo_backend_begin, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 260), (void *)_cffi_d_clingo_backend_begin },
   { "clingo_backend_end", (void *)_cffi_f_clingo_backend_end, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 260), (void *)_cffi_d_clingo_backend_end },
@@ -18380,14 +18404,14 @@ static const struct _cffi_global_s _cffi_globals[] = {
   { "clingo_backend_minimize", (void *)_cffi_f_clingo_backend_minimize, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 316), (void *)_cffi_d_clingo_backend_minimize },
   { "clingo_backend_project", (void *)_cffi_f_clingo_backend_project, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 322), (void *)_cffi_d_clingo_backend_project },
   { "clingo_backend_rule", (void *)_cffi_f_clingo_backend_rule, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 263), (void *)_cffi_d_clingo_backend_rule },
-  { "clingo_backend_theory_atom", (void *)_cffi_f_clingo_backend_theory_atom, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 349), (void *)_cffi_d_clingo_backend_theory_atom },
-  { "clingo_backend_theory_atom_with_guard", (void *)_cffi_f_clingo_backend_theory_atom_with_guard, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 356), (void *)_cffi_d_clingo_backend_theory_atom_with_guard },
+  { "clingo_backend_theory_atom", (void *)_cffi_f_clingo_backend_theory_atom, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 359), (void *)_cffi_d_clingo_backend_theory_atom },
+  { "clingo_backend_theory_atom_with_guard", (void *)_cffi_f_clingo_backend_theory_atom_with_guard, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 349), (void *)_cffi_d_clingo_backend_theory_atom_with_guard },
   { "clingo_backend_theory_element", (void *)_cffi_f_clingo_backend_theory_element, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 327), (void *)_cffi_d_clingo_backend_theory_element },
   { "clingo_backend_theory_term_function", (void *)_cffi_f_clingo_backend_theory_term_function, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 285), (void *)_cffi_d_clingo_backend_theory_term_function },
   { "clingo_backend_theory_term_number", (void *)_cffi_f_clingo_backend_theory_term_number, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 299), (void *)_cffi_d_clingo_backend_theory_term_number },
   { "clingo_backend_theory_term_sequence", (void *)_cffi_f_clingo_backend_theory_term_sequence, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 304), (void *)_cffi_d_clingo_backend_theory_term_sequence },
   { "clingo_backend_theory_term_string", (void *)_cffi_f_clingo_backend_theory_term_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 280), (void *)_cffi_d_clingo_backend_theory_term_string },
-  { "clingo_backend_theory_term_symbol", (void *)_cffi_f_clingo_backend_theory_term_symbol, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 370), (void *)_cffi_d_clingo_backend_theory_term_symbol },
+  { "clingo_backend_theory_term_symbol", (void *)_cffi_f_clingo_backend_theory_term_symbol, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 372), (void *)_cffi_d_clingo_backend_theory_term_symbol },
   { "clingo_backend_weight_rule", (void *)_cffi_f_clingo_backend_weight_rule, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 271), (void *)_cffi_d_clingo_backend_weight_rule },
   { "clingo_clause_type_learnt", (void *)_cffi_const_clingo_clause_type_learnt, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_clause_type_static", (void *)_cffi_const_clingo_clause_type_static, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
@@ -18395,56 +18419,56 @@ static const struct _cffi_global_s _cffi_globals[] = {
   { "clingo_clause_type_volatile_static", (void *)_cffi_const_clingo_clause_type_volatile_static, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_comment_type_block", (void *)_cffi_const_clingo_comment_type_block, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_comment_type_line", (void *)_cffi_const_clingo_comment_type_line, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_configuration_array_at", (void *)_cffi_f_clingo_configuration_array_at, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 423), (void *)_cffi_d_clingo_configuration_array_at },
-  { "clingo_configuration_array_size", (void *)_cffi_f_clingo_configuration_array_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 412), (void *)_cffi_d_clingo_configuration_array_size },
-  { "clingo_configuration_description", (void *)_cffi_f_clingo_configuration_description, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 395), (void *)_cffi_d_clingo_configuration_description },
-  { "clingo_configuration_map_at", (void *)_cffi_f_clingo_configuration_map_at, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 406), (void *)_cffi_d_clingo_configuration_map_at },
-  { "clingo_configuration_map_has_subkey", (void *)_cffi_f_clingo_configuration_map_has_subkey, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 400), (void *)_cffi_d_clingo_configuration_map_has_subkey },
-  { "clingo_configuration_map_size", (void *)_cffi_f_clingo_configuration_map_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 412), (void *)_cffi_d_clingo_configuration_map_size },
-  { "clingo_configuration_map_subkey_name", (void *)_cffi_f_clingo_configuration_map_subkey_name, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 417), (void *)_cffi_d_clingo_configuration_map_subkey_name },
-  { "clingo_configuration_root", (void *)_cffi_f_clingo_configuration_root, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 380), (void *)_cffi_d_clingo_configuration_root },
-  { "clingo_configuration_type", (void *)_cffi_f_clingo_configuration_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 429), (void *)_cffi_d_clingo_configuration_type },
+  { "clingo_configuration_array_at", (void *)_cffi_f_clingo_configuration_array_at, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 425), (void *)_cffi_d_clingo_configuration_array_at },
+  { "clingo_configuration_array_size", (void *)_cffi_f_clingo_configuration_array_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 414), (void *)_cffi_d_clingo_configuration_array_size },
+  { "clingo_configuration_description", (void *)_cffi_f_clingo_configuration_description, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 397), (void *)_cffi_d_clingo_configuration_description },
+  { "clingo_configuration_map_at", (void *)_cffi_f_clingo_configuration_map_at, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 408), (void *)_cffi_d_clingo_configuration_map_at },
+  { "clingo_configuration_map_has_subkey", (void *)_cffi_f_clingo_configuration_map_has_subkey, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 402), (void *)_cffi_d_clingo_configuration_map_has_subkey },
+  { "clingo_configuration_map_size", (void *)_cffi_f_clingo_configuration_map_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 414), (void *)_cffi_d_clingo_configuration_map_size },
+  { "clingo_configuration_map_subkey_name", (void *)_cffi_f_clingo_configuration_map_subkey_name, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 419), (void *)_cffi_d_clingo_configuration_map_subkey_name },
+  { "clingo_configuration_root", (void *)_cffi_f_clingo_configuration_root, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 382), (void *)_cffi_d_clingo_configuration_root },
+  { "clingo_configuration_type", (void *)_cffi_f_clingo_configuration_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 431), (void *)_cffi_d_clingo_configuration_type },
   { "clingo_configuration_type_array", (void *)_cffi_const_clingo_configuration_type_array, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_configuration_type_map", (void *)_cffi_const_clingo_configuration_type_map, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_configuration_type_value", (void *)_cffi_const_clingo_configuration_type_value, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_configuration_value_get", (void *)_cffi_f_clingo_configuration_value_get, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 389), (void *)_cffi_d_clingo_configuration_value_get },
-  { "clingo_configuration_value_get_size", (void *)_cffi_f_clingo_configuration_value_get_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 412), (void *)_cffi_d_clingo_configuration_value_get_size },
-  { "clingo_configuration_value_is_assigned", (void *)_cffi_f_clingo_configuration_value_is_assigned, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 384), (void *)_cffi_d_clingo_configuration_value_is_assigned },
-  { "clingo_configuration_value_set", (void *)_cffi_f_clingo_configuration_value_set, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 375), (void *)_cffi_d_clingo_configuration_value_set },
+  { "clingo_configuration_value_get", (void *)_cffi_f_clingo_configuration_value_get, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 391), (void *)_cffi_d_clingo_configuration_value_get },
+  { "clingo_configuration_value_get_size", (void *)_cffi_f_clingo_configuration_value_get_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 414), (void *)_cffi_d_clingo_configuration_value_get_size },
+  { "clingo_configuration_value_is_assigned", (void *)_cffi_f_clingo_configuration_value_is_assigned, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 386), (void *)_cffi_d_clingo_configuration_value_is_assigned },
+  { "clingo_configuration_value_set", (void *)_cffi_f_clingo_configuration_value_set, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 377), (void *)_cffi_d_clingo_configuration_value_set },
   { "clingo_consequence_false", (void *)_cffi_const_clingo_consequence_false, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_consequence_true", (void *)_cffi_const_clingo_consequence_true, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_consequence_unknown", (void *)_cffi_const_clingo_consequence_unknown, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_control_add", (void *)_cffi_f_clingo_control_add, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 451), (void *)_cffi_d_clingo_control_add },
-  { "clingo_control_assign_external", (void *)_cffi_f_clingo_control_assign_external, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 493), (void *)_cffi_d_clingo_control_assign_external },
-  { "clingo_control_backend", (void *)_cffi_f_clingo_control_backend, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 458), (void *)_cffi_d_clingo_control_backend },
-  { "clingo_control_clasp_facade", (void *)_cffi_f_clingo_control_clasp_facade, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 507), (void *)_cffi_d_clingo_control_clasp_facade },
-  { "clingo_control_cleanup", (void *)_cffi_f_clingo_control_cleanup, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 434), (void *)_cffi_d_clingo_control_cleanup },
-  { "clingo_control_configuration", (void *)_cffi_f_clingo_control_configuration, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 462), (void *)_cffi_d_clingo_control_configuration },
-  { "clingo_control_free", (void *)_cffi_f_clingo_control_free, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1167), (void *)_cffi_d_clingo_control_free },
-  { "clingo_control_get_const", (void *)_cffi_f_clingo_control_get_const, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 523), (void *)_cffi_d_clingo_control_get_const },
-  { "clingo_control_get_enable_cleanup", (void *)_cffi_f_clingo_control_get_enable_cleanup, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 434), (void *)_cffi_d_clingo_control_get_enable_cleanup },
-  { "clingo_control_get_enable_enumeration_assumption", (void *)_cffi_f_clingo_control_get_enable_enumeration_assumption, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 434), (void *)_cffi_d_clingo_control_get_enable_enumeration_assumption },
-  { "clingo_control_ground", (void *)_cffi_f_clingo_control_ground, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 472), (void *)_cffi_d_clingo_control_ground },
-  { "clingo_control_has_const", (void *)_cffi_f_clingo_control_has_const, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 518), (void *)_cffi_d_clingo_control_has_const },
-  { "clingo_control_interrupt", (void *)_cffi_f_clingo_control_interrupt, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1167), (void *)_cffi_d_clingo_control_interrupt },
-  { "clingo_control_is_conflicting", (void *)_cffi_f_clingo_control_is_conflicting, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 515), (void *)_cffi_d_clingo_control_is_conflicting },
-  { "clingo_control_load", (void *)_cffi_f_clingo_control_load, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 447), (void *)_cffi_d_clingo_control_load },
+  { "clingo_control_add", (void *)_cffi_f_clingo_control_add, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 453), (void *)_cffi_d_clingo_control_add },
+  { "clingo_control_assign_external", (void *)_cffi_f_clingo_control_assign_external, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 495), (void *)_cffi_d_clingo_control_assign_external },
+  { "clingo_control_backend", (void *)_cffi_f_clingo_control_backend, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 460), (void *)_cffi_d_clingo_control_backend },
+  { "clingo_control_clasp_facade", (void *)_cffi_f_clingo_control_clasp_facade, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 509), (void *)_cffi_d_clingo_control_clasp_facade },
+  { "clingo_control_cleanup", (void *)_cffi_f_clingo_control_cleanup, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 436), (void *)_cffi_d_clingo_control_cleanup },
+  { "clingo_control_configuration", (void *)_cffi_f_clingo_control_configuration, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 464), (void *)_cffi_d_clingo_control_configuration },
+  { "clingo_control_free", (void *)_cffi_f_clingo_control_free, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1169), (void *)_cffi_d_clingo_control_free },
+  { "clingo_control_get_const", (void *)_cffi_f_clingo_control_get_const, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 525), (void *)_cffi_d_clingo_control_get_const },
+  { "clingo_control_get_enable_cleanup", (void *)_cffi_f_clingo_control_get_enable_cleanup, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 436), (void *)_cffi_d_clingo_control_get_enable_cleanup },
+  { "clingo_control_get_enable_enumeration_assumption", (void *)_cffi_f_clingo_control_get_enable_enumeration_assumption, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 436), (void *)_cffi_d_clingo_control_get_enable_enumeration_assumption },
+  { "clingo_control_ground", (void *)_cffi_f_clingo_control_ground, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 474), (void *)_cffi_d_clingo_control_ground },
+  { "clingo_control_has_const", (void *)_cffi_f_clingo_control_has_const, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 520), (void *)_cffi_d_clingo_control_has_const },
+  { "clingo_control_interrupt", (void *)_cffi_f_clingo_control_interrupt, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1169), (void *)_cffi_d_clingo_control_interrupt },
+  { "clingo_control_is_conflicting", (void *)_cffi_f_clingo_control_is_conflicting, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 517), (void *)_cffi_d_clingo_control_is_conflicting },
+  { "clingo_control_load", (void *)_cffi_f_clingo_control_load, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 449), (void *)_cffi_d_clingo_control_load },
   { "clingo_control_new", (void *)_cffi_f_clingo_control_new, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 31), (void *)_cffi_d_clingo_control_new },
-  { "clingo_control_register_observer", (void *)_cffi_f_clingo_control_register_observer, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 466), (void *)_cffi_d_clingo_control_register_observer },
-  { "clingo_control_register_propagator", (void *)_cffi_f_clingo_control_register_propagator, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 483), (void *)_cffi_d_clingo_control_register_propagator },
-  { "clingo_control_release_external", (void *)_cffi_f_clingo_control_release_external, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 489), (void *)_cffi_d_clingo_control_release_external },
-  { "clingo_control_set_enable_cleanup", (void *)_cffi_f_clingo_control_set_enable_cleanup, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 437), (void *)_cffi_d_clingo_control_set_enable_cleanup },
-  { "clingo_control_set_enable_enumeration_assumption", (void *)_cffi_f_clingo_control_set_enable_enumeration_assumption, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 437), (void *)_cffi_d_clingo_control_set_enable_enumeration_assumption },
-  { "clingo_control_solve", (void *)_cffi_f_clingo_control_solve, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 498), (void *)_cffi_d_clingo_control_solve },
-  { "clingo_control_statistics", (void *)_cffi_f_clingo_control_statistics, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 528), (void *)_cffi_d_clingo_control_statistics },
-  { "clingo_control_symbolic_atoms", (void *)_cffi_f_clingo_control_symbolic_atoms, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 532), (void *)_cffi_d_clingo_control_symbolic_atoms },
-  { "clingo_control_theory_atoms", (void *)_cffi_f_clingo_control_theory_atoms, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 536), (void *)_cffi_d_clingo_control_theory_atoms },
+  { "clingo_control_register_observer", (void *)_cffi_f_clingo_control_register_observer, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 468), (void *)_cffi_d_clingo_control_register_observer },
+  { "clingo_control_register_propagator", (void *)_cffi_f_clingo_control_register_propagator, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 485), (void *)_cffi_d_clingo_control_register_propagator },
+  { "clingo_control_release_external", (void *)_cffi_f_clingo_control_release_external, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 491), (void *)_cffi_d_clingo_control_release_external },
+  { "clingo_control_set_enable_cleanup", (void *)_cffi_f_clingo_control_set_enable_cleanup, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 439), (void *)_cffi_d_clingo_control_set_enable_cleanup },
+  { "clingo_control_set_enable_enumeration_assumption", (void *)_cffi_f_clingo_control_set_enable_enumeration_assumption, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 439), (void *)_cffi_d_clingo_control_set_enable_enumeration_assumption },
+  { "clingo_control_solve", (void *)_cffi_f_clingo_control_solve, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 500), (void *)_cffi_d_clingo_control_solve },
+  { "clingo_control_statistics", (void *)_cffi_f_clingo_control_statistics, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 530), (void *)_cffi_d_clingo_control_statistics },
+  { "clingo_control_symbolic_atoms", (void *)_cffi_f_clingo_control_symbolic_atoms, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 534), (void *)_cffi_d_clingo_control_symbolic_atoms },
+  { "clingo_control_theory_atoms", (void *)_cffi_f_clingo_control_theory_atoms, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 538), (void *)_cffi_d_clingo_control_theory_atoms },
   { "clingo_error_bad_alloc", (void *)_cffi_const_clingo_error_bad_alloc, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_error_code", (void *)_cffi_f_clingo_error_code, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_N, 1141), (void *)_cffi_d_clingo_error_code },
+  { "clingo_error_code", (void *)_cffi_f_clingo_error_code, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_N, 1143), (void *)_cffi_d_clingo_error_code },
   { "clingo_error_logic", (void *)_cffi_const_clingo_error_logic, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_error_message", (void *)_cffi_f_clingo_error_message, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_N, 1121), (void *)_cffi_d_clingo_error_message },
+  { "clingo_error_message", (void *)_cffi_f_clingo_error_message, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_N, 1123), (void *)_cffi_d_clingo_error_message },
   { "clingo_error_runtime", (void *)_cffi_const_clingo_error_runtime, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_error_string", (void *)_cffi_f_clingo_error_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1112), (void *)_cffi_d_clingo_error_string },
+  { "clingo_error_string", (void *)_cffi_f_clingo_error_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1114), (void *)_cffi_d_clingo_error_string },
   { "clingo_error_success", (void *)_cffi_const_clingo_error_success, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_error_unknown", (void *)_cffi_const_clingo_error_unknown, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_external_type_false", (void *)_cffi_const_clingo_external_type_false, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
@@ -18457,58 +18481,58 @@ static const struct _cffi_global_s _cffi_globals[] = {
   { "clingo_heuristic_type_level", (void *)_cffi_const_clingo_heuristic_type_level, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_heuristic_type_sign", (void *)_cffi_const_clingo_heuristic_type_sign, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_heuristic_type_true", (void *)_cffi_const_clingo_heuristic_type_true, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_main", (void *)_cffi_f_clingo_main, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1129), (void *)_cffi_d_clingo_main },
-  { "clingo_model_contains", (void *)_cffi_f_clingo_model_contains, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 632), (void *)_cffi_d_clingo_model_contains },
-  { "clingo_model_context", (void *)_cffi_f_clingo_model_context, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 592), (void *)_cffi_d_clingo_model_context },
-  { "clingo_model_cost", (void *)_cffi_f_clingo_model_cost, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 615), (void *)_cffi_d_clingo_model_cost },
-  { "clingo_model_cost_size", (void *)_cffi_f_clingo_model_cost_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 620), (void *)_cffi_d_clingo_model_cost_size },
-  { "clingo_model_extend", (void *)_cffi_f_clingo_model_extend, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 577), (void *)_cffi_d_clingo_model_extend },
-  { "clingo_model_is_consequence", (void *)_cffi_f_clingo_model_is_consequence, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 610), (void *)_cffi_d_clingo_model_is_consequence },
-  { "clingo_model_is_true", (void *)_cffi_f_clingo_model_is_true, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 605), (void *)_cffi_d_clingo_model_is_true },
-  { "clingo_model_number", (void *)_cffi_f_clingo_model_number, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 628), (void *)_cffi_d_clingo_model_number },
-  { "clingo_model_optimality_proven", (void *)_cffi_f_clingo_model_optimality_proven, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 582), (void *)_cffi_d_clingo_model_optimality_proven },
-  { "clingo_model_priority", (void *)_cffi_f_clingo_model_priority, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 600), (void *)_cffi_d_clingo_model_priority },
-  { "clingo_model_symbols", (void *)_cffi_f_clingo_model_symbols, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 642), (void *)_cffi_d_clingo_model_symbols },
-  { "clingo_model_symbols_size", (void *)_cffi_f_clingo_model_symbols_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 637), (void *)_cffi_d_clingo_model_symbols_size },
-  { "clingo_model_thread_id", (void *)_cffi_f_clingo_model_thread_id, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 624), (void *)_cffi_d_clingo_model_thread_id },
-  { "clingo_model_type", (void *)_cffi_f_clingo_model_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 596), (void *)_cffi_d_clingo_model_type },
+  { "clingo_main", (void *)_cffi_f_clingo_main, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1131), (void *)_cffi_d_clingo_main },
+  { "clingo_model_contains", (void *)_cffi_f_clingo_model_contains, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 634), (void *)_cffi_d_clingo_model_contains },
+  { "clingo_model_context", (void *)_cffi_f_clingo_model_context, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 594), (void *)_cffi_d_clingo_model_context },
+  { "clingo_model_cost", (void *)_cffi_f_clingo_model_cost, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 617), (void *)_cffi_d_clingo_model_cost },
+  { "clingo_model_cost_size", (void *)_cffi_f_clingo_model_cost_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 622), (void *)_cffi_d_clingo_model_cost_size },
+  { "clingo_model_extend", (void *)_cffi_f_clingo_model_extend, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 579), (void *)_cffi_d_clingo_model_extend },
+  { "clingo_model_is_consequence", (void *)_cffi_f_clingo_model_is_consequence, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 612), (void *)_cffi_d_clingo_model_is_consequence },
+  { "clingo_model_is_true", (void *)_cffi_f_clingo_model_is_true, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 607), (void *)_cffi_d_clingo_model_is_true },
+  { "clingo_model_number", (void *)_cffi_f_clingo_model_number, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 630), (void *)_cffi_d_clingo_model_number },
+  { "clingo_model_optimality_proven", (void *)_cffi_f_clingo_model_optimality_proven, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 584), (void *)_cffi_d_clingo_model_optimality_proven },
+  { "clingo_model_priority", (void *)_cffi_f_clingo_model_priority, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 602), (void *)_cffi_d_clingo_model_priority },
+  { "clingo_model_symbols", (void *)_cffi_f_clingo_model_symbols, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 644), (void *)_cffi_d_clingo_model_symbols },
+  { "clingo_model_symbols_size", (void *)_cffi_f_clingo_model_symbols_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 639), (void *)_cffi_d_clingo_model_symbols_size },
+  { "clingo_model_thread_id", (void *)_cffi_f_clingo_model_thread_id, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 626), (void *)_cffi_d_clingo_model_thread_id },
+  { "clingo_model_type", (void *)_cffi_f_clingo_model_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 598), (void *)_cffi_d_clingo_model_type },
   { "clingo_model_type_brave_consequences", (void *)_cffi_const_clingo_model_type_brave_consequences, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_model_type_cautious_consequences", (void *)_cffi_const_clingo_model_type_cautious_consequences, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_model_type_stable_model", (void *)_cffi_const_clingo_model_type_stable_model, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_options_add", (void *)_cffi_f_clingo_options_add, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 655), (void *)_cffi_d_clingo_options_add },
-  { "clingo_options_add_flag", (void *)_cffi_f_clingo_options_add_flag, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 648), (void *)_cffi_d_clingo_options_add_flag },
+  { "clingo_options_add", (void *)_cffi_f_clingo_options_add, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 657), (void *)_cffi_d_clingo_options_add },
+  { "clingo_options_add_flag", (void *)_cffi_f_clingo_options_add_flag, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 650), (void *)_cffi_d_clingo_options_add_flag },
   { "clingo_parse_term", (void *)_cffi_f_clingo_parse_term, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 88), (void *)_cffi_d_clingo_parse_term },
-  { "clingo_program_builder_add", (void *)_cffi_f_clingo_program_builder_add, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 672), (void *)_cffi_d_clingo_program_builder_add },
-  { "clingo_program_builder_begin", (void *)_cffi_f_clingo_program_builder_begin, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 669), (void *)_cffi_d_clingo_program_builder_begin },
-  { "clingo_program_builder_end", (void *)_cffi_f_clingo_program_builder_end, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 669), (void *)_cffi_d_clingo_program_builder_end },
-  { "clingo_program_builder_init", (void *)_cffi_f_clingo_program_builder_init, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 479), (void *)_cffi_d_clingo_program_builder_init },
-  { "clingo_propagate_control_add_clause", (void *)_cffi_f_clingo_propagate_control_add_clause, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 684), (void *)_cffi_d_clingo_propagate_control_add_clause },
-  { "clingo_propagate_control_add_literal", (void *)_cffi_f_clingo_propagate_control_add_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 680), (void *)_cffi_d_clingo_propagate_control_add_literal },
-  { "clingo_propagate_control_add_watch", (void *)_cffi_f_clingo_propagate_control_add_watch, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 697), (void *)_cffi_d_clingo_propagate_control_add_watch },
-  { "clingo_propagate_control_assignment", (void *)_cffi_f_clingo_propagate_control_assignment, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1123), (void *)_cffi_d_clingo_propagate_control_assignment },
-  { "clingo_propagate_control_has_watch", (void *)_cffi_f_clingo_propagate_control_has_watch, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 705), (void *)_cffi_d_clingo_propagate_control_has_watch },
-  { "clingo_propagate_control_propagate", (void *)_cffi_f_clingo_propagate_control_propagate, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 676), (void *)_cffi_d_clingo_propagate_control_propagate },
-  { "clingo_propagate_control_remove_watch", (void *)_cffi_f_clingo_propagate_control_remove_watch, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1170), (void *)_cffi_d_clingo_propagate_control_remove_watch },
-  { "clingo_propagate_control_thread_id", (void *)_cffi_f_clingo_propagate_control_thread_id, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1155), (void *)_cffi_d_clingo_propagate_control_thread_id },
-  { "clingo_propagate_init_add_clause", (void *)_cffi_f_clingo_propagate_init_add_clause, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 718), (void *)_cffi_d_clingo_propagate_init_add_clause },
-  { "clingo_propagate_init_add_literal", (void *)_cffi_f_clingo_propagate_init_add_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 713), (void *)_cffi_d_clingo_propagate_init_add_literal },
-  { "clingo_propagate_init_add_minimize", (void *)_cffi_f_clingo_propagate_init_add_minimize, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 738), (void *)_cffi_d_clingo_propagate_init_add_minimize },
-  { "clingo_propagate_init_add_watch", (void *)_cffi_f_clingo_propagate_init_add_watch, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 724), (void *)_cffi_d_clingo_propagate_init_add_watch },
-  { "clingo_propagate_init_add_watch_to_thread", (void *)_cffi_f_clingo_propagate_init_add_watch_to_thread, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 744), (void *)_cffi_d_clingo_propagate_init_add_watch_to_thread },
-  { "clingo_propagate_init_add_weight_constraint", (void *)_cffi_f_clingo_propagate_init_add_weight_constraint, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 728), (void *)_cffi_d_clingo_propagate_init_add_weight_constraint },
-  { "clingo_propagate_init_assignment", (void *)_cffi_f_clingo_propagate_init_assignment, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1126), (void *)_cffi_d_clingo_propagate_init_assignment },
-  { "clingo_propagate_init_freeze_literal", (void *)_cffi_f_clingo_propagate_init_freeze_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 724), (void *)_cffi_d_clingo_propagate_init_freeze_literal },
-  { "clingo_propagate_init_get_check_mode", (void *)_cffi_f_clingo_propagate_init_get_check_mode, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1135), (void *)_cffi_d_clingo_propagate_init_get_check_mode },
-  { "clingo_propagate_init_get_undo_mode", (void *)_cffi_f_clingo_propagate_init_get_undo_mode, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1135), (void *)_cffi_d_clingo_propagate_init_get_undo_mode },
-  { "clingo_propagate_init_number_of_threads", (void *)_cffi_f_clingo_propagate_init_number_of_threads, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1135), (void *)_cffi_d_clingo_propagate_init_number_of_threads },
-  { "clingo_propagate_init_propagate", (void *)_cffi_f_clingo_propagate_init_propagate, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 709), (void *)_cffi_d_clingo_propagate_init_propagate },
-  { "clingo_propagate_init_remove_watch", (void *)_cffi_f_clingo_propagate_init_remove_watch, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 724), (void *)_cffi_d_clingo_propagate_init_remove_watch },
-  { "clingo_propagate_init_remove_watch_from_thread", (void *)_cffi_f_clingo_propagate_init_remove_watch_from_thread, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 744), (void *)_cffi_d_clingo_propagate_init_remove_watch_from_thread },
-  { "clingo_propagate_init_set_check_mode", (void *)_cffi_f_clingo_propagate_init_set_check_mode, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1180), (void *)_cffi_d_clingo_propagate_init_set_check_mode },
-  { "clingo_propagate_init_set_undo_mode", (void *)_cffi_f_clingo_propagate_init_set_undo_mode, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1180), (void *)_cffi_d_clingo_propagate_init_set_undo_mode },
-  { "clingo_propagate_init_solver_literal", (void *)_cffi_f_clingo_propagate_init_solver_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 761), (void *)_cffi_d_clingo_propagate_init_solver_literal },
-  { "clingo_propagate_init_symbolic_atoms", (void *)_cffi_f_clingo_propagate_init_symbolic_atoms, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 753), (void *)_cffi_d_clingo_propagate_init_symbolic_atoms },
-  { "clingo_propagate_init_theory_atoms", (void *)_cffi_f_clingo_propagate_init_theory_atoms, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 757), (void *)_cffi_d_clingo_propagate_init_theory_atoms },
+  { "clingo_program_builder_add", (void *)_cffi_f_clingo_program_builder_add, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 674), (void *)_cffi_d_clingo_program_builder_add },
+  { "clingo_program_builder_begin", (void *)_cffi_f_clingo_program_builder_begin, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 671), (void *)_cffi_d_clingo_program_builder_begin },
+  { "clingo_program_builder_end", (void *)_cffi_f_clingo_program_builder_end, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 671), (void *)_cffi_d_clingo_program_builder_end },
+  { "clingo_program_builder_init", (void *)_cffi_f_clingo_program_builder_init, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 481), (void *)_cffi_d_clingo_program_builder_init },
+  { "clingo_propagate_control_add_clause", (void *)_cffi_f_clingo_propagate_control_add_clause, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 686), (void *)_cffi_d_clingo_propagate_control_add_clause },
+  { "clingo_propagate_control_add_literal", (void *)_cffi_f_clingo_propagate_control_add_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 682), (void *)_cffi_d_clingo_propagate_control_add_literal },
+  { "clingo_propagate_control_add_watch", (void *)_cffi_f_clingo_propagate_control_add_watch, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 699), (void *)_cffi_d_clingo_propagate_control_add_watch },
+  { "clingo_propagate_control_assignment", (void *)_cffi_f_clingo_propagate_control_assignment, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1125), (void *)_cffi_d_clingo_propagate_control_assignment },
+  { "clingo_propagate_control_has_watch", (void *)_cffi_f_clingo_propagate_control_has_watch, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 707), (void *)_cffi_d_clingo_propagate_control_has_watch },
+  { "clingo_propagate_control_propagate", (void *)_cffi_f_clingo_propagate_control_propagate, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 678), (void *)_cffi_d_clingo_propagate_control_propagate },
+  { "clingo_propagate_control_remove_watch", (void *)_cffi_f_clingo_propagate_control_remove_watch, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1172), (void *)_cffi_d_clingo_propagate_control_remove_watch },
+  { "clingo_propagate_control_thread_id", (void *)_cffi_f_clingo_propagate_control_thread_id, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1157), (void *)_cffi_d_clingo_propagate_control_thread_id },
+  { "clingo_propagate_init_add_clause", (void *)_cffi_f_clingo_propagate_init_add_clause, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 720), (void *)_cffi_d_clingo_propagate_init_add_clause },
+  { "clingo_propagate_init_add_literal", (void *)_cffi_f_clingo_propagate_init_add_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 715), (void *)_cffi_d_clingo_propagate_init_add_literal },
+  { "clingo_propagate_init_add_minimize", (void *)_cffi_f_clingo_propagate_init_add_minimize, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 740), (void *)_cffi_d_clingo_propagate_init_add_minimize },
+  { "clingo_propagate_init_add_watch", (void *)_cffi_f_clingo_propagate_init_add_watch, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 726), (void *)_cffi_d_clingo_propagate_init_add_watch },
+  { "clingo_propagate_init_add_watch_to_thread", (void *)_cffi_f_clingo_propagate_init_add_watch_to_thread, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 746), (void *)_cffi_d_clingo_propagate_init_add_watch_to_thread },
+  { "clingo_propagate_init_add_weight_constraint", (void *)_cffi_f_clingo_propagate_init_add_weight_constraint, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 730), (void *)_cffi_d_clingo_propagate_init_add_weight_constraint },
+  { "clingo_propagate_init_assignment", (void *)_cffi_f_clingo_propagate_init_assignment, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1128), (void *)_cffi_d_clingo_propagate_init_assignment },
+  { "clingo_propagate_init_freeze_literal", (void *)_cffi_f_clingo_propagate_init_freeze_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 726), (void *)_cffi_d_clingo_propagate_init_freeze_literal },
+  { "clingo_propagate_init_get_check_mode", (void *)_cffi_f_clingo_propagate_init_get_check_mode, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1137), (void *)_cffi_d_clingo_propagate_init_get_check_mode },
+  { "clingo_propagate_init_get_undo_mode", (void *)_cffi_f_clingo_propagate_init_get_undo_mode, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1137), (void *)_cffi_d_clingo_propagate_init_get_undo_mode },
+  { "clingo_propagate_init_number_of_threads", (void *)_cffi_f_clingo_propagate_init_number_of_threads, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1137), (void *)_cffi_d_clingo_propagate_init_number_of_threads },
+  { "clingo_propagate_init_propagate", (void *)_cffi_f_clingo_propagate_init_propagate, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 711), (void *)_cffi_d_clingo_propagate_init_propagate },
+  { "clingo_propagate_init_remove_watch", (void *)_cffi_f_clingo_propagate_init_remove_watch, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 726), (void *)_cffi_d_clingo_propagate_init_remove_watch },
+  { "clingo_propagate_init_remove_watch_from_thread", (void *)_cffi_f_clingo_propagate_init_remove_watch_from_thread, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 746), (void *)_cffi_d_clingo_propagate_init_remove_watch_from_thread },
+  { "clingo_propagate_init_set_check_mode", (void *)_cffi_f_clingo_propagate_init_set_check_mode, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1182), (void *)_cffi_d_clingo_propagate_init_set_check_mode },
+  { "clingo_propagate_init_set_undo_mode", (void *)_cffi_f_clingo_propagate_init_set_undo_mode, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1182), (void *)_cffi_d_clingo_propagate_init_set_undo_mode },
+  { "clingo_propagate_init_solver_literal", (void *)_cffi_f_clingo_propagate_init_solver_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 763), (void *)_cffi_d_clingo_propagate_init_solver_literal },
+  { "clingo_propagate_init_symbolic_atoms", (void *)_cffi_f_clingo_propagate_init_symbolic_atoms, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 755), (void *)_cffi_d_clingo_propagate_init_symbolic_atoms },
+  { "clingo_propagate_init_theory_atoms", (void *)_cffi_f_clingo_propagate_init_theory_atoms, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 759), (void *)_cffi_d_clingo_propagate_init_theory_atoms },
   { "clingo_propagator_check_mode_both", (void *)_cffi_const_clingo_propagator_check_mode_both, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_propagator_check_mode_fixpoint", (void *)_cffi_const_clingo_propagator_check_mode_fixpoint, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_propagator_check_mode_none", (void *)_cffi_const_clingo_propagator_check_mode_none, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
@@ -18516,112 +18540,112 @@ static const struct _cffi_global_s _cffi_globals[] = {
   { "clingo_propagator_undo_mode_always", (void *)_cffi_const_clingo_propagator_undo_mode_always, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_propagator_undo_mode_default", (void *)_cffi_const_clingo_propagator_undo_mode_default, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_register_script", (void *)_cffi_f_clingo_register_script, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 62), (void *)_cffi_d_clingo_register_script },
-  { "clingo_script_version", (void *)_cffi_f_clingo_script_version, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1109), (void *)_cffi_d_clingo_script_version },
-  { "clingo_set_error", (void *)_cffi_f_clingo_set_error, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1194), (void *)_cffi_d_clingo_set_error },
+  { "clingo_script_version", (void *)_cffi_f_clingo_script_version, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1111), (void *)_cffi_d_clingo_script_version },
+  { "clingo_set_error", (void *)_cffi_f_clingo_set_error, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1196), (void *)_cffi_d_clingo_set_error },
   { "clingo_show_type_all", (void *)_cffi_const_clingo_show_type_all, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_show_type_atoms", (void *)_cffi_const_clingo_show_type_atoms, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_show_type_complement", (void *)_cffi_const_clingo_show_type_complement, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_show_type_shown", (void *)_cffi_const_clingo_show_type_shown, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_show_type_terms", (void *)_cffi_const_clingo_show_type_terms, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_show_type_theory", (void *)_cffi_const_clingo_show_type_theory, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_signature_arity", (void *)_cffi_f_clingo_signature_arity, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1158), (void *)_cffi_d_clingo_signature_arity },
+  { "clingo_signature_arity", (void *)_cffi_f_clingo_signature_arity, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1160), (void *)_cffi_d_clingo_signature_arity },
   { "clingo_signature_create", (void *)_cffi_f_clingo_signature_create, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 67), (void *)_cffi_d_clingo_signature_create },
-  { "clingo_signature_hash", (void *)_cffi_f_clingo_signature_hash, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1149), (void *)_cffi_d_clingo_signature_hash },
-  { "clingo_signature_is_equal_to", (void *)_cffi_f_clingo_signature_is_equal_to, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1078), (void *)_cffi_d_clingo_signature_is_equal_to },
-  { "clingo_signature_is_less_than", (void *)_cffi_f_clingo_signature_is_less_than, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1078), (void *)_cffi_d_clingo_signature_is_less_than },
-  { "clingo_signature_is_negative", (void *)_cffi_f_clingo_signature_is_negative, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1038), (void *)_cffi_d_clingo_signature_is_negative },
-  { "clingo_signature_is_positive", (void *)_cffi_f_clingo_signature_is_positive, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1038), (void *)_cffi_d_clingo_signature_is_positive },
-  { "clingo_signature_name", (void *)_cffi_f_clingo_signature_name, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1115), (void *)_cffi_d_clingo_signature_name },
-  { "clingo_solve_control_add_clause", (void *)_cffi_f_clingo_solve_control_add_clause, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 766), (void *)_cffi_d_clingo_solve_control_add_clause },
-  { "clingo_solve_control_symbolic_atoms", (void *)_cffi_f_clingo_solve_control_symbolic_atoms, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 771), (void *)_cffi_d_clingo_solve_control_symbolic_atoms },
+  { "clingo_signature_hash", (void *)_cffi_f_clingo_signature_hash, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1151), (void *)_cffi_d_clingo_signature_hash },
+  { "clingo_signature_is_equal_to", (void *)_cffi_f_clingo_signature_is_equal_to, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1080), (void *)_cffi_d_clingo_signature_is_equal_to },
+  { "clingo_signature_is_less_than", (void *)_cffi_f_clingo_signature_is_less_than, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1080), (void *)_cffi_d_clingo_signature_is_less_than },
+  { "clingo_signature_is_negative", (void *)_cffi_f_clingo_signature_is_negative, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1040), (void *)_cffi_d_clingo_signature_is_negative },
+  { "clingo_signature_is_positive", (void *)_cffi_f_clingo_signature_is_positive, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1040), (void *)_cffi_d_clingo_signature_is_positive },
+  { "clingo_signature_name", (void *)_cffi_f_clingo_signature_name, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1117), (void *)_cffi_d_clingo_signature_name },
+  { "clingo_solve_control_add_clause", (void *)_cffi_f_clingo_solve_control_add_clause, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 768), (void *)_cffi_d_clingo_solve_control_add_clause },
+  { "clingo_solve_control_symbolic_atoms", (void *)_cffi_f_clingo_solve_control_symbolic_atoms, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 773), (void *)_cffi_d_clingo_solve_control_symbolic_atoms },
   { "clingo_solve_event_type_finish", (void *)_cffi_const_clingo_solve_event_type_finish, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_solve_event_type_model", (void *)_cffi_const_clingo_solve_event_type_model, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_solve_event_type_statistics", (void *)_cffi_const_clingo_solve_event_type_statistics, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_solve_event_type_unsat", (void *)_cffi_const_clingo_solve_event_type_unsat, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_solve_handle_cancel", (void *)_cffi_f_clingo_solve_handle_cancel, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 775), (void *)_cffi_d_clingo_solve_handle_cancel },
-  { "clingo_solve_handle_close", (void *)_cffi_f_clingo_solve_handle_close, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 775), (void *)_cffi_d_clingo_solve_handle_close },
-  { "clingo_solve_handle_core", (void *)_cffi_f_clingo_solve_handle_core, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 782), (void *)_cffi_d_clingo_solve_handle_core },
-  { "clingo_solve_handle_get", (void *)_cffi_f_clingo_solve_handle_get, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 787), (void *)_cffi_d_clingo_solve_handle_get },
-  { "clingo_solve_handle_model", (void *)_cffi_f_clingo_solve_handle_model, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 778), (void *)_cffi_d_clingo_solve_handle_model },
-  { "clingo_solve_handle_resume", (void *)_cffi_f_clingo_solve_handle_resume, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 775), (void *)_cffi_d_clingo_solve_handle_resume },
-  { "clingo_solve_handle_wait", (void *)_cffi_f_clingo_solve_handle_wait, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1184), (void *)_cffi_d_clingo_solve_handle_wait },
+  { "clingo_solve_handle_cancel", (void *)_cffi_f_clingo_solve_handle_cancel, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 777), (void *)_cffi_d_clingo_solve_handle_cancel },
+  { "clingo_solve_handle_close", (void *)_cffi_f_clingo_solve_handle_close, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 777), (void *)_cffi_d_clingo_solve_handle_close },
+  { "clingo_solve_handle_core", (void *)_cffi_f_clingo_solve_handle_core, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 784), (void *)_cffi_d_clingo_solve_handle_core },
+  { "clingo_solve_handle_get", (void *)_cffi_f_clingo_solve_handle_get, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 789), (void *)_cffi_d_clingo_solve_handle_get },
+  { "clingo_solve_handle_model", (void *)_cffi_f_clingo_solve_handle_model, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 780), (void *)_cffi_d_clingo_solve_handle_model },
+  { "clingo_solve_handle_resume", (void *)_cffi_f_clingo_solve_handle_resume, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 777), (void *)_cffi_d_clingo_solve_handle_resume },
+  { "clingo_solve_handle_wait", (void *)_cffi_f_clingo_solve_handle_wait, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1186), (void *)_cffi_d_clingo_solve_handle_wait },
   { "clingo_solve_mode_async", (void *)_cffi_const_clingo_solve_mode_async, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_solve_mode_yield", (void *)_cffi_const_clingo_solve_mode_yield, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_solve_result_exhausted", (void *)_cffi_const_clingo_solve_result_exhausted, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_solve_result_interrupted", (void *)_cffi_const_clingo_solve_result_interrupted, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_solve_result_satisfiable", (void *)_cffi_const_clingo_solve_result_satisfiable, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_solve_result_unsatisfiable", (void *)_cffi_const_clingo_solve_result_unsatisfiable, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_statistics_array_at", (void *)_cffi_f_clingo_statistics_array_at, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 846), (void *)_cffi_d_clingo_statistics_array_at },
-  { "clingo_statistics_array_push", (void *)_cffi_f_clingo_statistics_array_push, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 803), (void *)_cffi_d_clingo_statistics_array_push },
-  { "clingo_statistics_array_size", (void *)_cffi_f_clingo_statistics_array_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 835), (void *)_cffi_d_clingo_statistics_array_size },
-  { "clingo_statistics_map_add_subkey", (void *)_cffi_f_clingo_statistics_map_add_subkey, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 791), (void *)_cffi_d_clingo_statistics_map_add_subkey },
-  { "clingo_statistics_map_at", (void *)_cffi_f_clingo_statistics_map_at, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 819), (void *)_cffi_d_clingo_statistics_map_at },
-  { "clingo_statistics_map_has_subkey", (void *)_cffi_f_clingo_statistics_map_has_subkey, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 813), (void *)_cffi_d_clingo_statistics_map_has_subkey },
-  { "clingo_statistics_map_size", (void *)_cffi_f_clingo_statistics_map_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 835), (void *)_cffi_d_clingo_statistics_map_size },
-  { "clingo_statistics_map_subkey_name", (void *)_cffi_f_clingo_statistics_map_subkey_name, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 840), (void *)_cffi_d_clingo_statistics_map_subkey_name },
-  { "clingo_statistics_root", (void *)_cffi_f_clingo_statistics_root, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 809), (void *)_cffi_d_clingo_statistics_root },
-  { "clingo_statistics_type", (void *)_cffi_f_clingo_statistics_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 830), (void *)_cffi_d_clingo_statistics_type },
+  { "clingo_statistics_array_at", (void *)_cffi_f_clingo_statistics_array_at, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 848), (void *)_cffi_d_clingo_statistics_array_at },
+  { "clingo_statistics_array_push", (void *)_cffi_f_clingo_statistics_array_push, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 805), (void *)_cffi_d_clingo_statistics_array_push },
+  { "clingo_statistics_array_size", (void *)_cffi_f_clingo_statistics_array_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 837), (void *)_cffi_d_clingo_statistics_array_size },
+  { "clingo_statistics_map_add_subkey", (void *)_cffi_f_clingo_statistics_map_add_subkey, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 793), (void *)_cffi_d_clingo_statistics_map_add_subkey },
+  { "clingo_statistics_map_at", (void *)_cffi_f_clingo_statistics_map_at, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 821), (void *)_cffi_d_clingo_statistics_map_at },
+  { "clingo_statistics_map_has_subkey", (void *)_cffi_f_clingo_statistics_map_has_subkey, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 815), (void *)_cffi_d_clingo_statistics_map_has_subkey },
+  { "clingo_statistics_map_size", (void *)_cffi_f_clingo_statistics_map_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 837), (void *)_cffi_d_clingo_statistics_map_size },
+  { "clingo_statistics_map_subkey_name", (void *)_cffi_f_clingo_statistics_map_subkey_name, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 842), (void *)_cffi_d_clingo_statistics_map_subkey_name },
+  { "clingo_statistics_root", (void *)_cffi_f_clingo_statistics_root, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 811), (void *)_cffi_d_clingo_statistics_root },
+  { "clingo_statistics_type", (void *)_cffi_f_clingo_statistics_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 832), (void *)_cffi_d_clingo_statistics_type },
   { "clingo_statistics_type_array", (void *)_cffi_const_clingo_statistics_type_array, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_statistics_type_empty", (void *)_cffi_const_clingo_statistics_type_empty, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_statistics_type_map", (void *)_cffi_const_clingo_statistics_type_map, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_statistics_type_value", (void *)_cffi_const_clingo_statistics_type_value, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_statistics_value_get", (void *)_cffi_f_clingo_statistics_value_get, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 825), (void *)_cffi_d_clingo_statistics_value_get },
-  { "clingo_statistics_value_set", (void *)_cffi_f_clingo_statistics_value_set, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 798), (void *)_cffi_d_clingo_statistics_value_set },
-  { "clingo_symbol_arguments", (void *)_cffi_f_clingo_symbol_arguments, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1073), (void *)_cffi_d_clingo_symbol_arguments },
+  { "clingo_statistics_value_get", (void *)_cffi_f_clingo_statistics_value_get, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 827), (void *)_cffi_d_clingo_statistics_value_get },
+  { "clingo_statistics_value_set", (void *)_cffi_f_clingo_statistics_value_set, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 800), (void *)_cffi_d_clingo_statistics_value_set },
+  { "clingo_symbol_arguments", (void *)_cffi_f_clingo_symbol_arguments, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1075), (void *)_cffi_d_clingo_symbol_arguments },
   { "clingo_symbol_create_function", (void *)_cffi_f_clingo_symbol_create_function, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 77), (void *)_cffi_d_clingo_symbol_create_function },
   { "clingo_symbol_create_id", (void *)_cffi_f_clingo_symbol_create_id, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 53), (void *)_cffi_d_clingo_symbol_create_id },
-  { "clingo_symbol_create_infimum", (void *)_cffi_f_clingo_symbol_create_infimum, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1207), (void *)_cffi_d_clingo_symbol_create_infimum },
-  { "clingo_symbol_create_number", (void *)_cffi_f_clingo_symbol_create_number, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1203), (void *)_cffi_d_clingo_symbol_create_number },
+  { "clingo_symbol_create_infimum", (void *)_cffi_f_clingo_symbol_create_infimum, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1209), (void *)_cffi_d_clingo_symbol_create_infimum },
+  { "clingo_symbol_create_number", (void *)_cffi_f_clingo_symbol_create_number, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1205), (void *)_cffi_d_clingo_symbol_create_number },
   { "clingo_symbol_create_string", (void *)_cffi_f_clingo_symbol_create_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 73), (void *)_cffi_d_clingo_symbol_create_string },
-  { "clingo_symbol_create_supremum", (void *)_cffi_f_clingo_symbol_create_supremum, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1207), (void *)_cffi_d_clingo_symbol_create_supremum },
-  { "clingo_symbol_hash", (void *)_cffi_f_clingo_symbol_hash, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1149), (void *)_cffi_d_clingo_symbol_hash },
-  { "clingo_symbol_is_equal_to", (void *)_cffi_f_clingo_symbol_is_equal_to, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1078), (void *)_cffi_d_clingo_symbol_is_equal_to },
-  { "clingo_symbol_is_less_than", (void *)_cffi_f_clingo_symbol_is_less_than, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1078), (void *)_cffi_d_clingo_symbol_is_less_than },
-  { "clingo_symbol_is_negative", (void *)_cffi_f_clingo_symbol_is_negative, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1041), (void *)_cffi_d_clingo_symbol_is_negative },
-  { "clingo_symbol_is_positive", (void *)_cffi_f_clingo_symbol_is_positive, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1041), (void *)_cffi_d_clingo_symbol_is_positive },
-  { "clingo_symbol_name", (void *)_cffi_f_clingo_symbol_name, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1050), (void *)_cffi_d_clingo_symbol_name },
-  { "clingo_symbol_number", (void *)_cffi_f_clingo_symbol_number, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1054), (void *)_cffi_d_clingo_symbol_number },
-  { "clingo_symbol_string", (void *)_cffi_f_clingo_symbol_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1050), (void *)_cffi_d_clingo_symbol_string },
-  { "clingo_symbol_to_string", (void *)_cffi_f_clingo_symbol_to_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1045), (void *)_cffi_d_clingo_symbol_to_string },
-  { "clingo_symbol_to_string_size", (void *)_cffi_f_clingo_symbol_to_string_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1064), (void *)_cffi_d_clingo_symbol_to_string_size },
-  { "clingo_symbol_type", (void *)_cffi_f_clingo_symbol_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1138), (void *)_cffi_d_clingo_symbol_type },
+  { "clingo_symbol_create_supremum", (void *)_cffi_f_clingo_symbol_create_supremum, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1209), (void *)_cffi_d_clingo_symbol_create_supremum },
+  { "clingo_symbol_hash", (void *)_cffi_f_clingo_symbol_hash, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1151), (void *)_cffi_d_clingo_symbol_hash },
+  { "clingo_symbol_is_equal_to", (void *)_cffi_f_clingo_symbol_is_equal_to, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1080), (void *)_cffi_d_clingo_symbol_is_equal_to },
+  { "clingo_symbol_is_less_than", (void *)_cffi_f_clingo_symbol_is_less_than, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1080), (void *)_cffi_d_clingo_symbol_is_less_than },
+  { "clingo_symbol_is_negative", (void *)_cffi_f_clingo_symbol_is_negative, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1043), (void *)_cffi_d_clingo_symbol_is_negative },
+  { "clingo_symbol_is_positive", (void *)_cffi_f_clingo_symbol_is_positive, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1043), (void *)_cffi_d_clingo_symbol_is_positive },
+  { "clingo_symbol_name", (void *)_cffi_f_clingo_symbol_name, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1052), (void *)_cffi_d_clingo_symbol_name },
+  { "clingo_symbol_number", (void *)_cffi_f_clingo_symbol_number, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1056), (void *)_cffi_d_clingo_symbol_number },
+  { "clingo_symbol_string", (void *)_cffi_f_clingo_symbol_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1052), (void *)_cffi_d_clingo_symbol_string },
+  { "clingo_symbol_to_string", (void *)_cffi_f_clingo_symbol_to_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1047), (void *)_cffi_d_clingo_symbol_to_string },
+  { "clingo_symbol_to_string_size", (void *)_cffi_f_clingo_symbol_to_string_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1066), (void *)_cffi_d_clingo_symbol_to_string_size },
+  { "clingo_symbol_type", (void *)_cffi_f_clingo_symbol_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1140), (void *)_cffi_d_clingo_symbol_type },
   { "clingo_symbol_type_function", (void *)_cffi_const_clingo_symbol_type_function, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_symbol_type_infimum", (void *)_cffi_const_clingo_symbol_type_infimum, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_symbol_type_number", (void *)_cffi_const_clingo_symbol_type_number, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_symbol_type_string", (void *)_cffi_const_clingo_symbol_type_string, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_symbol_type_supremum", (void *)_cffi_const_clingo_symbol_type_supremum, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_symbolic_atoms_begin", (void *)_cffi_f_clingo_symbolic_atoms_begin, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 865), (void *)_cffi_d_clingo_symbolic_atoms_begin },
-  { "clingo_symbolic_atoms_end", (void *)_cffi_f_clingo_symbolic_atoms_end, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 856), (void *)_cffi_d_clingo_symbolic_atoms_end },
-  { "clingo_symbolic_atoms_find", (void *)_cffi_f_clingo_symbolic_atoms_find, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 880), (void *)_cffi_d_clingo_symbolic_atoms_find },
-  { "clingo_symbolic_atoms_is_external", (void *)_cffi_f_clingo_symbolic_atoms_is_external, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 870), (void *)_cffi_d_clingo_symbolic_atoms_is_external },
-  { "clingo_symbolic_atoms_is_fact", (void *)_cffi_f_clingo_symbolic_atoms_is_fact, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 870), (void *)_cffi_d_clingo_symbolic_atoms_is_fact },
-  { "clingo_symbolic_atoms_is_valid", (void *)_cffi_f_clingo_symbolic_atoms_is_valid, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 870), (void *)_cffi_d_clingo_symbolic_atoms_is_valid },
-  { "clingo_symbolic_atoms_iterator_is_equal_to", (void *)_cffi_f_clingo_symbolic_atoms_iterator_is_equal_to, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 885), (void *)_cffi_d_clingo_symbolic_atoms_iterator_is_equal_to },
-  { "clingo_symbolic_atoms_literal", (void *)_cffi_f_clingo_symbolic_atoms_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 875), (void *)_cffi_d_clingo_symbolic_atoms_literal },
-  { "clingo_symbolic_atoms_next", (void *)_cffi_f_clingo_symbolic_atoms_next, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 880), (void *)_cffi_d_clingo_symbolic_atoms_next },
-  { "clingo_symbolic_atoms_signatures", (void *)_cffi_f_clingo_symbolic_atoms_signatures, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 860), (void *)_cffi_d_clingo_symbolic_atoms_signatures },
-  { "clingo_symbolic_atoms_signatures_size", (void *)_cffi_f_clingo_symbolic_atoms_signatures_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 852), (void *)_cffi_d_clingo_symbolic_atoms_signatures_size },
-  { "clingo_symbolic_atoms_size", (void *)_cffi_f_clingo_symbolic_atoms_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 852), (void *)_cffi_d_clingo_symbolic_atoms_size },
-  { "clingo_symbolic_atoms_symbol", (void *)_cffi_f_clingo_symbolic_atoms_symbol, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 880), (void *)_cffi_d_clingo_symbolic_atoms_symbol },
-  { "clingo_theory_atoms_atom_elements", (void *)_cffi_f_clingo_theory_atoms_atom_elements, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 943), (void *)_cffi_d_clingo_theory_atoms_atom_elements },
-  { "clingo_theory_atoms_atom_guard", (void *)_cffi_f_clingo_theory_atoms_atom_guard, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 911), (void *)_cffi_d_clingo_theory_atoms_atom_guard },
-  { "clingo_theory_atoms_atom_has_guard", (void *)_cffi_f_clingo_theory_atoms_atom_has_guard, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 895), (void *)_cffi_d_clingo_theory_atoms_atom_has_guard },
-  { "clingo_theory_atoms_atom_literal", (void *)_cffi_f_clingo_theory_atoms_atom_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 922), (void *)_cffi_d_clingo_theory_atoms_atom_literal },
-  { "clingo_theory_atoms_atom_term", (void *)_cffi_f_clingo_theory_atoms_atom_term, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 938), (void *)_cffi_d_clingo_theory_atoms_atom_term },
-  { "clingo_theory_atoms_atom_to_string", (void *)_cffi_f_clingo_theory_atoms_atom_to_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 900), (void *)_cffi_d_clingo_theory_atoms_atom_to_string },
-  { "clingo_theory_atoms_atom_to_string_size", (void *)_cffi_f_clingo_theory_atoms_atom_to_string_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 933), (void *)_cffi_d_clingo_theory_atoms_atom_to_string_size },
-  { "clingo_theory_atoms_element_condition", (void *)_cffi_f_clingo_theory_atoms_element_condition, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 927), (void *)_cffi_d_clingo_theory_atoms_element_condition },
-  { "clingo_theory_atoms_element_condition_id", (void *)_cffi_f_clingo_theory_atoms_element_condition_id, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 922), (void *)_cffi_d_clingo_theory_atoms_element_condition_id },
-  { "clingo_theory_atoms_element_to_string", (void *)_cffi_f_clingo_theory_atoms_element_to_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 900), (void *)_cffi_d_clingo_theory_atoms_element_to_string },
-  { "clingo_theory_atoms_element_to_string_size", (void *)_cffi_f_clingo_theory_atoms_element_to_string_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 933), (void *)_cffi_d_clingo_theory_atoms_element_to_string_size },
-  { "clingo_theory_atoms_element_tuple", (void *)_cffi_f_clingo_theory_atoms_element_tuple, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 943), (void *)_cffi_d_clingo_theory_atoms_element_tuple },
-  { "clingo_theory_atoms_size", (void *)_cffi_f_clingo_theory_atoms_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 891), (void *)_cffi_d_clingo_theory_atoms_size },
-  { "clingo_theory_atoms_term_arguments", (void *)_cffi_f_clingo_theory_atoms_term_arguments, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 943), (void *)_cffi_d_clingo_theory_atoms_term_arguments },
-  { "clingo_theory_atoms_term_name", (void *)_cffi_f_clingo_theory_atoms_term_name, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 906), (void *)_cffi_d_clingo_theory_atoms_term_name },
-  { "clingo_theory_atoms_term_number", (void *)_cffi_f_clingo_theory_atoms_term_number, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 917), (void *)_cffi_d_clingo_theory_atoms_term_number },
-  { "clingo_theory_atoms_term_to_string", (void *)_cffi_f_clingo_theory_atoms_term_to_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 900), (void *)_cffi_d_clingo_theory_atoms_term_to_string },
-  { "clingo_theory_atoms_term_to_string_size", (void *)_cffi_f_clingo_theory_atoms_term_to_string_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 933), (void *)_cffi_d_clingo_theory_atoms_term_to_string_size },
-  { "clingo_theory_atoms_term_type", (void *)_cffi_f_clingo_theory_atoms_term_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 917), (void *)_cffi_d_clingo_theory_atoms_term_type },
+  { "clingo_symbolic_atoms_begin", (void *)_cffi_f_clingo_symbolic_atoms_begin, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 867), (void *)_cffi_d_clingo_symbolic_atoms_begin },
+  { "clingo_symbolic_atoms_end", (void *)_cffi_f_clingo_symbolic_atoms_end, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 858), (void *)_cffi_d_clingo_symbolic_atoms_end },
+  { "clingo_symbolic_atoms_find", (void *)_cffi_f_clingo_symbolic_atoms_find, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 882), (void *)_cffi_d_clingo_symbolic_atoms_find },
+  { "clingo_symbolic_atoms_is_external", (void *)_cffi_f_clingo_symbolic_atoms_is_external, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 872), (void *)_cffi_d_clingo_symbolic_atoms_is_external },
+  { "clingo_symbolic_atoms_is_fact", (void *)_cffi_f_clingo_symbolic_atoms_is_fact, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 872), (void *)_cffi_d_clingo_symbolic_atoms_is_fact },
+  { "clingo_symbolic_atoms_is_valid", (void *)_cffi_f_clingo_symbolic_atoms_is_valid, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 872), (void *)_cffi_d_clingo_symbolic_atoms_is_valid },
+  { "clingo_symbolic_atoms_iterator_is_equal_to", (void *)_cffi_f_clingo_symbolic_atoms_iterator_is_equal_to, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 887), (void *)_cffi_d_clingo_symbolic_atoms_iterator_is_equal_to },
+  { "clingo_symbolic_atoms_literal", (void *)_cffi_f_clingo_symbolic_atoms_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 877), (void *)_cffi_d_clingo_symbolic_atoms_literal },
+  { "clingo_symbolic_atoms_next", (void *)_cffi_f_clingo_symbolic_atoms_next, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 882), (void *)_cffi_d_clingo_symbolic_atoms_next },
+  { "clingo_symbolic_atoms_signatures", (void *)_cffi_f_clingo_symbolic_atoms_signatures, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 862), (void *)_cffi_d_clingo_symbolic_atoms_signatures },
+  { "clingo_symbolic_atoms_signatures_size", (void *)_cffi_f_clingo_symbolic_atoms_signatures_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 854), (void *)_cffi_d_clingo_symbolic_atoms_signatures_size },
+  { "clingo_symbolic_atoms_size", (void *)_cffi_f_clingo_symbolic_atoms_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 854), (void *)_cffi_d_clingo_symbolic_atoms_size },
+  { "clingo_symbolic_atoms_symbol", (void *)_cffi_f_clingo_symbolic_atoms_symbol, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 882), (void *)_cffi_d_clingo_symbolic_atoms_symbol },
+  { "clingo_theory_atoms_atom_elements", (void *)_cffi_f_clingo_theory_atoms_atom_elements, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 945), (void *)_cffi_d_clingo_theory_atoms_atom_elements },
+  { "clingo_theory_atoms_atom_guard", (void *)_cffi_f_clingo_theory_atoms_atom_guard, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 913), (void *)_cffi_d_clingo_theory_atoms_atom_guard },
+  { "clingo_theory_atoms_atom_has_guard", (void *)_cffi_f_clingo_theory_atoms_atom_has_guard, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 897), (void *)_cffi_d_clingo_theory_atoms_atom_has_guard },
+  { "clingo_theory_atoms_atom_literal", (void *)_cffi_f_clingo_theory_atoms_atom_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 924), (void *)_cffi_d_clingo_theory_atoms_atom_literal },
+  { "clingo_theory_atoms_atom_term", (void *)_cffi_f_clingo_theory_atoms_atom_term, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 940), (void *)_cffi_d_clingo_theory_atoms_atom_term },
+  { "clingo_theory_atoms_atom_to_string", (void *)_cffi_f_clingo_theory_atoms_atom_to_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 902), (void *)_cffi_d_clingo_theory_atoms_atom_to_string },
+  { "clingo_theory_atoms_atom_to_string_size", (void *)_cffi_f_clingo_theory_atoms_atom_to_string_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 935), (void *)_cffi_d_clingo_theory_atoms_atom_to_string_size },
+  { "clingo_theory_atoms_element_condition", (void *)_cffi_f_clingo_theory_atoms_element_condition, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 929), (void *)_cffi_d_clingo_theory_atoms_element_condition },
+  { "clingo_theory_atoms_element_condition_id", (void *)_cffi_f_clingo_theory_atoms_element_condition_id, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 924), (void *)_cffi_d_clingo_theory_atoms_element_condition_id },
+  { "clingo_theory_atoms_element_to_string", (void *)_cffi_f_clingo_theory_atoms_element_to_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 902), (void *)_cffi_d_clingo_theory_atoms_element_to_string },
+  { "clingo_theory_atoms_element_to_string_size", (void *)_cffi_f_clingo_theory_atoms_element_to_string_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 935), (void *)_cffi_d_clingo_theory_atoms_element_to_string_size },
+  { "clingo_theory_atoms_element_tuple", (void *)_cffi_f_clingo_theory_atoms_element_tuple, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 945), (void *)_cffi_d_clingo_theory_atoms_element_tuple },
+  { "clingo_theory_atoms_size", (void *)_cffi_f_clingo_theory_atoms_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 893), (void *)_cffi_d_clingo_theory_atoms_size },
+  { "clingo_theory_atoms_term_arguments", (void *)_cffi_f_clingo_theory_atoms_term_arguments, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 945), (void *)_cffi_d_clingo_theory_atoms_term_arguments },
+  { "clingo_theory_atoms_term_name", (void *)_cffi_f_clingo_theory_atoms_term_name, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 908), (void *)_cffi_d_clingo_theory_atoms_term_name },
+  { "clingo_theory_atoms_term_number", (void *)_cffi_f_clingo_theory_atoms_term_number, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 919), (void *)_cffi_d_clingo_theory_atoms_term_number },
+  { "clingo_theory_atoms_term_to_string", (void *)_cffi_f_clingo_theory_atoms_term_to_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 902), (void *)_cffi_d_clingo_theory_atoms_term_to_string },
+  { "clingo_theory_atoms_term_to_string_size", (void *)_cffi_f_clingo_theory_atoms_term_to_string_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 935), (void *)_cffi_d_clingo_theory_atoms_term_to_string_size },
+  { "clingo_theory_atoms_term_type", (void *)_cffi_f_clingo_theory_atoms_term_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 919), (void *)_cffi_d_clingo_theory_atoms_term_type },
   { "clingo_theory_sequence_type_list", (void *)_cffi_const_clingo_theory_sequence_type_list, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_theory_sequence_type_set", (void *)_cffi_const_clingo_theory_sequence_type_set, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_theory_sequence_type_tuple", (void *)_cffi_const_clingo_theory_sequence_type_tuple, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
@@ -18634,92 +18658,92 @@ static const struct _cffi_global_s _cffi_globals[] = {
   { "clingo_truth_value_false", (void *)_cffi_const_clingo_truth_value_false, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_truth_value_free", (void *)_cffi_const_clingo_truth_value_free, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_truth_value_true", (void *)_cffi_const_clingo_truth_value_true, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_version", (void *)_cffi_f_clingo_version, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1189), (void *)_cffi_d_clingo_version },
+  { "clingo_version", (void *)_cffi_f_clingo_version, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1191), (void *)_cffi_d_clingo_version },
   { "clingo_warning_atom_undefined", (void *)_cffi_const_clingo_warning_atom_undefined, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_warning_file_included", (void *)_cffi_const_clingo_warning_file_included, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_warning_global_variable", (void *)_cffi_const_clingo_warning_global_variable, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_warning_operation_undefined", (void *)_cffi_const_clingo_warning_operation_undefined, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_warning_other", (void *)_cffi_const_clingo_warning_other, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_warning_runtime_error", (void *)_cffi_const_clingo_warning_runtime_error, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_warning_string", (void *)_cffi_f_clingo_warning_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1112), (void *)_cffi_d_clingo_warning_string },
+  { "clingo_warning_string", (void *)_cffi_f_clingo_warning_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1114), (void *)_cffi_d_clingo_warning_string },
   { "clingo_warning_variable_unbounded", (void *)_cffi_const_clingo_warning_variable_unbounded, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_weight_constraint_type_equivalence", (void *)_cffi_const_clingo_weight_constraint_type_equivalence, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_weight_constraint_type_implication_left", (void *)_cffi_const_clingo_weight_constraint_type_implication_left, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_weight_constraint_type_implication_right", (void *)_cffi_const_clingo_weight_constraint_type_implication_right, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "g_clingo_ast_attribute_names", (void *)_cffi_var_g_clingo_ast_attribute_names, _CFFI_OP(_CFFI_OP_GLOBAL_VAR_F, 1253), (void *)0 },
-  { "g_clingo_ast_constructors", (void *)_cffi_var_g_clingo_ast_constructors, _CFFI_OP(_CFFI_OP_GLOBAL_VAR_F, 1256), (void *)0 },
+  { "g_clingo_ast_attribute_names", (void *)_cffi_var_g_clingo_ast_attribute_names, _CFFI_OP(_CFFI_OP_GLOBAL_VAR_F, 1255), (void *)0 },
+  { "g_clingo_ast_constructors", (void *)_cffi_var_g_clingo_ast_constructors, _CFFI_OP(_CFFI_OP_GLOBAL_VAR_F, 1258), (void *)0 },
   { "pyclingo_application_logger", (void *)&_cffi_externpy__pyclingo_application_logger, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 27), (void *)pyclingo_application_logger },
-  { "pyclingo_application_main", (void *)&_cffi_externpy__pyclingo_application_main, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1218), (void *)pyclingo_application_main },
-  { "pyclingo_application_message_limit", (void *)&_cffi_externpy__pyclingo_application_message_limit, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1311), (void *)pyclingo_application_message_limit },
-  { "pyclingo_application_options_parse", (void *)&_cffi_externpy__pyclingo_application_options_parse, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 660), (void *)pyclingo_application_options_parse },
-  { "pyclingo_application_print_model", (void *)&_cffi_externpy__pyclingo_application_print_model, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1224), (void *)pyclingo_application_print_model },
-  { "pyclingo_application_program_name", (void *)&_cffi_externpy__pyclingo_application_program_name, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1247), (void *)pyclingo_application_program_name },
-  { "pyclingo_application_register_options", (void *)&_cffi_externpy__pyclingo_application_register_options, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1225), (void *)pyclingo_application_register_options },
-  { "pyclingo_application_validate_options", (void *)&_cffi_externpy__pyclingo_application_validate_options, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 588), (void *)pyclingo_application_validate_options },
-  { "pyclingo_application_version", (void *)&_cffi_externpy__pyclingo_application_version, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1247), (void *)pyclingo_application_version },
-  { "pyclingo_ast_callback", (void *)&_cffi_externpy__pyclingo_ast_callback, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1217), (void *)pyclingo_ast_callback },
-  { "pyclingo_call", (void *)&_cffi_externpy__pyclingo_call, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1245), (void *)pyclingo_call },
-  { "pyclingo_callable", (void *)&_cffi_externpy__pyclingo_callable, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1216), (void *)pyclingo_callable },
-  { "pyclingo_execute", (void *)&_cffi_externpy__pyclingo_execute, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1244), (void *)pyclingo_execute },
-  { "pyclingo_ground_callback", (void *)&_cffi_externpy__pyclingo_ground_callback, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 476), (void *)pyclingo_ground_callback },
+  { "pyclingo_application_main", (void *)&_cffi_externpy__pyclingo_application_main, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1220), (void *)pyclingo_application_main },
+  { "pyclingo_application_message_limit", (void *)&_cffi_externpy__pyclingo_application_message_limit, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1313), (void *)pyclingo_application_message_limit },
+  { "pyclingo_application_options_parse", (void *)&_cffi_externpy__pyclingo_application_options_parse, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 662), (void *)pyclingo_application_options_parse },
+  { "pyclingo_application_print_model", (void *)&_cffi_externpy__pyclingo_application_print_model, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1226), (void *)pyclingo_application_print_model },
+  { "pyclingo_application_program_name", (void *)&_cffi_externpy__pyclingo_application_program_name, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1249), (void *)pyclingo_application_program_name },
+  { "pyclingo_application_register_options", (void *)&_cffi_externpy__pyclingo_application_register_options, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1227), (void *)pyclingo_application_register_options },
+  { "pyclingo_application_validate_options", (void *)&_cffi_externpy__pyclingo_application_validate_options, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 590), (void *)pyclingo_application_validate_options },
+  { "pyclingo_application_version", (void *)&_cffi_externpy__pyclingo_application_version, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1249), (void *)pyclingo_application_version },
+  { "pyclingo_ast_callback", (void *)&_cffi_externpy__pyclingo_ast_callback, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1219), (void *)pyclingo_ast_callback },
+  { "pyclingo_call", (void *)&_cffi_externpy__pyclingo_call, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1247), (void *)pyclingo_call },
+  { "pyclingo_callable", (void *)&_cffi_externpy__pyclingo_callable, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1218), (void *)pyclingo_callable },
+  { "pyclingo_execute", (void *)&_cffi_externpy__pyclingo_execute, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1246), (void *)pyclingo_execute },
+  { "pyclingo_ground_callback", (void *)&_cffi_externpy__pyclingo_ground_callback, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 478), (void *)pyclingo_ground_callback },
   { "pyclingo_logger_callback", (void *)&_cffi_externpy__pyclingo_logger_callback, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 27), (void *)pyclingo_logger_callback },
-  { "pyclingo_main", (void *)&_cffi_externpy__pyclingo_main, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1246), (void *)pyclingo_main },
-  { "pyclingo_observer_acyc_edge", (void *)&_cffi_externpy__pyclingo_observer_acyc_edge, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1230), (void *)pyclingo_observer_acyc_edge },
-  { "pyclingo_observer_assume", (void *)&_cffi_externpy__pyclingo_observer_assume, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1231), (void *)pyclingo_observer_assume },
-  { "pyclingo_observer_begin_step", (void *)&_cffi_externpy__pyclingo_observer_begin_step, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 588), (void *)pyclingo_observer_begin_step },
-  { "pyclingo_observer_end_step", (void *)&_cffi_externpy__pyclingo_observer_end_step, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 588), (void *)pyclingo_observer_end_step },
-  { "pyclingo_observer_external", (void *)&_cffi_externpy__pyclingo_observer_external, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1238), (void *)pyclingo_observer_external },
-  { "pyclingo_observer_heuristic", (void *)&_cffi_externpy__pyclingo_observer_heuristic, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1236), (void *)pyclingo_observer_heuristic },
-  { "pyclingo_observer_init_program", (void *)&_cffi_externpy__pyclingo_observer_init_program, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1215), (void *)pyclingo_observer_init_program },
-  { "pyclingo_observer_minimize", (void *)&_cffi_externpy__pyclingo_observer_minimize, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1232), (void *)pyclingo_observer_minimize },
-  { "pyclingo_observer_output_atom", (void *)&_cffi_externpy__pyclingo_observer_output_atom, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1243), (void *)pyclingo_observer_output_atom },
-  { "pyclingo_observer_output_term", (void *)&_cffi_externpy__pyclingo_observer_output_term, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1242), (void *)pyclingo_observer_output_term },
-  { "pyclingo_observer_project", (void *)&_cffi_externpy__pyclingo_observer_project, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1233), (void *)pyclingo_observer_project },
-  { "pyclingo_observer_rule", (void *)&_cffi_externpy__pyclingo_observer_rule, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1213), (void *)pyclingo_observer_rule },
-  { "pyclingo_observer_theory_atom", (void *)&_cffi_externpy__pyclingo_observer_theory_atom, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1241), (void *)pyclingo_observer_theory_atom },
-  { "pyclingo_observer_theory_atom_with_guard", (void *)&_cffi_externpy__pyclingo_observer_theory_atom_with_guard, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1240), (void *)pyclingo_observer_theory_atom_with_guard },
-  { "pyclingo_observer_theory_element", (void *)&_cffi_externpy__pyclingo_observer_theory_element, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1239), (void *)pyclingo_observer_theory_element },
-  { "pyclingo_observer_theory_term_compound", (void *)&_cffi_externpy__pyclingo_observer_theory_term_compound, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1237), (void *)pyclingo_observer_theory_term_compound },
-  { "pyclingo_observer_theory_term_number", (void *)&_cffi_externpy__pyclingo_observer_theory_term_number, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1238), (void *)pyclingo_observer_theory_term_number },
-  { "pyclingo_observer_theory_term_string", (void *)&_cffi_externpy__pyclingo_observer_theory_term_string, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1234), (void *)pyclingo_observer_theory_term_string },
-  { "pyclingo_observer_weight_rule", (void *)&_cffi_externpy__pyclingo_observer_weight_rule, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1214), (void *)pyclingo_observer_weight_rule },
-  { "pyclingo_propagator_check", (void *)&_cffi_externpy__pyclingo_propagator_check, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1227), (void *)pyclingo_propagator_check },
-  { "pyclingo_propagator_decide", (void *)&_cffi_externpy__pyclingo_propagator_decide, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1235), (void *)pyclingo_propagator_decide },
-  { "pyclingo_propagator_init", (void *)&_cffi_externpy__pyclingo_propagator_init, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1228), (void *)pyclingo_propagator_init },
-  { "pyclingo_propagator_propagate", (void *)&_cffi_externpy__pyclingo_propagator_propagate, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1226), (void *)pyclingo_propagator_propagate },
-  { "pyclingo_propagator_undo", (void *)&_cffi_externpy__pyclingo_propagator_undo, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1312), (void *)pyclingo_propagator_undo },
-  { "pyclingo_script_call", (void *)&_cffi_externpy__pyclingo_script_call, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1221), (void *)pyclingo_script_call },
-  { "pyclingo_script_callable", (void *)&_cffi_externpy__pyclingo_script_callable, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1216), (void *)pyclingo_script_callable },
-  { "pyclingo_script_execute", (void *)&_cffi_externpy__pyclingo_script_execute, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1220), (void *)pyclingo_script_execute },
-  { "pyclingo_script_main", (void *)&_cffi_externpy__pyclingo_script_main, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1219), (void *)pyclingo_script_main },
-  { "pyclingo_solve_event_callback", (void *)&_cffi_externpy__pyclingo_solve_event_callback, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 503), (void *)pyclingo_solve_event_callback },
+  { "pyclingo_main", (void *)&_cffi_externpy__pyclingo_main, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1248), (void *)pyclingo_main },
+  { "pyclingo_observer_acyc_edge", (void *)&_cffi_externpy__pyclingo_observer_acyc_edge, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1232), (void *)pyclingo_observer_acyc_edge },
+  { "pyclingo_observer_assume", (void *)&_cffi_externpy__pyclingo_observer_assume, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1233), (void *)pyclingo_observer_assume },
+  { "pyclingo_observer_begin_step", (void *)&_cffi_externpy__pyclingo_observer_begin_step, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 590), (void *)pyclingo_observer_begin_step },
+  { "pyclingo_observer_end_step", (void *)&_cffi_externpy__pyclingo_observer_end_step, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 590), (void *)pyclingo_observer_end_step },
+  { "pyclingo_observer_external", (void *)&_cffi_externpy__pyclingo_observer_external, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1240), (void *)pyclingo_observer_external },
+  { "pyclingo_observer_heuristic", (void *)&_cffi_externpy__pyclingo_observer_heuristic, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1238), (void *)pyclingo_observer_heuristic },
+  { "pyclingo_observer_init_program", (void *)&_cffi_externpy__pyclingo_observer_init_program, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1217), (void *)pyclingo_observer_init_program },
+  { "pyclingo_observer_minimize", (void *)&_cffi_externpy__pyclingo_observer_minimize, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1234), (void *)pyclingo_observer_minimize },
+  { "pyclingo_observer_output_atom", (void *)&_cffi_externpy__pyclingo_observer_output_atom, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1245), (void *)pyclingo_observer_output_atom },
+  { "pyclingo_observer_output_term", (void *)&_cffi_externpy__pyclingo_observer_output_term, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1244), (void *)pyclingo_observer_output_term },
+  { "pyclingo_observer_project", (void *)&_cffi_externpy__pyclingo_observer_project, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1235), (void *)pyclingo_observer_project },
+  { "pyclingo_observer_rule", (void *)&_cffi_externpy__pyclingo_observer_rule, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1215), (void *)pyclingo_observer_rule },
+  { "pyclingo_observer_theory_atom", (void *)&_cffi_externpy__pyclingo_observer_theory_atom, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1243), (void *)pyclingo_observer_theory_atom },
+  { "pyclingo_observer_theory_atom_with_guard", (void *)&_cffi_externpy__pyclingo_observer_theory_atom_with_guard, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1242), (void *)pyclingo_observer_theory_atom_with_guard },
+  { "pyclingo_observer_theory_element", (void *)&_cffi_externpy__pyclingo_observer_theory_element, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1241), (void *)pyclingo_observer_theory_element },
+  { "pyclingo_observer_theory_term_compound", (void *)&_cffi_externpy__pyclingo_observer_theory_term_compound, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1239), (void *)pyclingo_observer_theory_term_compound },
+  { "pyclingo_observer_theory_term_number", (void *)&_cffi_externpy__pyclingo_observer_theory_term_number, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1240), (void *)pyclingo_observer_theory_term_number },
+  { "pyclingo_observer_theory_term_string", (void *)&_cffi_externpy__pyclingo_observer_theory_term_string, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1236), (void *)pyclingo_observer_theory_term_string },
+  { "pyclingo_observer_weight_rule", (void *)&_cffi_externpy__pyclingo_observer_weight_rule, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1216), (void *)pyclingo_observer_weight_rule },
+  { "pyclingo_propagator_check", (void *)&_cffi_externpy__pyclingo_propagator_check, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1229), (void *)pyclingo_propagator_check },
+  { "pyclingo_propagator_decide", (void *)&_cffi_externpy__pyclingo_propagator_decide, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1237), (void *)pyclingo_propagator_decide },
+  { "pyclingo_propagator_init", (void *)&_cffi_externpy__pyclingo_propagator_init, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1230), (void *)pyclingo_propagator_init },
+  { "pyclingo_propagator_propagate", (void *)&_cffi_externpy__pyclingo_propagator_propagate, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1228), (void *)pyclingo_propagator_propagate },
+  { "pyclingo_propagator_undo", (void *)&_cffi_externpy__pyclingo_propagator_undo, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1314), (void *)pyclingo_propagator_undo },
+  { "pyclingo_script_call", (void *)&_cffi_externpy__pyclingo_script_call, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1223), (void *)pyclingo_script_call },
+  { "pyclingo_script_callable", (void *)&_cffi_externpy__pyclingo_script_callable, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1218), (void *)pyclingo_script_callable },
+  { "pyclingo_script_execute", (void *)&_cffi_externpy__pyclingo_script_execute, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1222), (void *)pyclingo_script_execute },
+  { "pyclingo_script_main", (void *)&_cffi_externpy__pyclingo_script_main, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1221), (void *)pyclingo_script_main },
+  { "pyclingo_solve_event_callback", (void *)&_cffi_externpy__pyclingo_solve_event_callback, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 505), (void *)pyclingo_solve_event_callback },
 };
 
 static const struct _cffi_field_s _cffi_fields[] = {
   { "program_name", offsetof(clingo_application_t, program_name),
                     sizeof(((clingo_application_t *)0)->program_name),
-                    _CFFI_OP(_CFFI_OP_NOOP, 1247) },
+                    _CFFI_OP(_CFFI_OP_NOOP, 1249) },
   { "version", offsetof(clingo_application_t, version),
                sizeof(((clingo_application_t *)0)->version),
-               _CFFI_OP(_CFFI_OP_NOOP, 1247) },
+               _CFFI_OP(_CFFI_OP_NOOP, 1249) },
   { "message_limit", offsetof(clingo_application_t, message_limit),
                      sizeof(((clingo_application_t *)0)->message_limit),
-                     _CFFI_OP(_CFFI_OP_NOOP, 1311) },
+                     _CFFI_OP(_CFFI_OP_NOOP, 1313) },
   { "main", offsetof(clingo_application_t, main),
             sizeof(((clingo_application_t *)0)->main),
-            _CFFI_OP(_CFFI_OP_NOOP, 1218) },
+            _CFFI_OP(_CFFI_OP_NOOP, 1220) },
   { "logger", offsetof(clingo_application_t, logger),
               sizeof(((clingo_application_t *)0)->logger),
               _CFFI_OP(_CFFI_OP_NOOP, 27) },
   { "printer", offsetof(clingo_application_t, printer),
                sizeof(((clingo_application_t *)0)->printer),
-               _CFFI_OP(_CFFI_OP_NOOP, 1224) },
+               _CFFI_OP(_CFFI_OP_NOOP, 1226) },
   { "register_options", offsetof(clingo_application_t, register_options),
                         sizeof(((clingo_application_t *)0)->register_options),
-                        _CFFI_OP(_CFFI_OP_NOOP, 1225) },
+                        _CFFI_OP(_CFFI_OP_NOOP, 1227) },
   { "validate_options", offsetof(clingo_application_t, validate_options),
                         sizeof(((clingo_application_t *)0)->validate_options),
-                        _CFFI_OP(_CFFI_OP_NOOP, 588) },
+                        _CFFI_OP(_CFFI_OP_NOOP, 590) },
   { "attribute", offsetof(clingo_ast_argument_t, attribute),
                  sizeof(((clingo_ast_argument_t *)0)->attribute),
                  _CFFI_OP(_CFFI_OP_NOOP, 155) },
@@ -18737,73 +18761,73 @@ static const struct _cffi_field_s _cffi_fields[] = {
             _CFFI_OP(_CFFI_OP_NOOP, 40) },
   { "arguments", offsetof(clingo_ast_constructor_t, arguments),
                  sizeof(((clingo_ast_constructor_t *)0)->arguments),
-                 _CFFI_OP(_CFFI_OP_NOOP, 1251) },
+                 _CFFI_OP(_CFFI_OP_NOOP, 1253) },
   { "size", offsetof(clingo_ast_constructor_t, size),
             sizeof(((clingo_ast_constructor_t *)0)->size),
             _CFFI_OP(_CFFI_OP_NOOP, 3) },
   { "constructors", offsetof(clingo_ast_constructors_t, constructors),
                     sizeof(((clingo_ast_constructors_t *)0)->constructors),
-                    _CFFI_OP(_CFFI_OP_NOOP, 1254) },
+                    _CFFI_OP(_CFFI_OP_NOOP, 1256) },
   { "size", offsetof(clingo_ast_constructors_t, size),
             sizeof(((clingo_ast_constructors_t *)0)->size),
             _CFFI_OP(_CFFI_OP_NOOP, 3) },
   { "init_program", offsetof(clingo_ground_program_observer_t, init_program),
                     sizeof(((clingo_ground_program_observer_t *)0)->init_program),
-                    _CFFI_OP(_CFFI_OP_NOOP, 1215) },
+                    _CFFI_OP(_CFFI_OP_NOOP, 1217) },
   { "begin_step", offsetof(clingo_ground_program_observer_t, begin_step),
                   sizeof(((clingo_ground_program_observer_t *)0)->begin_step),
-                  _CFFI_OP(_CFFI_OP_NOOP, 588) },
+                  _CFFI_OP(_CFFI_OP_NOOP, 590) },
   { "end_step", offsetof(clingo_ground_program_observer_t, end_step),
                 sizeof(((clingo_ground_program_observer_t *)0)->end_step),
-                _CFFI_OP(_CFFI_OP_NOOP, 588) },
+                _CFFI_OP(_CFFI_OP_NOOP, 590) },
   { "rule", offsetof(clingo_ground_program_observer_t, rule),
             sizeof(((clingo_ground_program_observer_t *)0)->rule),
-            _CFFI_OP(_CFFI_OP_NOOP, 1213) },
+            _CFFI_OP(_CFFI_OP_NOOP, 1215) },
   { "weight_rule", offsetof(clingo_ground_program_observer_t, weight_rule),
                    sizeof(((clingo_ground_program_observer_t *)0)->weight_rule),
-                   _CFFI_OP(_CFFI_OP_NOOP, 1214) },
+                   _CFFI_OP(_CFFI_OP_NOOP, 1216) },
   { "minimize", offsetof(clingo_ground_program_observer_t, minimize),
                 sizeof(((clingo_ground_program_observer_t *)0)->minimize),
-                _CFFI_OP(_CFFI_OP_NOOP, 1232) },
+                _CFFI_OP(_CFFI_OP_NOOP, 1234) },
   { "project", offsetof(clingo_ground_program_observer_t, project),
                sizeof(((clingo_ground_program_observer_t *)0)->project),
-               _CFFI_OP(_CFFI_OP_NOOP, 1233) },
+               _CFFI_OP(_CFFI_OP_NOOP, 1235) },
   { "output_atom", offsetof(clingo_ground_program_observer_t, output_atom),
                    sizeof(((clingo_ground_program_observer_t *)0)->output_atom),
-                   _CFFI_OP(_CFFI_OP_NOOP, 1243) },
+                   _CFFI_OP(_CFFI_OP_NOOP, 1245) },
   { "output_term", offsetof(clingo_ground_program_observer_t, output_term),
                    sizeof(((clingo_ground_program_observer_t *)0)->output_term),
-                   _CFFI_OP(_CFFI_OP_NOOP, 1242) },
+                   _CFFI_OP(_CFFI_OP_NOOP, 1244) },
   { "external", offsetof(clingo_ground_program_observer_t, external),
                 sizeof(((clingo_ground_program_observer_t *)0)->external),
-                _CFFI_OP(_CFFI_OP_NOOP, 1238) },
+                _CFFI_OP(_CFFI_OP_NOOP, 1240) },
   { "assume", offsetof(clingo_ground_program_observer_t, assume),
               sizeof(((clingo_ground_program_observer_t *)0)->assume),
-              _CFFI_OP(_CFFI_OP_NOOP, 1231) },
+              _CFFI_OP(_CFFI_OP_NOOP, 1233) },
   { "heuristic", offsetof(clingo_ground_program_observer_t, heuristic),
                  sizeof(((clingo_ground_program_observer_t *)0)->heuristic),
-                 _CFFI_OP(_CFFI_OP_NOOP, 1236) },
+                 _CFFI_OP(_CFFI_OP_NOOP, 1238) },
   { "acyc_edge", offsetof(clingo_ground_program_observer_t, acyc_edge),
                  sizeof(((clingo_ground_program_observer_t *)0)->acyc_edge),
-                 _CFFI_OP(_CFFI_OP_NOOP, 1230) },
+                 _CFFI_OP(_CFFI_OP_NOOP, 1232) },
   { "theory_term_number", offsetof(clingo_ground_program_observer_t, theory_term_number),
                           sizeof(((clingo_ground_program_observer_t *)0)->theory_term_number),
-                          _CFFI_OP(_CFFI_OP_NOOP, 1238) },
+                          _CFFI_OP(_CFFI_OP_NOOP, 1240) },
   { "theory_term_string", offsetof(clingo_ground_program_observer_t, theory_term_string),
                           sizeof(((clingo_ground_program_observer_t *)0)->theory_term_string),
-                          _CFFI_OP(_CFFI_OP_NOOP, 1234) },
+                          _CFFI_OP(_CFFI_OP_NOOP, 1236) },
   { "theory_term_compound", offsetof(clingo_ground_program_observer_t, theory_term_compound),
                             sizeof(((clingo_ground_program_observer_t *)0)->theory_term_compound),
-                            _CFFI_OP(_CFFI_OP_NOOP, 1237) },
+                            _CFFI_OP(_CFFI_OP_NOOP, 1239) },
   { "theory_element", offsetof(clingo_ground_program_observer_t, theory_element),
                       sizeof(((clingo_ground_program_observer_t *)0)->theory_element),
-                      _CFFI_OP(_CFFI_OP_NOOP, 1239) },
+                      _CFFI_OP(_CFFI_OP_NOOP, 1241) },
   { "theory_atom", offsetof(clingo_ground_program_observer_t, theory_atom),
                    sizeof(((clingo_ground_program_observer_t *)0)->theory_atom),
-                   _CFFI_OP(_CFFI_OP_NOOP, 1241) },
+                   _CFFI_OP(_CFFI_OP_NOOP, 1243) },
   { "theory_atom_with_guard", offsetof(clingo_ground_program_observer_t, theory_atom_with_guard),
                               sizeof(((clingo_ground_program_observer_t *)0)->theory_atom_with_guard),
-                              _CFFI_OP(_CFFI_OP_NOOP, 1240) },
+                              _CFFI_OP(_CFFI_OP_NOOP, 1242) },
   { "begin_file", offsetof(clingo_location_t, begin_file),
                   sizeof(((clingo_location_t *)0)->begin_file),
                   _CFFI_OP(_CFFI_OP_NOOP, 40) },
@@ -18833,34 +18857,34 @@ static const struct _cffi_field_s _cffi_fields[] = {
             _CFFI_OP(_CFFI_OP_NOOP, 3) },
   { "init", offsetof(clingo_propagator_t, init),
             sizeof(((clingo_propagator_t *)0)->init),
-            _CFFI_OP(_CFFI_OP_NOOP, 1228) },
+            _CFFI_OP(_CFFI_OP_NOOP, 1230) },
   { "propagate", offsetof(clingo_propagator_t, propagate),
                  sizeof(((clingo_propagator_t *)0)->propagate),
-                 _CFFI_OP(_CFFI_OP_NOOP, 1226) },
+                 _CFFI_OP(_CFFI_OP_NOOP, 1228) },
   { "undo", offsetof(clingo_propagator_t, undo),
             sizeof(((clingo_propagator_t *)0)->undo),
-            _CFFI_OP(_CFFI_OP_NOOP, 1312) },
+            _CFFI_OP(_CFFI_OP_NOOP, 1314) },
   { "check", offsetof(clingo_propagator_t, check),
              sizeof(((clingo_propagator_t *)0)->check),
-             _CFFI_OP(_CFFI_OP_NOOP, 1227) },
+             _CFFI_OP(_CFFI_OP_NOOP, 1229) },
   { "decide", offsetof(clingo_propagator_t, decide),
               sizeof(((clingo_propagator_t *)0)->decide),
-              _CFFI_OP(_CFFI_OP_NOOP, 1235) },
+              _CFFI_OP(_CFFI_OP_NOOP, 1237) },
   { "execute", offsetof(clingo_script_t, execute),
                sizeof(((clingo_script_t *)0)->execute),
-               _CFFI_OP(_CFFI_OP_NOOP, 1223) },
+               _CFFI_OP(_CFFI_OP_NOOP, 1225) },
   { "call", offsetof(clingo_script_t, call),
             sizeof(((clingo_script_t *)0)->call),
-            _CFFI_OP(_CFFI_OP_NOOP, 1222) },
+            _CFFI_OP(_CFFI_OP_NOOP, 1224) },
   { "callable", offsetof(clingo_script_t, callable),
                 sizeof(((clingo_script_t *)0)->callable),
-                _CFFI_OP(_CFFI_OP_NOOP, 1216) },
+                _CFFI_OP(_CFFI_OP_NOOP, 1218) },
   { "main", offsetof(clingo_script_t, main),
             sizeof(((clingo_script_t *)0)->main),
-            _CFFI_OP(_CFFI_OP_NOOP, 1219) },
+            _CFFI_OP(_CFFI_OP_NOOP, 1221) },
   { "free", offsetof(clingo_script_t, free),
             sizeof(((clingo_script_t *)0)->free),
-            _CFFI_OP(_CFFI_OP_NOOP, 1313) },
+            _CFFI_OP(_CFFI_OP_NOOP, 1315) },
   { "version", offsetof(clingo_script_t, version),
                sizeof(((clingo_script_t *)0)->version),
                _CFFI_OP(_CFFI_OP_NOOP, 40) },
@@ -18873,144 +18897,144 @@ static const struct _cffi_field_s _cffi_fields[] = {
 };
 
 static const struct _cffi_struct_union_s _cffi_struct_unions[] = {
-  { "clingo_application", 1249, _CFFI_F_CHECK_FIELDS,
+  { "clingo_application", 1251, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_application_t), offsetof(struct _cffi_align__clingo_application_t, y), 0, 8 },
-  { "clingo_assignment", 1250, _CFFI_F_OPAQUE,
+  { "clingo_assignment", 1252, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_ast", 1257, _CFFI_F_OPAQUE,
+  { "clingo_ast", 1259, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_ast_argument", 1252, _CFFI_F_CHECK_FIELDS,
+  { "clingo_ast_argument", 1254, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_ast_argument_t), offsetof(struct _cffi_align__clingo_ast_argument_t, y), 8, 2 },
-  { "clingo_ast_attribute_names", 1253, _CFFI_F_CHECK_FIELDS,
+  { "clingo_ast_attribute_names", 1255, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_ast_attribute_names_t), offsetof(struct _cffi_align__clingo_ast_attribute_names_t, y), 10, 2 },
-  { "clingo_ast_constructor", 1255, _CFFI_F_CHECK_FIELDS,
+  { "clingo_ast_constructor", 1257, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_ast_constructor_t), offsetof(struct _cffi_align__clingo_ast_constructor_t, y), 12, 3 },
-  { "clingo_ast_constructors", 1256, _CFFI_F_CHECK_FIELDS,
+  { "clingo_ast_constructors", 1258, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_ast_constructors_t), offsetof(struct _cffi_align__clingo_ast_constructors_t, y), 15, 2 },
-  { "clingo_backend", 1258, _CFFI_F_OPAQUE,
+  { "clingo_backend", 1260, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_configuration", 1259, _CFFI_F_OPAQUE,
+  { "clingo_configuration", 1261, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_control", 1260, _CFFI_F_OPAQUE,
+  { "clingo_control", 1262, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_ground_program_observer", 1261, _CFFI_F_CHECK_FIELDS,
+  { "clingo_ground_program_observer", 1263, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_ground_program_observer_t), offsetof(struct _cffi_align__clingo_ground_program_observer_t, y), 17, 19 },
-  { "clingo_location", 1262, _CFFI_F_CHECK_FIELDS,
+  { "clingo_location", 1264, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_location_t), offsetof(struct _cffi_align__clingo_location_t, y), 36, 6 },
-  { "clingo_model", 1263, _CFFI_F_OPAQUE,
+  { "clingo_model", 1265, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_options", 1264, _CFFI_F_OPAQUE,
+  { "clingo_options", 1266, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_part", 1265, _CFFI_F_CHECK_FIELDS,
+  { "clingo_part", 1267, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_part_t), offsetof(struct _cffi_align__clingo_part_t, y), 42, 3 },
-  { "clingo_program_builder", 1266, _CFFI_F_OPAQUE,
+  { "clingo_program_builder", 1268, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_propagate_control", 1267, _CFFI_F_OPAQUE,
+  { "clingo_propagate_control", 1269, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_propagate_init", 1268, _CFFI_F_OPAQUE,
+  { "clingo_propagate_init", 1270, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_propagator", 1269, _CFFI_F_CHECK_FIELDS,
+  { "clingo_propagator", 1271, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_propagator_t), offsetof(struct _cffi_align__clingo_propagator_t, y), 45, 5 },
-  { "clingo_script", 1270, _CFFI_F_CHECK_FIELDS,
+  { "clingo_script", 1272, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_script_t), offsetof(struct _cffi_align__clingo_script_t, y), 50, 6 },
-  { "clingo_solve_control", 1271, _CFFI_F_OPAQUE,
+  { "clingo_solve_control", 1273, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_solve_handle", 1272, _CFFI_F_OPAQUE,
+  { "clingo_solve_handle", 1274, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_statistic", 1273, _CFFI_F_OPAQUE,
+  { "clingo_statistic", 1275, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_symbolic_atoms", 1274, _CFFI_F_OPAQUE,
+  { "clingo_symbolic_atoms", 1276, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_theory_atoms", 1275, _CFFI_F_OPAQUE,
+  { "clingo_theory_atoms", 1277, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_weighted_literal", 1276, _CFFI_F_CHECK_FIELDS,
+  { "clingo_weighted_literal", 1278, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_weighted_literal_t), offsetof(struct _cffi_align__clingo_weighted_literal_t, y), 56, 2 },
 };
 
 static const struct _cffi_enum_s _cffi_enums[] = {
-  { "clingo_ast_aggregate_function_e", 1277, _cffi_prim_int(sizeof(enum clingo_ast_aggregate_function_e), ((enum clingo_ast_aggregate_function_e)-1) <= 0),
+  { "clingo_ast_aggregate_function_e", 1279, _cffi_prim_int(sizeof(enum clingo_ast_aggregate_function_e), ((enum clingo_ast_aggregate_function_e)-1) <= 0),
     "clingo_ast_aggregate_function_count,clingo_ast_aggregate_function_sum,clingo_ast_aggregate_function_sump,clingo_ast_aggregate_function_min,clingo_ast_aggregate_function_max" },
-  { "clingo_ast_attribute_e", 1278, _cffi_prim_int(sizeof(enum clingo_ast_attribute_e), ((enum clingo_ast_attribute_e)-1) <= 0),
+  { "clingo_ast_attribute_e", 1280, _cffi_prim_int(sizeof(enum clingo_ast_attribute_e), ((enum clingo_ast_attribute_e)-1) <= 0),
     "clingo_ast_attribute_argument,clingo_ast_attribute_arguments,clingo_ast_attribute_arity,clingo_ast_attribute_atom,clingo_ast_attribute_atoms,clingo_ast_attribute_atom_type,clingo_ast_attribute_bias,clingo_ast_attribute_body,clingo_ast_attribute_code,clingo_ast_attribute_coefficient,clingo_ast_attribute_comparison,clingo_ast_attribute_condition,clingo_ast_attribute_elements,clingo_ast_attribute_external,clingo_ast_attribute_external_type,clingo_ast_attribute_function,clingo_ast_attribute_guard,clingo_ast_attribute_guards,clingo_ast_attribute_head,clingo_ast_attribute_is_default,clingo_ast_attribute_left,clingo_ast_attribute_left_guard,clingo_ast_attribute_literal,clingo_ast_attribute_location,clingo_ast_attribute_modifier,clingo_ast_attribute_name,clingo_ast_attribute_node_u,clingo_ast_attribute_node_v,clingo_ast_attribute_operator_name,clingo_ast_attribute_operator_type,clingo_ast_attribute_operators,clingo_ast_attribute_parameters,clingo_ast_attribute_positive,clingo_ast_attribute_priority,clingo_ast_attribute_right,clingo_ast_attribute_right_guard,clingo_ast_attribute_sequence_type,clingo_ast_attribute_sign,clingo_ast_attribute_symbol,clingo_ast_attribute_term,clingo_ast_attribute_terms,clingo_ast_attribute_value,clingo_ast_attribute_variable,clingo_ast_attribute_weight,clingo_ast_attribute_comment_type" },
-  { "clingo_ast_attribute_type_e", 1279, _cffi_prim_int(sizeof(enum clingo_ast_attribute_type_e), ((enum clingo_ast_attribute_type_e)-1) <= 0),
+  { "clingo_ast_attribute_type_e", 1281, _cffi_prim_int(sizeof(enum clingo_ast_attribute_type_e), ((enum clingo_ast_attribute_type_e)-1) <= 0),
     "clingo_ast_attribute_type_number,clingo_ast_attribute_type_symbol,clingo_ast_attribute_type_location,clingo_ast_attribute_type_string,clingo_ast_attribute_type_ast,clingo_ast_attribute_type_optional_ast,clingo_ast_attribute_type_string_array,clingo_ast_attribute_type_ast_array" },
-  { "clingo_ast_binary_operator_e", 1280, _cffi_prim_int(sizeof(enum clingo_ast_binary_operator_e), ((enum clingo_ast_binary_operator_e)-1) <= 0),
+  { "clingo_ast_binary_operator_e", 1282, _cffi_prim_int(sizeof(enum clingo_ast_binary_operator_e), ((enum clingo_ast_binary_operator_e)-1) <= 0),
     "clingo_ast_binary_operator_xor,clingo_ast_binary_operator_or,clingo_ast_binary_operator_and,clingo_ast_binary_operator_plus,clingo_ast_binary_operator_minus,clingo_ast_binary_operator_multiplication,clingo_ast_binary_operator_division,clingo_ast_binary_operator_modulo,clingo_ast_binary_operator_power" },
-  { "clingo_ast_comparison_operator_e", 1281, _cffi_prim_int(sizeof(enum clingo_ast_comparison_operator_e), ((enum clingo_ast_comparison_operator_e)-1) <= 0),
+  { "clingo_ast_comparison_operator_e", 1283, _cffi_prim_int(sizeof(enum clingo_ast_comparison_operator_e), ((enum clingo_ast_comparison_operator_e)-1) <= 0),
     "clingo_ast_comparison_operator_greater_than,clingo_ast_comparison_operator_less_than,clingo_ast_comparison_operator_less_equal,clingo_ast_comparison_operator_greater_equal,clingo_ast_comparison_operator_not_equal,clingo_ast_comparison_operator_equal" },
-  { "clingo_ast_sign_e", 1282, _cffi_prim_int(sizeof(enum clingo_ast_sign_e), ((enum clingo_ast_sign_e)-1) <= 0),
+  { "clingo_ast_sign_e", 1284, _cffi_prim_int(sizeof(enum clingo_ast_sign_e), ((enum clingo_ast_sign_e)-1) <= 0),
     "clingo_ast_sign_no_sign,clingo_ast_sign_negation,clingo_ast_sign_double_negation" },
-  { "clingo_ast_theory_atom_definition_type_e", 1283, _cffi_prim_int(sizeof(enum clingo_ast_theory_atom_definition_type_e), ((enum clingo_ast_theory_atom_definition_type_e)-1) <= 0),
+  { "clingo_ast_theory_atom_definition_type_e", 1285, _cffi_prim_int(sizeof(enum clingo_ast_theory_atom_definition_type_e), ((enum clingo_ast_theory_atom_definition_type_e)-1) <= 0),
     "clingo_ast_theory_atom_definition_type_head,clingo_ast_theory_atom_definition_type_body,clingo_ast_theory_atom_definition_type_any,clingo_ast_theory_atom_definition_type_directive" },
-  { "clingo_ast_theory_operator_type_e", 1284, _cffi_prim_int(sizeof(enum clingo_ast_theory_operator_type_e), ((enum clingo_ast_theory_operator_type_e)-1) <= 0),
+  { "clingo_ast_theory_operator_type_e", 1286, _cffi_prim_int(sizeof(enum clingo_ast_theory_operator_type_e), ((enum clingo_ast_theory_operator_type_e)-1) <= 0),
     "clingo_ast_theory_operator_type_unary,clingo_ast_theory_operator_type_binary_left,clingo_ast_theory_operator_type_binary_right" },
-  { "clingo_ast_theory_sequence_type_e", 1285, _cffi_prim_int(sizeof(enum clingo_ast_theory_sequence_type_e), ((enum clingo_ast_theory_sequence_type_e)-1) <= 0),
+  { "clingo_ast_theory_sequence_type_e", 1287, _cffi_prim_int(sizeof(enum clingo_ast_theory_sequence_type_e), ((enum clingo_ast_theory_sequence_type_e)-1) <= 0),
     "clingo_ast_theory_sequence_type_tuple,clingo_ast_theory_sequence_type_list,clingo_ast_theory_sequence_type_set" },
-  { "clingo_ast_type_e", 1286, _cffi_prim_int(sizeof(enum clingo_ast_type_e), ((enum clingo_ast_type_e)-1) <= 0),
+  { "clingo_ast_type_e", 1288, _cffi_prim_int(sizeof(enum clingo_ast_type_e), ((enum clingo_ast_type_e)-1) <= 0),
     "clingo_ast_type_id,clingo_ast_type_variable,clingo_ast_type_symbolic_term,clingo_ast_type_unary_operation,clingo_ast_type_binary_operation,clingo_ast_type_interval,clingo_ast_type_function,clingo_ast_type_pool,clingo_ast_type_boolean_constant,clingo_ast_type_symbolic_atom,clingo_ast_type_comparison,clingo_ast_type_guard,clingo_ast_type_conditional_literal,clingo_ast_type_aggregate,clingo_ast_type_body_aggregate_element,clingo_ast_type_body_aggregate,clingo_ast_type_head_aggregate_element,clingo_ast_type_head_aggregate,clingo_ast_type_disjunction,clingo_ast_type_theory_sequence,clingo_ast_type_theory_function,clingo_ast_type_theory_unparsed_term_element,clingo_ast_type_theory_unparsed_term,clingo_ast_type_theory_guard,clingo_ast_type_theory_atom_element,clingo_ast_type_theory_atom,clingo_ast_type_literal,clingo_ast_type_theory_operator_definition,clingo_ast_type_theory_term_definition,clingo_ast_type_theory_guard_definition,clingo_ast_type_theory_atom_definition,clingo_ast_type_rule,clingo_ast_type_definition,clingo_ast_type_show_signature,clingo_ast_type_show_term,clingo_ast_type_minimize,clingo_ast_type_script,clingo_ast_type_program,clingo_ast_type_external,clingo_ast_type_edge,clingo_ast_type_heuristic,clingo_ast_type_project_atom,clingo_ast_type_project_signature,clingo_ast_type_defined,clingo_ast_type_theory_definition,clingo_ast_type_comment" },
-  { "clingo_ast_unary_operator_e", 1287, _cffi_prim_int(sizeof(enum clingo_ast_unary_operator_e), ((enum clingo_ast_unary_operator_e)-1) <= 0),
+  { "clingo_ast_unary_operator_e", 1289, _cffi_prim_int(sizeof(enum clingo_ast_unary_operator_e), ((enum clingo_ast_unary_operator_e)-1) <= 0),
     "clingo_ast_unary_operator_minus,clingo_ast_unary_operator_negation,clingo_ast_unary_operator_absolute" },
-  { "clingo_ast_unpool_type_e", 1288, _cffi_prim_int(sizeof(enum clingo_ast_unpool_type_e), ((enum clingo_ast_unpool_type_e)-1) <= 0),
+  { "clingo_ast_unpool_type_e", 1290, _cffi_prim_int(sizeof(enum clingo_ast_unpool_type_e), ((enum clingo_ast_unpool_type_e)-1) <= 0),
     "clingo_ast_unpool_type_condition,clingo_ast_unpool_type_other,clingo_ast_unpool_type_all" },
-  { "clingo_clause_type_e", 1289, _cffi_prim_int(sizeof(enum clingo_clause_type_e), ((enum clingo_clause_type_e)-1) <= 0),
+  { "clingo_clause_type_e", 1291, _cffi_prim_int(sizeof(enum clingo_clause_type_e), ((enum clingo_clause_type_e)-1) <= 0),
     "clingo_clause_type_learnt,clingo_clause_type_static,clingo_clause_type_volatile,clingo_clause_type_volatile_static" },
-  { "clingo_comment_type_e", 1290, _cffi_prim_int(sizeof(enum clingo_comment_type_e), ((enum clingo_comment_type_e)-1) <= 0),
+  { "clingo_comment_type_e", 1292, _cffi_prim_int(sizeof(enum clingo_comment_type_e), ((enum clingo_comment_type_e)-1) <= 0),
     "clingo_comment_type_line,clingo_comment_type_block" },
-  { "clingo_configuration_type_e", 1291, _cffi_prim_int(sizeof(enum clingo_configuration_type_e), ((enum clingo_configuration_type_e)-1) <= 0),
+  { "clingo_configuration_type_e", 1293, _cffi_prim_int(sizeof(enum clingo_configuration_type_e), ((enum clingo_configuration_type_e)-1) <= 0),
     "clingo_configuration_type_value,clingo_configuration_type_array,clingo_configuration_type_map" },
-  { "clingo_consequence_e", 1292, _cffi_prim_int(sizeof(enum clingo_consequence_e), ((enum clingo_consequence_e)-1) <= 0),
+  { "clingo_consequence_e", 1294, _cffi_prim_int(sizeof(enum clingo_consequence_e), ((enum clingo_consequence_e)-1) <= 0),
     "clingo_consequence_false,clingo_consequence_true,clingo_consequence_unknown" },
-  { "clingo_error_e", 1293, _cffi_prim_int(sizeof(enum clingo_error_e), ((enum clingo_error_e)-1) <= 0),
+  { "clingo_error_e", 1295, _cffi_prim_int(sizeof(enum clingo_error_e), ((enum clingo_error_e)-1) <= 0),
     "clingo_error_success,clingo_error_runtime,clingo_error_logic,clingo_error_bad_alloc,clingo_error_unknown" },
-  { "clingo_external_type_e", 1294, _cffi_prim_int(sizeof(enum clingo_external_type_e), ((enum clingo_external_type_e)-1) <= 0),
+  { "clingo_external_type_e", 1296, _cffi_prim_int(sizeof(enum clingo_external_type_e), ((enum clingo_external_type_e)-1) <= 0),
     "clingo_external_type_free,clingo_external_type_true,clingo_external_type_false,clingo_external_type_release" },
-  { "clingo_heuristic_type_e", 1295, _cffi_prim_int(sizeof(enum clingo_heuristic_type_e), ((enum clingo_heuristic_type_e)-1) <= 0),
+  { "clingo_heuristic_type_e", 1297, _cffi_prim_int(sizeof(enum clingo_heuristic_type_e), ((enum clingo_heuristic_type_e)-1) <= 0),
     "clingo_heuristic_type_level,clingo_heuristic_type_sign,clingo_heuristic_type_factor,clingo_heuristic_type_init,clingo_heuristic_type_true,clingo_heuristic_type_false" },
-  { "clingo_model_type_e", 1296, _cffi_prim_int(sizeof(enum clingo_model_type_e), ((enum clingo_model_type_e)-1) <= 0),
+  { "clingo_model_type_e", 1298, _cffi_prim_int(sizeof(enum clingo_model_type_e), ((enum clingo_model_type_e)-1) <= 0),
     "clingo_model_type_stable_model,clingo_model_type_brave_consequences,clingo_model_type_cautious_consequences" },
-  { "clingo_propagator_check_mode_e", 1297, _cffi_prim_int(sizeof(enum clingo_propagator_check_mode_e), ((enum clingo_propagator_check_mode_e)-1) <= 0),
+  { "clingo_propagator_check_mode_e", 1299, _cffi_prim_int(sizeof(enum clingo_propagator_check_mode_e), ((enum clingo_propagator_check_mode_e)-1) <= 0),
     "clingo_propagator_check_mode_none,clingo_propagator_check_mode_total,clingo_propagator_check_mode_fixpoint,clingo_propagator_check_mode_both" },
-  { "clingo_propagator_undo_mode_e", 1298, _cffi_prim_int(sizeof(enum clingo_propagator_undo_mode_e), ((enum clingo_propagator_undo_mode_e)-1) <= 0),
+  { "clingo_propagator_undo_mode_e", 1300, _cffi_prim_int(sizeof(enum clingo_propagator_undo_mode_e), ((enum clingo_propagator_undo_mode_e)-1) <= 0),
     "clingo_propagator_undo_mode_default,clingo_propagator_undo_mode_always" },
-  { "clingo_show_type_e", 1299, _cffi_prim_int(sizeof(enum clingo_show_type_e), ((enum clingo_show_type_e)-1) <= 0),
+  { "clingo_show_type_e", 1301, _cffi_prim_int(sizeof(enum clingo_show_type_e), ((enum clingo_show_type_e)-1) <= 0),
     "clingo_show_type_shown,clingo_show_type_atoms,clingo_show_type_terms,clingo_show_type_theory,clingo_show_type_all,clingo_show_type_complement" },
-  { "clingo_solve_event_type_e", 1300, _cffi_prim_int(sizeof(enum clingo_solve_event_type_e), ((enum clingo_solve_event_type_e)-1) <= 0),
+  { "clingo_solve_event_type_e", 1302, _cffi_prim_int(sizeof(enum clingo_solve_event_type_e), ((enum clingo_solve_event_type_e)-1) <= 0),
     "clingo_solve_event_type_model,clingo_solve_event_type_unsat,clingo_solve_event_type_statistics,clingo_solve_event_type_finish" },
-  { "clingo_solve_mode_e", 1301, _cffi_prim_int(sizeof(enum clingo_solve_mode_e), ((enum clingo_solve_mode_e)-1) <= 0),
+  { "clingo_solve_mode_e", 1303, _cffi_prim_int(sizeof(enum clingo_solve_mode_e), ((enum clingo_solve_mode_e)-1) <= 0),
     "clingo_solve_mode_async,clingo_solve_mode_yield" },
-  { "clingo_solve_result_e", 1302, _cffi_prim_int(sizeof(enum clingo_solve_result_e), ((enum clingo_solve_result_e)-1) <= 0),
+  { "clingo_solve_result_e", 1304, _cffi_prim_int(sizeof(enum clingo_solve_result_e), ((enum clingo_solve_result_e)-1) <= 0),
     "clingo_solve_result_satisfiable,clingo_solve_result_unsatisfiable,clingo_solve_result_exhausted,clingo_solve_result_interrupted" },
-  { "clingo_statistics_type_e", 1303, _cffi_prim_int(sizeof(enum clingo_statistics_type_e), ((enum clingo_statistics_type_e)-1) <= 0),
+  { "clingo_statistics_type_e", 1305, _cffi_prim_int(sizeof(enum clingo_statistics_type_e), ((enum clingo_statistics_type_e)-1) <= 0),
     "clingo_statistics_type_empty,clingo_statistics_type_value,clingo_statistics_type_array,clingo_statistics_type_map" },
-  { "clingo_symbol_type_e", 1304, _cffi_prim_int(sizeof(enum clingo_symbol_type_e), ((enum clingo_symbol_type_e)-1) <= 0),
+  { "clingo_symbol_type_e", 1306, _cffi_prim_int(sizeof(enum clingo_symbol_type_e), ((enum clingo_symbol_type_e)-1) <= 0),
     "clingo_symbol_type_infimum,clingo_symbol_type_number,clingo_symbol_type_string,clingo_symbol_type_function,clingo_symbol_type_supremum" },
-  { "clingo_theory_sequence_type_e", 1305, _cffi_prim_int(sizeof(enum clingo_theory_sequence_type_e), ((enum clingo_theory_sequence_type_e)-1) <= 0),
-    "clingo_theory_sequence_type_tuple,clingo_theory_sequence_type_list,clingo_theory_sequence_type_set" },
-  { "clingo_theory_term_type_e", 1306, _cffi_prim_int(sizeof(enum clingo_theory_term_type_e), ((enum clingo_theory_term_type_e)-1) <= 0),
+  { "clingo_theory_sequence_type_e", 1307, _cffi_prim_int(sizeof(enum clingo_theory_sequence_type_e), ((enum clingo_theory_sequence_type_e)-1) <= 0),
+    "clingo_theory_sequence_type_tuple,clingo_theory_sequence_type_set,clingo_theory_sequence_type_list" },
+  { "clingo_theory_term_type_e", 1308, _cffi_prim_int(sizeof(enum clingo_theory_term_type_e), ((enum clingo_theory_term_type_e)-1) <= 0),
     "clingo_theory_term_type_tuple,clingo_theory_term_type_list,clingo_theory_term_type_set,clingo_theory_term_type_function,clingo_theory_term_type_number,clingo_theory_term_type_symbol" },
-  { "clingo_truth_value_e", 1307, _cffi_prim_int(sizeof(enum clingo_truth_value_e), ((enum clingo_truth_value_e)-1) <= 0),
+  { "clingo_truth_value_e", 1309, _cffi_prim_int(sizeof(enum clingo_truth_value_e), ((enum clingo_truth_value_e)-1) <= 0),
     "clingo_truth_value_free,clingo_truth_value_true,clingo_truth_value_false" },
-  { "clingo_warning_e", 1308, _cffi_prim_int(sizeof(enum clingo_warning_e), ((enum clingo_warning_e)-1) <= 0),
+  { "clingo_warning_e", 1310, _cffi_prim_int(sizeof(enum clingo_warning_e), ((enum clingo_warning_e)-1) <= 0),
     "clingo_warning_operation_undefined,clingo_warning_runtime_error,clingo_warning_atom_undefined,clingo_warning_file_included,clingo_warning_variable_unbounded,clingo_warning_global_variable,clingo_warning_other" },
-  { "clingo_weight_constraint_type_e", 1309, _cffi_prim_int(sizeof(enum clingo_weight_constraint_type_e), ((enum clingo_weight_constraint_type_e)-1) <= 0),
+  { "clingo_weight_constraint_type_e", 1311, _cffi_prim_int(sizeof(enum clingo_weight_constraint_type_e), ((enum clingo_weight_constraint_type_e)-1) <= 0),
     "clingo_weight_constraint_type_implication_left,clingo_weight_constraint_type_implication_right,clingo_weight_constraint_type_equivalence" },
 };
 
 static const struct _cffi_typename_s _cffi_typenames[] = {
-  { "clingo_application_t", 1249 },
-  { "clingo_assignment_t", 1250 },
+  { "clingo_application_t", 1251 },
+  { "clingo_assignment_t", 1252 },
   { "clingo_ast_aggregate_function_t", 155 },
-  { "clingo_ast_argument_t", 1252 },
-  { "clingo_ast_attribute_names_t", 1253 },
+  { "clingo_ast_argument_t", 1254 },
+  { "clingo_ast_attribute_names_t", 1255 },
   { "clingo_ast_attribute_t", 155 },
   { "clingo_ast_attribute_type_t", 155 },
   { "clingo_ast_binary_operator_t", 155 },
   { "clingo_ast_callback_t", 24 },
   { "clingo_ast_comparison_operator_t", 155 },
-  { "clingo_ast_constructor_t", 1255 },
-  { "clingo_ast_constructors_t", 1256 },
+  { "clingo_ast_constructor_t", 1257 },
+  { "clingo_ast_constructors_t", 1258 },
   { "clingo_ast_sign_t", 155 },
-  { "clingo_ast_t", 1257 },
+  { "clingo_ast_t", 1259 },
   { "clingo_ast_theory_atom_definition_type_t", 155 },
   { "clingo_ast_theory_operator_type_t", 155 },
   { "clingo_ast_theory_sequence_type_t", 155 },
@@ -19018,63 +19042,63 @@ static const struct _cffi_typename_s _cffi_typenames[] = {
   { "clingo_ast_unary_operator_t", 155 },
   { "clingo_ast_unpool_type_bitset_t", 155 },
   { "clingo_atom_t", 69 },
-  { "clingo_backend_t", 1258 },
+  { "clingo_backend_t", 1260 },
   { "clingo_clause_type_t", 155 },
   { "clingo_comment_type_t", 155 },
-  { "clingo_configuration_t", 1259 },
+  { "clingo_configuration_t", 1261 },
   { "clingo_configuration_type_bitset_t", 29 },
   { "clingo_consequence_t", 155 },
-  { "clingo_control_t", 1260 },
-  { "clingo_default_model_printer_t", 588 },
+  { "clingo_control_t", 1262 },
+  { "clingo_default_model_printer_t", 590 },
   { "clingo_error_t", 155 },
   { "clingo_external_type_t", 155 },
-  { "clingo_ground_callback_t", 476 },
-  { "clingo_ground_program_observer_t", 1261 },
+  { "clingo_ground_callback_t", 478 },
+  { "clingo_ground_program_observer_t", 1263 },
   { "clingo_heuristic_type_t", 155 },
   { "clingo_id_t", 69 },
   { "clingo_literal_t", 12 },
-  { "clingo_location_t", 1262 },
+  { "clingo_location_t", 1264 },
   { "clingo_logger_t", 27 },
-  { "clingo_main_function_t", 1218 },
-  { "clingo_model_printer_t", 1224 },
-  { "clingo_model_t", 1263 },
+  { "clingo_main_function_t", 1220 },
+  { "clingo_model_printer_t", 1226 },
+  { "clingo_model_t", 1265 },
   { "clingo_model_type_t", 155 },
-  { "clingo_options_t", 1264 },
-  { "clingo_part_t", 1265 },
-  { "clingo_program_builder_t", 1266 },
-  { "clingo_propagate_control_t", 1267 },
-  { "clingo_propagate_init_t", 1268 },
-  { "clingo_propagator_check_callback_t", 1227 },
+  { "clingo_options_t", 1266 },
+  { "clingo_part_t", 1267 },
+  { "clingo_program_builder_t", 1268 },
+  { "clingo_propagate_control_t", 1269 },
+  { "clingo_propagate_init_t", 1270 },
+  { "clingo_propagator_check_callback_t", 1229 },
   { "clingo_propagator_check_mode_t", 155 },
-  { "clingo_propagator_init_callback_t", 1228 },
-  { "clingo_propagator_propagate_callback_t", 1226 },
-  { "clingo_propagator_t", 1269 },
-  { "clingo_propagator_undo_callback_t", 1312 },
+  { "clingo_propagator_init_callback_t", 1230 },
+  { "clingo_propagator_propagate_callback_t", 1228 },
+  { "clingo_propagator_t", 1271 },
+  { "clingo_propagator_undo_callback_t", 1314 },
   { "clingo_propagator_undo_mode_t", 155 },
-  { "clingo_script_t", 1270 },
+  { "clingo_script_t", 1272 },
   { "clingo_show_type_bitset_t", 29 },
   { "clingo_signature_t", 246 },
-  { "clingo_solve_control_t", 1271 },
-  { "clingo_solve_event_callback_t", 503 },
+  { "clingo_solve_control_t", 1273 },
+  { "clingo_solve_event_callback_t", 505 },
   { "clingo_solve_event_type_t", 29 },
-  { "clingo_solve_handle_t", 1272 },
+  { "clingo_solve_handle_t", 1274 },
   { "clingo_solve_mode_bitset_t", 29 },
   { "clingo_solve_result_bitset_t", 29 },
-  { "clingo_statistics_t", 1273 },
+  { "clingo_statistics_t", 1275 },
   { "clingo_statistics_type_t", 155 },
-  { "clingo_symbol_callback_t", 559 },
+  { "clingo_symbol_callback_t", 561 },
   { "clingo_symbol_t", 246 },
   { "clingo_symbol_type_t", 155 },
   { "clingo_symbolic_atom_iterator_t", 246 },
-  { "clingo_symbolic_atoms_t", 1274 },
-  { "clingo_theory_atoms_t", 1275 },
+  { "clingo_symbolic_atoms_t", 1276 },
+  { "clingo_theory_atoms_t", 1277 },
   { "clingo_theory_sequence_type_t", 155 },
   { "clingo_theory_term_type_t", 155 },
   { "clingo_truth_value_t", 155 },
   { "clingo_warning_t", 155 },
   { "clingo_weight_constraint_type_t", 155 },
   { "clingo_weight_t", 12 },
-  { "clingo_weighted_literal_t", 1276 },
+  { "clingo_weighted_literal_t", 1278 },
 };
 
 static const struct _cffi_type_context_s _cffi_type_context = {
@@ -19089,7 +19113,7 @@ static const struct _cffi_type_context_s _cffi_type_context = {
   33,  /* num_enums */
   78,  /* num_typenames */
   NULL,  /* no includes */
-  1315,  /* num_types */
+  1317,  /* num_types */
   1,  /* flags */
 };
 

--- a/libclingo/clingo.h
+++ b/libclingo/clingo.h
@@ -203,7 +203,7 @@ enum clingo_truth_value_e {
 //! Corresponding type to ::clingo_truth_value_e.
 typedef int clingo_truth_value_t;
 
-//! Represents a source code location marking its beginnig and end.
+//! Represents a source code location marking its beginning and end.
 //!
 //! @note Not all locations refer to physical files.
 //! By convention, such locations use a name put in angular brackets as filename.
@@ -1205,8 +1205,8 @@ CLINGO_VISIBILITY_DEFAULT clingo_assignment_t const *clingo_propagate_init_assig
 //! To be able to use the variable in clauses during propagation or add watches to it, it has to be frozen.
 //! Otherwise, it might be removed during preprocessing.
 //!
-//! @attention If varibales were added, subsequent calls to functions adding constraints or ::clingo_propagate_init_propagate() are expensive.
-//! It is best to add varables in batches.
+//! @attention If variables were added, subsequent calls to functions adding constraints or ::clingo_propagate_init_propagate() are expensive.
+//! It is best to add variables in batches.
 //!
 //! @param[in] init the target
 //! @param[in] freeze whether to freeze the literal
@@ -1385,7 +1385,7 @@ typedef struct clingo_propagator {
     //! @note This is the last point to access symbolic and theory atoms.
     //! Once the search has started, they are no longer accessible.
     //!
-    //! @param[in] init initizialization object
+    //! @param[in] init initialization object
     //! @param[in] data user data for the callback
     //! @return whether the call was successful
     //! @see ::clingo_propagator_init_callback_t
@@ -1693,9 +1693,9 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_backend_theory_term_symbol(clingo_backend_
 //! Add a theory atom element.
 //!
 //! @param[in] backend the target backend
-//! @param[in] tuple the array of term ids represeting the tuple
+//! @param[in] tuple the array of term ids representing the tuple
 //! @param[in] tuple_size the size of the tuple
-//! @param[in] condition an array of program literals represeting the condition
+//! @param[in] condition an array of program literals representing the condition
 //! @param[in] condition_size the size of the condition
 //! @param[out] element_id the resulting element id
 //! @return whether the call was successful; might set one of the following error codes:
@@ -1703,26 +1703,34 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_backend_theory_term_symbol(clingo_backend_
 CLINGO_VISIBILITY_DEFAULT bool clingo_backend_theory_element(clingo_backend_t *backend, clingo_id_t const *tuple, size_t tuple_size, clingo_literal_t const *condition, size_t condition_size, clingo_id_t *element_id);
 //! Add a theory atom without a guard.
 //!
+//! If atom is set to zero, the theory atom is a directive,
+//! if atom is set to UINT32_MAX, the theory atom receives a fresh atom,
+//! and otherwise the theory atom receives the given atom id.
+//!
 //! @param[in] backend the target backend
-//! @param[in] atom_id_or_zero a program atom or zero for theory directives
+//! @param[in] atom an undefined value, program atom, or zero for theory directives
 //! @param[in] term_id the term id of the term associated with the theory atom
 //! @param[in] elements an array of element ids for the theory atoms's elements
 //! @param[in] size the number of elements
+//! @param[out] atom_id the final program atom of the theory atom
 //! @return whether the call was successful; might set one of the following error codes:
 //! - ::clingo_error_bad_alloc
-CLINGO_VISIBILITY_DEFAULT bool clingo_backend_theory_atom(clingo_backend_t *backend, clingo_atom_t atom_id_or_zero, clingo_id_t term_id, clingo_id_t const *elements, size_t size);
+CLINGO_VISIBILITY_DEFAULT bool clingo_backend_theory_atom(clingo_backend_t *backend, clingo_atom_t atom, clingo_id_t term_id, clingo_id_t const *elements, size_t size, clingo_atom_t *atom_id);
 //! Add a theory atom with a guard.
 //!
+//! See the note regarding atom at clingo_backend_theory_atom().
+//!
 //! @param[in] backend the target backend
-//! @param[in] atom_id_or_zero a program atom or zero for theory directives
+//! @param[in] atom an undefined value, program atom, or zero for theory directives
 //! @param[in] term_id the term id of the term associated with the theory atom
 //! @param[in] elements an array of element ids for the theory atoms's elements
 //! @param[in] size the number of elements
 //! @param[in] operator_name the string representation of a theory operator
 //! @param[in] right_hand_side_id the term id of the right hand side term
+//! @param[out] atom_id the final program atom of the theory atom
 //! @return whether the call was successful; might set one of the following error codes:
 //! - ::clingo_error_bad_alloc
-CLINGO_VISIBILITY_DEFAULT bool clingo_backend_theory_atom_with_guard(clingo_backend_t *backend, clingo_atom_t atom_id_or_zero, clingo_id_t term_id, clingo_id_t const *elements, size_t size, char const *operator_name, clingo_id_t right_hand_side_id);
+CLINGO_VISIBILITY_DEFAULT bool clingo_backend_theory_atom_with_guard(clingo_backend_t *backend, clingo_atom_t atom, clingo_id_t term_id, clingo_id_t const *elements, size_t size, char const *operator_name, clingo_id_t right_hand_side_id, clingo_atom_t *atom_id);
 
 //! @}
 

--- a/libclingo/clingo.hh
+++ b/libclingo/clingo.hh
@@ -38,6 +38,7 @@
 #include <tuple>
 #include <forward_list>
 #include <atomic>
+#include <limits>
 
 #include <iostream>
 
@@ -1498,8 +1499,10 @@ public:
     id_t add_theory_term_function(char const *name, IdSpan elements);
     id_t add_theory_term_symbol(Symbol symbol);
     id_t add_theory_element(IdSpan tuple, LiteralSpan condition);
-    void theory_atom(id_t atom_id_or_zero, id_t term_id, IdSpan elements);
-    void theory_atom(id_t atom_id_or_zero, id_t term_id, IdSpan elements, char const *operator_name, id_t right_hand_side_id);
+    atom_t theory_atom(id_t term_id, IdSpan elements);
+    atom_t theory_atom(id_t term_id, IdSpan elements, char const *operator_name, id_t right_hand_side_id);
+    atom_t theory_atom(id_t atom_id_or_zero, id_t term_id, IdSpan elements);
+    atom_t theory_atom(id_t atom_id_or_zero, id_t term_id, IdSpan elements, char const *operator_name, id_t right_hand_side_id);
     clingo_backend_t *to_c() const { return backend_; }
 private:
     clingo_backend_t *backend_;
@@ -3212,12 +3215,28 @@ inline id_t Backend::add_theory_element(IdSpan tuple, LiteralSpan condition) {
     return ret;
 }
 
-inline void Backend::theory_atom(id_t atom_id_or_zero, id_t term_id, IdSpan elements) {
-    Detail::handle_error(clingo_backend_theory_atom(backend_, atom_id_or_zero, term_id, elements.begin(), elements.size()));
+inline atom_t Backend::theory_atom(id_t term_id, IdSpan elements) {
+    atom_t ret = 0;
+    Detail::handle_error(clingo_backend_theory_atom(backend_, std::numeric_limits<atom_t>::max(), term_id, elements.begin(), elements.size(), &ret));
+    return ret;
 }
 
-inline void Backend::theory_atom(id_t atom_id_or_zero, id_t term_id, IdSpan elements, char const *operator_name, id_t right_hand_side_id) {
-    Detail::handle_error(clingo_backend_theory_atom_with_guard(backend_, atom_id_or_zero, term_id, elements.begin(), elements.size(), operator_name, right_hand_side_id));
+inline atom_t Backend::theory_atom(id_t term_id, IdSpan elements, char const *operator_name, id_t right_hand_side_id) {
+    atom_t ret = 0;
+    Detail::handle_error(clingo_backend_theory_atom_with_guard(backend_, std::numeric_limits<atom_t>::max(), term_id, elements.begin(), elements.size(), operator_name, right_hand_side_id, &ret));
+    return ret;
+}
+
+inline atom_t Backend::theory_atom(id_t atom_id_or_zero, id_t term_id, IdSpan elements) {
+    atom_t ret = 0;
+    Detail::handle_error(clingo_backend_theory_atom(backend_, atom_id_or_zero, term_id, elements.begin(), elements.size(), &ret));
+    return ret;
+}
+
+inline atom_t Backend::theory_atom(id_t atom_id_or_zero, id_t term_id, IdSpan elements, char const *operator_name, id_t right_hand_side_id) {
+    atom_t ret = 0;
+    Detail::handle_error(clingo_backend_theory_atom_with_guard(backend_, atom_id_or_zero, term_id, elements.begin(), elements.size(), operator_name, right_hand_side_id, &ret));
+    return ret;
 }
 
 // {{{2 statistics

--- a/libclingo/src/control.cc
+++ b/libclingo/src/control.cc
@@ -1191,20 +1191,24 @@ extern "C" bool clingo_backend_theory_element(clingo_backend_t *backend, clingo_
     GRINGO_CLINGO_CATCH;
 }
 
-extern "C" bool clingo_backend_theory_atom(clingo_backend_t *backend, clingo_atom_t atom_id_or_zero, clingo_id_t term_id, clingo_id_t const *elements, size_t size) {
+extern "C" bool clingo_backend_theory_atom(clingo_backend_t *backend, clingo_atom_t atom, clingo_id_t term_id, clingo_id_t const *elements, size_t size, clingo_atom_t *atom_id) {
     GRINGO_CLINGO_TRY {
-        auto newAtom = [atom_id_or_zero]() -> Atom_t { return atom_id_or_zero; };
-        backend->theoryData().addAtom(newAtom, term_id, Potassco::IdSpan{elements, size});
+        auto newAtom = [backend, atom]() -> Atom_t {
+            return atom == std::numeric_limits<clingo_atom_t>::max() ? backend->addProgramAtom() : atom;
+        };
+        *atom_id = backend->theoryData().addAtom(newAtom, term_id, Potassco::IdSpan{elements, size}).first.atom();
     }
     GRINGO_CLINGO_CATCH;
 }
 
-extern "C" bool clingo_backend_theory_atom_with_guard(clingo_backend_t *backend, clingo_atom_t atom_id_or_zero, clingo_id_t term_id, clingo_id_t const *elements, size_t size, char const *operator_name, clingo_id_t right_hand_side_id) {
+extern "C" bool clingo_backend_theory_atom_with_guard(clingo_backend_t *backend, clingo_atom_t atom, clingo_id_t term_id, clingo_id_t const *elements, size_t size, char const *operator_name, clingo_id_t right_hand_side_id, clingo_atom_t *atom_id) {
     GRINGO_CLINGO_TRY {
         auto &theory = backend->theoryData();
         auto op_id = theory.addTerm(operator_name);
-        auto newAtom = [atom_id_or_zero]() -> Atom_t { return atom_id_or_zero; };
-        theory.addAtom(newAtom, term_id, Potassco::IdSpan{elements, size}, op_id, right_hand_side_id);
+        auto newAtom = [backend, atom]() -> Atom_t {
+            return atom == std::numeric_limits<clingo_atom_t>::max() ? backend->addProgramAtom() : atom;
+        };
+        *atom_id = theory.addAtom(newAtom, term_id, Potassco::IdSpan{elements, size}, op_id, right_hand_side_id).first.atom();
     }
     GRINGO_CLINGO_CATCH;
 }

--- a/libpyclingo/_clingo.c
+++ b/libpyclingo/_clingo.c
@@ -612,8 +612,7 @@ extern "C" {
 
    * _cffi_call_python_org, which on CPython is actually part of the
      _cffi_exports[] array, is the function pointer copied from
-     _cffi_backend.  If _cffi_start_python() fails, then this is set
-     to NULL; otherwise, it should never be NULL.
+     _cffi_backend.
 
    After initialization is complete, both are equal.  However, the
    first one remains equal to &_cffi_start_and_call_python until the
@@ -963,7 +962,7 @@ static int _cffi_initialize_python(void)
 
         if (f != NULL && f != Py_None) {
             PyFile_WriteString("\nFrom: " _CFFI_MODULE_NAME
-                               "\ncompiled with cffi version: 1.15.1"
+                               "\ncompiled with cffi version: 1.15.0"
                                "\n_cffi_backend module: ", f);
             modules = PyImport_GetModuleDict();
             mod = PyDict_GetItemString(modules, "_cffi_backend");
@@ -1294,14 +1293,14 @@ static void *_cffi_types[] = {
 /*  3 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28), // size_t
 /*  4 */ _CFFI_OP(_CFFI_OP_POINTER, 12), // int32_t const *
 /*  5 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/*  6 */ _CFFI_OP(_CFFI_OP_POINTER, 1314), // void *
+/*  6 */ _CFFI_OP(_CFFI_OP_POINTER, 1316), // void *
 /*  7 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /*  8 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(_Bool, uint32_t const *, size_t, int32_t, clingo_weighted_literal_t const *, size_t, void *)
 /*  9 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
 /* 10 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
 /* 11 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
 /* 12 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21), // int32_t
-/* 13 */ _CFFI_OP(_CFFI_OP_POINTER, 1276), // clingo_weighted_literal_t const *
+/* 13 */ _CFFI_OP(_CFFI_OP_POINTER, 1278), // clingo_weighted_literal_t const *
 /* 14 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
 /* 15 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
 /* 16 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
@@ -1314,8 +1313,8 @@ static void *_cffi_types[] = {
 /* 23 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
 /* 24 */ _CFFI_OP(_CFFI_OP_POINTER, 252), // _Bool(*)(clingo_ast_t *, void *)
 /* 25 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 26 */ _CFFI_OP(_CFFI_OP_POINTER, 1260), // clingo_control_t *
-/* 27 */ _CFFI_OP(_CFFI_OP_POINTER, 1198), // void(*)(int, char const *, void *)
+/* 26 */ _CFFI_OP(_CFFI_OP_POINTER, 1262), // clingo_control_t *
+/* 27 */ _CFFI_OP(_CFFI_OP_POINTER, 1200), // void(*)(int, char const *, void *)
 /* 28 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
 /* 29 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8), // unsigned int
 /* 30 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
@@ -1328,7 +1327,7 @@ static void *_cffi_types[] = {
 /* 37 */ _CFFI_OP(_CFFI_OP_POINTER, 26), // clingo_control_t * *
 /* 38 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 39 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(char const *, _Bool *, void *)
-/* 40 */ _CFFI_OP(_CFFI_OP_POINTER, 1248), // char const *
+/* 40 */ _CFFI_OP(_CFFI_OP_POINTER, 1250), // char const *
 /* 41 */ _CFFI_OP(_CFFI_OP_POINTER, 1), // _Bool *
 /* 42 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
 /* 43 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
@@ -1352,7 +1351,7 @@ static void *_cffi_types[] = {
 /* 61 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 62 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(char const *, clingo_script_t const *, void *)
 /* 63 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 64 */ _CFFI_OP(_CFFI_OP_POINTER, 1270), // clingo_script_t const *
+/* 64 */ _CFFI_OP(_CFFI_OP_POINTER, 1272), // clingo_script_t const *
 /* 65 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
 /* 66 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 67 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(char const *, uint32_t, _Bool, uint64_t *)
@@ -1384,7 +1383,7 @@ static void *_cffi_types[] = {
 /* 93 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
 /* 94 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 95 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_assignment_t const *)
-/* 96 */ _CFFI_OP(_CFFI_OP_POINTER, 1250), // clingo_assignment_t const *
+/* 96 */ _CFFI_OP(_CFFI_OP_POINTER, 1252), // clingo_assignment_t const *
 /* 97 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 98 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_assignment_t const *, int32_t)
 /* 99 */ _CFFI_OP(_CFFI_OP_NOOP, 96),
@@ -1425,8 +1424,8 @@ static void *_cffi_types[] = {
 /* 134 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
 /* 135 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 136 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_ast_t *, char *, size_t)
-/* 137 */ _CFFI_OP(_CFFI_OP_POINTER, 1257), // clingo_ast_t *
-/* 138 */ _CFFI_OP(_CFFI_OP_POINTER, 1248), // char *
+/* 137 */ _CFFI_OP(_CFFI_OP_POINTER, 1259), // clingo_ast_t *
+/* 138 */ _CFFI_OP(_CFFI_OP_POINTER, 1250), // char *
 /* 139 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
 /* 140 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 141 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_ast_t *, clingo_ast_t * *)
@@ -1475,12 +1474,12 @@ static void *_cffi_types[] = {
 /* 184 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_ast_t *, int, clingo_location_t *)
 /* 185 */ _CFFI_OP(_CFFI_OP_NOOP, 137),
 /* 186 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 187 */ _CFFI_OP(_CFFI_OP_POINTER, 1262), // clingo_location_t *
+/* 187 */ _CFFI_OP(_CFFI_OP_POINTER, 1264), // clingo_location_t *
 /* 188 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 189 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_ast_t *, int, clingo_location_t const *)
 /* 190 */ _CFFI_OP(_CFFI_OP_NOOP, 137),
 /* 191 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 192 */ _CFFI_OP(_CFFI_OP_POINTER, 1262), // clingo_location_t const *
+/* 192 */ _CFFI_OP(_CFFI_OP_POINTER, 1264), // clingo_location_t const *
 /* 193 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 194 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_ast_t *, int, int *)
 /* 195 */ _CFFI_OP(_CFFI_OP_NOOP, 137),
@@ -1545,11 +1544,11 @@ static void *_cffi_types[] = {
 /* 254 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
 /* 255 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 256 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_ast_t const *, void *)
-/* 257 */ _CFFI_OP(_CFFI_OP_POINTER, 1257), // clingo_ast_t const *
+/* 257 */ _CFFI_OP(_CFFI_OP_POINTER, 1259), // clingo_ast_t const *
 /* 258 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
 /* 259 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 260 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_backend_t *)
-/* 261 */ _CFFI_OP(_CFFI_OP_POINTER, 1258), // clingo_backend_t *
+/* 261 */ _CFFI_OP(_CFFI_OP_POINTER, 1260), // clingo_backend_t *
 /* 262 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
 /* 263 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_backend_t *, _Bool, uint32_t const *, size_t, int32_t const *, size_t)
 /* 264 */ _CFFI_OP(_CFFI_OP_NOOP, 261),
@@ -1637,972 +1636,974 @@ static void *_cffi_types[] = {
 /* 346 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
 /* 347 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
 /* 348 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 349 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_backend_t *, uint32_t, uint32_t, uint32_t const *, size_t)
+/* 349 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_backend_t *, uint32_t, uint32_t, uint32_t const *, size_t, char const *, uint32_t, uint32_t *)
 /* 350 */ _CFFI_OP(_CFFI_OP_NOOP, 261),
 /* 351 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
 /* 352 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
 /* 353 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
 /* 354 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 355 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 356 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_backend_t *, uint32_t, uint32_t, uint32_t const *, size_t, char const *, uint32_t)
-/* 357 */ _CFFI_OP(_CFFI_OP_NOOP, 261),
-/* 358 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 359 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 360 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
-/* 361 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 362 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 363 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 364 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 365 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_backend_t *, uint64_t *, uint32_t *)
-/* 366 */ _CFFI_OP(_CFFI_OP_NOOP, 261),
-/* 367 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 368 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
-/* 369 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 370 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_backend_t *, uint64_t, uint32_t *)
-/* 371 */ _CFFI_OP(_CFFI_OP_NOOP, 261),
-/* 372 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 373 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
-/* 374 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 375 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t *, uint32_t, char const *)
-/* 376 */ _CFFI_OP(_CFFI_OP_POINTER, 1259), // clingo_configuration_t *
-/* 377 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 378 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 379 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 380 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t *)
-/* 381 */ _CFFI_OP(_CFFI_OP_POINTER, 1259), // clingo_configuration_t const *
-/* 382 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
-/* 383 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 384 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, _Bool *)
-/* 385 */ _CFFI_OP(_CFFI_OP_NOOP, 381),
-/* 386 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 387 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 388 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 389 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, char *, size_t)
-/* 390 */ _CFFI_OP(_CFFI_OP_NOOP, 381),
-/* 391 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 392 */ _CFFI_OP(_CFFI_OP_NOOP, 138),
-/* 393 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 394 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 395 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, char const * *)
-/* 396 */ _CFFI_OP(_CFFI_OP_NOOP, 381),
-/* 397 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 398 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
-/* 399 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 400 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, char const *, _Bool *)
-/* 401 */ _CFFI_OP(_CFFI_OP_NOOP, 381),
-/* 402 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 403 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 404 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 405 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 406 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, char const *, uint32_t *)
-/* 407 */ _CFFI_OP(_CFFI_OP_NOOP, 381),
-/* 408 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 409 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 410 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
-/* 411 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 412 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, size_t *)
-/* 413 */ _CFFI_OP(_CFFI_OP_NOOP, 381),
-/* 414 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 415 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 416 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 417 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, size_t, char const * *)
-/* 418 */ _CFFI_OP(_CFFI_OP_NOOP, 381),
-/* 419 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 420 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 421 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
-/* 422 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 423 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, size_t, uint32_t *)
-/* 424 */ _CFFI_OP(_CFFI_OP_NOOP, 381),
-/* 425 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 426 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 427 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
-/* 428 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 429 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, unsigned int *)
-/* 430 */ _CFFI_OP(_CFFI_OP_NOOP, 381),
-/* 431 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 432 */ _CFFI_OP(_CFFI_OP_POINTER, 29), // unsigned int *
-/* 433 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 434 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *)
-/* 435 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 436 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 437 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, _Bool)
-/* 438 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 439 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
-/* 440 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 441 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, char const * const *, size_t, void *)
-/* 442 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 443 */ _CFFI_OP(_CFFI_OP_NOOP, 22),
-/* 444 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 445 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 446 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 447 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, char const *)
-/* 448 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 449 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 450 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 451 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, char const *, char const * const *, size_t, char const *)
-/* 452 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 453 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 454 */ _CFFI_OP(_CFFI_OP_NOOP, 22),
-/* 455 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 456 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 457 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 458 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_backend_t * *)
-/* 459 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 460 */ _CFFI_OP(_CFFI_OP_POINTER, 261), // clingo_backend_t * *
-/* 461 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 462 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_configuration_t * *)
-/* 463 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 464 */ _CFFI_OP(_CFFI_OP_POINTER, 376), // clingo_configuration_t * *
-/* 465 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 466 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_ground_program_observer_t const *, _Bool, void *)
-/* 467 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 468 */ _CFFI_OP(_CFFI_OP_POINTER, 1261), // clingo_ground_program_observer_t const *
-/* 469 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
-/* 470 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 471 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 472 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_part_t const *, size_t, _Bool(*)(clingo_location_t const *, char const *, uint64_t const *, size_t, void *, _Bool(*)(uint64_t const *, size_t, void *), void *), void *)
-/* 473 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 474 */ _CFFI_OP(_CFFI_OP_POINTER, 1265), // clingo_part_t const *
-/* 475 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 476 */ _CFFI_OP(_CFFI_OP_POINTER, 563), // _Bool(*)(clingo_location_t const *, char const *, uint64_t const *, size_t, void *, _Bool(*)(uint64_t const *, size_t, void *), void *)
-/* 477 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 478 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 479 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_program_builder_t * *)
-/* 480 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 481 */ _CFFI_OP(_CFFI_OP_POINTER, 670), // clingo_program_builder_t * *
-/* 482 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 483 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_propagator_t const *, void *, _Bool)
-/* 484 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 485 */ _CFFI_OP(_CFFI_OP_POINTER, 1269), // clingo_propagator_t const *
-/* 486 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 487 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
-/* 488 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 489 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, int32_t)
-/* 490 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 491 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 492 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 493 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, int32_t, int)
-/* 494 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 495 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 496 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 497 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 498 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, unsigned int, int32_t const *, size_t, _Bool(*)(unsigned int, void *, void *, _Bool *), void *, clingo_solve_handle_t * *)
-/* 499 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 500 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8),
-/* 501 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
-/* 502 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 503 */ _CFFI_OP(_CFFI_OP_POINTER, 1082), // _Bool(*)(unsigned int, void *, void *, _Bool *)
-/* 504 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 505 */ _CFFI_OP(_CFFI_OP_POINTER, 776), // clingo_solve_handle_t * *
-/* 506 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 507 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, void * *)
-/* 508 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 509 */ _CFFI_OP(_CFFI_OP_POINTER, 6), // void * *
-/* 510 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 511 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, void *)
-/* 512 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 513 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 514 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 515 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *)
-/* 516 */ _CFFI_OP(_CFFI_OP_POINTER, 1260), // clingo_control_t const *
-/* 517 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 518 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *, char const *, _Bool *)
-/* 519 */ _CFFI_OP(_CFFI_OP_NOOP, 516),
-/* 520 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 521 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 522 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 523 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *, char const *, uint64_t *)
-/* 524 */ _CFFI_OP(_CFFI_OP_NOOP, 516),
-/* 525 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 526 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 527 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 528 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *, clingo_statistics_t const * *)
-/* 529 */ _CFFI_OP(_CFFI_OP_NOOP, 516),
-/* 530 */ _CFFI_OP(_CFFI_OP_POINTER, 810), // clingo_statistics_t const * *
-/* 531 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 532 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *, clingo_symbolic_atoms_t const * *)
-/* 533 */ _CFFI_OP(_CFFI_OP_NOOP, 516),
-/* 534 */ _CFFI_OP(_CFFI_OP_POINTER, 853), // clingo_symbolic_atoms_t const * *
-/* 535 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 536 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *, clingo_theory_atoms_t const * *)
-/* 537 */ _CFFI_OP(_CFFI_OP_NOOP, 516),
-/* 538 */ _CFFI_OP(_CFFI_OP_POINTER, 892), // clingo_theory_atoms_t const * *
-/* 539 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 540 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_location_t *, char const *, void *)
-/* 541 */ _CFFI_OP(_CFFI_OP_NOOP, 187),
-/* 542 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 543 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 544 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 545 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_location_t *, char const *, void *, size_t, void *, void *, void *)
-/* 546 */ _CFFI_OP(_CFFI_OP_NOOP, 187),
-/* 547 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 548 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 549 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 355 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 356 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 357 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
+/* 358 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 359 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_backend_t *, uint32_t, uint32_t, uint32_t const *, size_t, uint32_t *)
+/* 360 */ _CFFI_OP(_CFFI_OP_NOOP, 261),
+/* 361 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 362 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 363 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
+/* 364 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 365 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
+/* 366 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 367 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_backend_t *, uint64_t *, uint32_t *)
+/* 368 */ _CFFI_OP(_CFFI_OP_NOOP, 261),
+/* 369 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 370 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
+/* 371 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 372 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_backend_t *, uint64_t, uint32_t *)
+/* 373 */ _CFFI_OP(_CFFI_OP_NOOP, 261),
+/* 374 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 375 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
+/* 376 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 377 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t *, uint32_t, char const *)
+/* 378 */ _CFFI_OP(_CFFI_OP_POINTER, 1261), // clingo_configuration_t *
+/* 379 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 380 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 381 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 382 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t *)
+/* 383 */ _CFFI_OP(_CFFI_OP_POINTER, 1261), // clingo_configuration_t const *
+/* 384 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
+/* 385 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 386 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, _Bool *)
+/* 387 */ _CFFI_OP(_CFFI_OP_NOOP, 383),
+/* 388 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 389 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 390 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 391 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, char *, size_t)
+/* 392 */ _CFFI_OP(_CFFI_OP_NOOP, 383),
+/* 393 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 394 */ _CFFI_OP(_CFFI_OP_NOOP, 138),
+/* 395 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 396 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 397 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, char const * *)
+/* 398 */ _CFFI_OP(_CFFI_OP_NOOP, 383),
+/* 399 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 400 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
+/* 401 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 402 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, char const *, _Bool *)
+/* 403 */ _CFFI_OP(_CFFI_OP_NOOP, 383),
+/* 404 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 405 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 406 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 407 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 408 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, char const *, uint32_t *)
+/* 409 */ _CFFI_OP(_CFFI_OP_NOOP, 383),
+/* 410 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 411 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 412 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
+/* 413 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 414 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, size_t *)
+/* 415 */ _CFFI_OP(_CFFI_OP_NOOP, 383),
+/* 416 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 417 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 418 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 419 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, size_t, char const * *)
+/* 420 */ _CFFI_OP(_CFFI_OP_NOOP, 383),
+/* 421 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 422 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 423 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
+/* 424 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 425 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, size_t, uint32_t *)
+/* 426 */ _CFFI_OP(_CFFI_OP_NOOP, 383),
+/* 427 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 428 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 429 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
+/* 430 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 431 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_configuration_t const *, uint32_t, unsigned int *)
+/* 432 */ _CFFI_OP(_CFFI_OP_NOOP, 383),
+/* 433 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 434 */ _CFFI_OP(_CFFI_OP_POINTER, 29), // unsigned int *
+/* 435 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 436 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *)
+/* 437 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 438 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 439 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, _Bool)
+/* 440 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 441 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
+/* 442 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 443 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, char const * const *, size_t, void *)
+/* 444 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 445 */ _CFFI_OP(_CFFI_OP_NOOP, 22),
+/* 446 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 447 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 448 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 449 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, char const *)
+/* 450 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 451 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 452 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 453 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, char const *, char const * const *, size_t, char const *)
+/* 454 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 455 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 456 */ _CFFI_OP(_CFFI_OP_NOOP, 22),
+/* 457 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 458 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 459 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 460 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_backend_t * *)
+/* 461 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 462 */ _CFFI_OP(_CFFI_OP_POINTER, 261), // clingo_backend_t * *
+/* 463 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 464 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_configuration_t * *)
+/* 465 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 466 */ _CFFI_OP(_CFFI_OP_POINTER, 378), // clingo_configuration_t * *
+/* 467 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 468 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_ground_program_observer_t const *, _Bool, void *)
+/* 469 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 470 */ _CFFI_OP(_CFFI_OP_POINTER, 1263), // clingo_ground_program_observer_t const *
+/* 471 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
+/* 472 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 473 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 474 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_part_t const *, size_t, _Bool(*)(clingo_location_t const *, char const *, uint64_t const *, size_t, void *, _Bool(*)(uint64_t const *, size_t, void *), void *), void *)
+/* 475 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 476 */ _CFFI_OP(_CFFI_OP_POINTER, 1267), // clingo_part_t const *
+/* 477 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 478 */ _CFFI_OP(_CFFI_OP_POINTER, 565), // _Bool(*)(clingo_location_t const *, char const *, uint64_t const *, size_t, void *, _Bool(*)(uint64_t const *, size_t, void *), void *)
+/* 479 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 480 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 481 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_program_builder_t * *)
+/* 482 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 483 */ _CFFI_OP(_CFFI_OP_POINTER, 672), // clingo_program_builder_t * *
+/* 484 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 485 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, clingo_propagator_t const *, void *, _Bool)
+/* 486 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 487 */ _CFFI_OP(_CFFI_OP_POINTER, 1271), // clingo_propagator_t const *
+/* 488 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 489 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
+/* 490 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 491 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, int32_t)
+/* 492 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 493 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 494 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 495 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, int32_t, int)
+/* 496 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 497 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 498 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 499 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 500 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, unsigned int, int32_t const *, size_t, _Bool(*)(unsigned int, void *, void *, _Bool *), void *, clingo_solve_handle_t * *)
+/* 501 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 502 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8),
+/* 503 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 504 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 505 */ _CFFI_OP(_CFFI_OP_POINTER, 1084), // _Bool(*)(unsigned int, void *, void *, _Bool *)
+/* 506 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 507 */ _CFFI_OP(_CFFI_OP_POINTER, 778), // clingo_solve_handle_t * *
+/* 508 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 509 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, void * *)
+/* 510 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 511 */ _CFFI_OP(_CFFI_OP_POINTER, 6), // void * *
+/* 512 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 513 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t *, void *)
+/* 514 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 515 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 516 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 517 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *)
+/* 518 */ _CFFI_OP(_CFFI_OP_POINTER, 1262), // clingo_control_t const *
+/* 519 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 520 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *, char const *, _Bool *)
+/* 521 */ _CFFI_OP(_CFFI_OP_NOOP, 518),
+/* 522 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 523 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 524 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 525 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *, char const *, uint64_t *)
+/* 526 */ _CFFI_OP(_CFFI_OP_NOOP, 518),
+/* 527 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 528 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 529 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 530 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *, clingo_statistics_t const * *)
+/* 531 */ _CFFI_OP(_CFFI_OP_NOOP, 518),
+/* 532 */ _CFFI_OP(_CFFI_OP_POINTER, 812), // clingo_statistics_t const * *
+/* 533 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 534 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *, clingo_symbolic_atoms_t const * *)
+/* 535 */ _CFFI_OP(_CFFI_OP_NOOP, 518),
+/* 536 */ _CFFI_OP(_CFFI_OP_POINTER, 855), // clingo_symbolic_atoms_t const * *
+/* 537 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 538 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_control_t const *, clingo_theory_atoms_t const * *)
+/* 539 */ _CFFI_OP(_CFFI_OP_NOOP, 518),
+/* 540 */ _CFFI_OP(_CFFI_OP_POINTER, 894), // clingo_theory_atoms_t const * *
+/* 541 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 542 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_location_t *, char const *, void *)
+/* 543 */ _CFFI_OP(_CFFI_OP_NOOP, 187),
+/* 544 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 545 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 546 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 547 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_location_t *, char const *, void *, size_t, void *, void *, void *)
+/* 548 */ _CFFI_OP(_CFFI_OP_NOOP, 187),
+/* 549 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
 /* 550 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 551 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 551 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
 /* 552 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 553 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 554 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_location_t const *, char const *, uint64_t const *, size_t, _Bool(*)(uint64_t const *, size_t, void *), void *, void *)
-/* 555 */ _CFFI_OP(_CFFI_OP_NOOP, 192),
-/* 556 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 557 */ _CFFI_OP(_CFFI_OP_NOOP, 79),
-/* 558 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 559 */ _CFFI_OP(_CFFI_OP_POINTER, 1033), // _Bool(*)(uint64_t const *, size_t, void *)
-/* 560 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 561 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 562 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 563 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_location_t const *, char const *, uint64_t const *, size_t, void *, _Bool(*)(uint64_t const *, size_t, void *), void *)
-/* 564 */ _CFFI_OP(_CFFI_OP_NOOP, 192),
-/* 565 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 566 */ _CFFI_OP(_CFFI_OP_NOOP, 79),
-/* 567 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 568 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 569 */ _CFFI_OP(_CFFI_OP_NOOP, 559),
+/* 553 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 554 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 555 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 556 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_location_t const *, char const *, uint64_t const *, size_t, _Bool(*)(uint64_t const *, size_t, void *), void *, void *)
+/* 557 */ _CFFI_OP(_CFFI_OP_NOOP, 192),
+/* 558 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 559 */ _CFFI_OP(_CFFI_OP_NOOP, 79),
+/* 560 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 561 */ _CFFI_OP(_CFFI_OP_POINTER, 1035), // _Bool(*)(uint64_t const *, size_t, void *)
+/* 562 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 563 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 564 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 565 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_location_t const *, char const *, uint64_t const *, size_t, void *, _Bool(*)(uint64_t const *, size_t, void *), void *)
+/* 566 */ _CFFI_OP(_CFFI_OP_NOOP, 192),
+/* 567 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 568 */ _CFFI_OP(_CFFI_OP_NOOP, 79),
+/* 569 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
 /* 570 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 571 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 572 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_location_t const *, char const *, void *)
-/* 573 */ _CFFI_OP(_CFFI_OP_NOOP, 192),
-/* 574 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 575 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 576 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 577 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t *, uint64_t const *, size_t)
-/* 578 */ _CFFI_OP(_CFFI_OP_POINTER, 1263), // clingo_model_t *
-/* 579 */ _CFFI_OP(_CFFI_OP_NOOP, 79),
-/* 580 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 581 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 582 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, _Bool *)
-/* 583 */ _CFFI_OP(_CFFI_OP_POINTER, 1263), // clingo_model_t const *
-/* 584 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 585 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 586 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, _Bool(*)(void *), void *, void *)
-/* 587 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 588 */ _CFFI_OP(_CFFI_OP_POINTER, 1088), // _Bool(*)(void *)
-/* 589 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 590 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 591 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 592 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, clingo_solve_control_t * *)
-/* 593 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 594 */ _CFFI_OP(_CFFI_OP_POINTER, 767), // clingo_solve_control_t * *
-/* 595 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 596 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, int *)
-/* 597 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 598 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
-/* 599 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 600 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, int32_t *, size_t)
-/* 601 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 602 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
-/* 603 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 604 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 605 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, int32_t, _Bool *)
-/* 606 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 607 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 608 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 609 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 610 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, int32_t, int *)
-/* 611 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 612 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 613 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
-/* 614 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 615 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, int64_t *, size_t)
-/* 616 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 617 */ _CFFI_OP(_CFFI_OP_POINTER, 1310), // int64_t *
-/* 618 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 619 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 620 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, size_t *)
-/* 621 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 622 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 623 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 624 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, uint32_t *)
-/* 625 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 626 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
-/* 627 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 628 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, uint64_t *)
-/* 629 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 630 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 631 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 632 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, uint64_t, _Bool *)
-/* 633 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 634 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 635 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 636 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 637 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, unsigned int, size_t *)
-/* 638 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 639 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8),
-/* 640 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 641 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 642 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, unsigned int, uint64_t *, size_t)
-/* 643 */ _CFFI_OP(_CFFI_OP_NOOP, 583),
-/* 644 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8),
-/* 645 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 646 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 647 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 648 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_options_t *, char const *, char const *, char const *, _Bool *)
-/* 649 */ _CFFI_OP(_CFFI_OP_POINTER, 1264), // clingo_options_t *
-/* 650 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 651 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 571 */ _CFFI_OP(_CFFI_OP_NOOP, 561),
+/* 572 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 573 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 574 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_location_t const *, char const *, void *)
+/* 575 */ _CFFI_OP(_CFFI_OP_NOOP, 192),
+/* 576 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 577 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 578 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 579 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t *, uint64_t const *, size_t)
+/* 580 */ _CFFI_OP(_CFFI_OP_POINTER, 1265), // clingo_model_t *
+/* 581 */ _CFFI_OP(_CFFI_OP_NOOP, 79),
+/* 582 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 583 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 584 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, _Bool *)
+/* 585 */ _CFFI_OP(_CFFI_OP_POINTER, 1265), // clingo_model_t const *
+/* 586 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 587 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 588 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, _Bool(*)(void *), void *, void *)
+/* 589 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 590 */ _CFFI_OP(_CFFI_OP_POINTER, 1090), // _Bool(*)(void *)
+/* 591 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 592 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 593 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 594 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, clingo_solve_control_t * *)
+/* 595 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 596 */ _CFFI_OP(_CFFI_OP_POINTER, 769), // clingo_solve_control_t * *
+/* 597 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 598 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, int *)
+/* 599 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 600 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
+/* 601 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 602 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, int32_t *, size_t)
+/* 603 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 604 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
+/* 605 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 606 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 607 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, int32_t, _Bool *)
+/* 608 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 609 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 610 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 611 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 612 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, int32_t, int *)
+/* 613 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 614 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 615 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
+/* 616 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 617 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, int64_t *, size_t)
+/* 618 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 619 */ _CFFI_OP(_CFFI_OP_POINTER, 1312), // int64_t *
+/* 620 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 621 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 622 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, size_t *)
+/* 623 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 624 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 625 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 626 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, uint32_t *)
+/* 627 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 628 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
+/* 629 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 630 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, uint64_t *)
+/* 631 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 632 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 633 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 634 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, uint64_t, _Bool *)
+/* 635 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 636 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 637 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 638 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 639 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, unsigned int, size_t *)
+/* 640 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 641 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8),
+/* 642 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 643 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 644 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_model_t const *, unsigned int, uint64_t *, size_t)
+/* 645 */ _CFFI_OP(_CFFI_OP_NOOP, 585),
+/* 646 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8),
+/* 647 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 648 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 649 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 650 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_options_t *, char const *, char const *, char const *, _Bool *)
+/* 651 */ _CFFI_OP(_CFFI_OP_POINTER, 1266), // clingo_options_t *
 /* 652 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 653 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 654 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 655 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_options_t *, char const *, char const *, char const *, _Bool(*)(char const *, void *), void *, _Bool, char const *)
-/* 656 */ _CFFI_OP(_CFFI_OP_NOOP, 649),
-/* 657 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 658 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 653 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 654 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 655 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 656 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 657 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_options_t *, char const *, char const *, char const *, _Bool(*)(char const *, void *), void *, _Bool, char const *)
+/* 658 */ _CFFI_OP(_CFFI_OP_NOOP, 651),
 /* 659 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 660 */ _CFFI_OP(_CFFI_OP_POINTER, 84), // _Bool(*)(char const *, void *)
-/* 661 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 662 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
-/* 663 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 664 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 665 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_options_t *, void *)
-/* 666 */ _CFFI_OP(_CFFI_OP_NOOP, 649),
-/* 667 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 668 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 669 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_program_builder_t *)
-/* 670 */ _CFFI_OP(_CFFI_OP_POINTER, 1266), // clingo_program_builder_t *
-/* 671 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 672 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_program_builder_t *, clingo_ast_t *)
-/* 673 */ _CFFI_OP(_CFFI_OP_NOOP, 670),
-/* 674 */ _CFFI_OP(_CFFI_OP_NOOP, 137),
-/* 675 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 676 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, _Bool *)
-/* 677 */ _CFFI_OP(_CFFI_OP_POINTER, 1267), // clingo_propagate_control_t *
-/* 678 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 679 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 680 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, int32_t *)
-/* 681 */ _CFFI_OP(_CFFI_OP_NOOP, 677),
-/* 682 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
-/* 683 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 684 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, int32_t const *, size_t, int, _Bool *)
-/* 685 */ _CFFI_OP(_CFFI_OP_NOOP, 677),
-/* 686 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
-/* 687 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 688 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 689 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 690 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 691 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, int32_t const *, size_t, void *)
-/* 692 */ _CFFI_OP(_CFFI_OP_NOOP, 677),
-/* 693 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
-/* 694 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 695 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 696 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 697 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, int32_t)
-/* 698 */ _CFFI_OP(_CFFI_OP_NOOP, 677),
-/* 699 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 700 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 701 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, void *)
-/* 702 */ _CFFI_OP(_CFFI_OP_NOOP, 677),
-/* 703 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 704 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 705 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t const *, int32_t)
-/* 706 */ _CFFI_OP(_CFFI_OP_POINTER, 1267), // clingo_propagate_control_t const *
-/* 707 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 708 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 709 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, _Bool *)
-/* 710 */ _CFFI_OP(_CFFI_OP_POINTER, 1268), // clingo_propagate_init_t *
-/* 711 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 712 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 713 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, _Bool, int32_t *)
-/* 714 */ _CFFI_OP(_CFFI_OP_NOOP, 710),
-/* 715 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
-/* 716 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
-/* 717 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 718 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, int32_t const *, size_t, _Bool *)
-/* 719 */ _CFFI_OP(_CFFI_OP_NOOP, 710),
-/* 720 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
-/* 721 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 722 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 723 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 724 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, int32_t)
-/* 725 */ _CFFI_OP(_CFFI_OP_NOOP, 710),
-/* 726 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 727 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 728 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, int32_t, clingo_weighted_literal_t const *, size_t, int32_t, int, _Bool, _Bool *)
-/* 729 */ _CFFI_OP(_CFFI_OP_NOOP, 710),
-/* 730 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 731 */ _CFFI_OP(_CFFI_OP_NOOP, 13),
-/* 732 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 733 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 734 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 735 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
-/* 736 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 737 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 738 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, int32_t, int32_t, int32_t)
-/* 739 */ _CFFI_OP(_CFFI_OP_NOOP, 710),
-/* 740 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 741 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 660 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 661 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 662 */ _CFFI_OP(_CFFI_OP_POINTER, 84), // _Bool(*)(char const *, void *)
+/* 663 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 664 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
+/* 665 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 666 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 667 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_options_t *, void *)
+/* 668 */ _CFFI_OP(_CFFI_OP_NOOP, 651),
+/* 669 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 670 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 671 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_program_builder_t *)
+/* 672 */ _CFFI_OP(_CFFI_OP_POINTER, 1268), // clingo_program_builder_t *
+/* 673 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 674 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_program_builder_t *, clingo_ast_t *)
+/* 675 */ _CFFI_OP(_CFFI_OP_NOOP, 672),
+/* 676 */ _CFFI_OP(_CFFI_OP_NOOP, 137),
+/* 677 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 678 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, _Bool *)
+/* 679 */ _CFFI_OP(_CFFI_OP_POINTER, 1269), // clingo_propagate_control_t *
+/* 680 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 681 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 682 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, int32_t *)
+/* 683 */ _CFFI_OP(_CFFI_OP_NOOP, 679),
+/* 684 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
+/* 685 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 686 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, int32_t const *, size_t, int, _Bool *)
+/* 687 */ _CFFI_OP(_CFFI_OP_NOOP, 679),
+/* 688 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 689 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 690 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 691 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 692 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 693 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, int32_t const *, size_t, void *)
+/* 694 */ _CFFI_OP(_CFFI_OP_NOOP, 679),
+/* 695 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 696 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 697 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 698 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 699 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, int32_t)
+/* 700 */ _CFFI_OP(_CFFI_OP_NOOP, 679),
+/* 701 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 702 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 703 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t *, void *)
+/* 704 */ _CFFI_OP(_CFFI_OP_NOOP, 679),
+/* 705 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 706 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 707 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_control_t const *, int32_t)
+/* 708 */ _CFFI_OP(_CFFI_OP_POINTER, 1269), // clingo_propagate_control_t const *
+/* 709 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 710 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 711 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, _Bool *)
+/* 712 */ _CFFI_OP(_CFFI_OP_POINTER, 1270), // clingo_propagate_init_t *
+/* 713 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 714 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 715 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, _Bool, int32_t *)
+/* 716 */ _CFFI_OP(_CFFI_OP_NOOP, 712),
+/* 717 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
+/* 718 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
+/* 719 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 720 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, int32_t const *, size_t, _Bool *)
+/* 721 */ _CFFI_OP(_CFFI_OP_NOOP, 712),
+/* 722 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 723 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 724 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 725 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 726 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, int32_t)
+/* 727 */ _CFFI_OP(_CFFI_OP_NOOP, 712),
+/* 728 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 729 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 730 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, int32_t, clingo_weighted_literal_t const *, size_t, int32_t, int, _Bool, _Bool *)
+/* 731 */ _CFFI_OP(_CFFI_OP_NOOP, 712),
+/* 732 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 733 */ _CFFI_OP(_CFFI_OP_NOOP, 13),
+/* 734 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 735 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 736 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 737 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 1),
+/* 738 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 739 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 740 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, int32_t, int32_t, int32_t)
+/* 741 */ _CFFI_OP(_CFFI_OP_NOOP, 712),
 /* 742 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 743 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 744 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, int32_t, uint32_t)
-/* 745 */ _CFFI_OP(_CFFI_OP_NOOP, 710),
-/* 746 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 747 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 748 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 749 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, void *)
-/* 750 */ _CFFI_OP(_CFFI_OP_NOOP, 710),
-/* 751 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 752 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 753 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t const *, clingo_symbolic_atoms_t const * *)
-/* 754 */ _CFFI_OP(_CFFI_OP_POINTER, 1268), // clingo_propagate_init_t const *
-/* 755 */ _CFFI_OP(_CFFI_OP_NOOP, 534),
-/* 756 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 757 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t const *, clingo_theory_atoms_t const * *)
-/* 758 */ _CFFI_OP(_CFFI_OP_NOOP, 754),
-/* 759 */ _CFFI_OP(_CFFI_OP_NOOP, 538),
-/* 760 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 761 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t const *, int32_t, int32_t *)
-/* 762 */ _CFFI_OP(_CFFI_OP_NOOP, 754),
-/* 763 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 764 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
-/* 765 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 766 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_control_t *, int32_t const *, size_t)
-/* 767 */ _CFFI_OP(_CFFI_OP_POINTER, 1271), // clingo_solve_control_t *
-/* 768 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
-/* 769 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 770 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 771 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_control_t const *, clingo_symbolic_atoms_t const * *)
-/* 772 */ _CFFI_OP(_CFFI_OP_POINTER, 1271), // clingo_solve_control_t const *
-/* 773 */ _CFFI_OP(_CFFI_OP_NOOP, 534),
-/* 774 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 775 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_handle_t *)
-/* 776 */ _CFFI_OP(_CFFI_OP_POINTER, 1272), // clingo_solve_handle_t *
-/* 777 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 778 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_handle_t *, clingo_model_t const * *)
-/* 779 */ _CFFI_OP(_CFFI_OP_NOOP, 776),
-/* 780 */ _CFFI_OP(_CFFI_OP_POINTER, 583), // clingo_model_t const * *
-/* 781 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 782 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_handle_t *, int32_t const * *, size_t *)
-/* 783 */ _CFFI_OP(_CFFI_OP_NOOP, 776),
-/* 784 */ _CFFI_OP(_CFFI_OP_POINTER, 4), // int32_t const * *
-/* 785 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 786 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 787 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_handle_t *, unsigned int *)
-/* 788 */ _CFFI_OP(_CFFI_OP_NOOP, 776),
-/* 789 */ _CFFI_OP(_CFFI_OP_NOOP, 432),
-/* 790 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 791 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t *, uint64_t, char const *, int, uint64_t *)
-/* 792 */ _CFFI_OP(_CFFI_OP_POINTER, 1273), // clingo_statistics_t *
-/* 793 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 794 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 795 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 796 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 797 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 798 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t *, uint64_t, double)
-/* 799 */ _CFFI_OP(_CFFI_OP_NOOP, 792),
-/* 800 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 801 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 14), // double
-/* 802 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 803 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t *, uint64_t, int, uint64_t *)
-/* 804 */ _CFFI_OP(_CFFI_OP_NOOP, 792),
-/* 805 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 806 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 807 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 808 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 809 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t *)
-/* 810 */ _CFFI_OP(_CFFI_OP_POINTER, 1273), // clingo_statistics_t const *
-/* 811 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 812 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 813 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, char const *, _Bool *)
-/* 814 */ _CFFI_OP(_CFFI_OP_NOOP, 810),
-/* 815 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 816 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 817 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 818 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 819 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, char const *, uint64_t *)
-/* 820 */ _CFFI_OP(_CFFI_OP_NOOP, 810),
-/* 821 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 822 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 823 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 824 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 825 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, double *)
-/* 826 */ _CFFI_OP(_CFFI_OP_NOOP, 810),
-/* 827 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 828 */ _CFFI_OP(_CFFI_OP_POINTER, 801), // double *
-/* 829 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 830 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, int *)
-/* 831 */ _CFFI_OP(_CFFI_OP_NOOP, 810),
-/* 832 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 833 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
-/* 834 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 835 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, size_t *)
-/* 836 */ _CFFI_OP(_CFFI_OP_NOOP, 810),
-/* 837 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 838 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 839 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 840 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, size_t, char const * *)
-/* 841 */ _CFFI_OP(_CFFI_OP_NOOP, 810),
-/* 842 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 843 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 844 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
-/* 845 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 846 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, size_t, uint64_t *)
-/* 847 */ _CFFI_OP(_CFFI_OP_NOOP, 810),
-/* 848 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 849 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 850 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 851 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 852 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, size_t *)
-/* 853 */ _CFFI_OP(_CFFI_OP_POINTER, 1274), // clingo_symbolic_atoms_t const *
-/* 854 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 855 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 856 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t *)
-/* 857 */ _CFFI_OP(_CFFI_OP_NOOP, 853),
-/* 858 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 859 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 860 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t *, size_t)
-/* 861 */ _CFFI_OP(_CFFI_OP_NOOP, 853),
-/* 862 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 863 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 864 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 865 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t const *, uint64_t *)
-/* 866 */ _CFFI_OP(_CFFI_OP_NOOP, 853),
-/* 867 */ _CFFI_OP(_CFFI_OP_NOOP, 79),
-/* 868 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 869 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 870 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t, _Bool *)
-/* 871 */ _CFFI_OP(_CFFI_OP_NOOP, 853),
-/* 872 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 873 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 874 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 875 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t, int32_t *)
-/* 876 */ _CFFI_OP(_CFFI_OP_NOOP, 853),
-/* 877 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 878 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
-/* 879 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 880 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t, uint64_t *)
-/* 881 */ _CFFI_OP(_CFFI_OP_NOOP, 853),
-/* 882 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 883 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 884 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 885 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t, uint64_t, _Bool *)
-/* 886 */ _CFFI_OP(_CFFI_OP_NOOP, 853),
-/* 887 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 888 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 889 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 890 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 891 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, size_t *)
-/* 892 */ _CFFI_OP(_CFFI_OP_POINTER, 1275), // clingo_theory_atoms_t const *
-/* 893 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 894 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 895 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, _Bool *)
-/* 896 */ _CFFI_OP(_CFFI_OP_NOOP, 892),
-/* 897 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 898 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 899 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 900 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, char *, size_t)
-/* 901 */ _CFFI_OP(_CFFI_OP_NOOP, 892),
-/* 902 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 903 */ _CFFI_OP(_CFFI_OP_NOOP, 138),
-/* 904 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 905 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 906 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, char const * *)
-/* 907 */ _CFFI_OP(_CFFI_OP_NOOP, 892),
-/* 908 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 909 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
-/* 910 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 911 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, char const * *, uint32_t *)
-/* 912 */ _CFFI_OP(_CFFI_OP_NOOP, 892),
-/* 913 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 914 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
-/* 915 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
-/* 916 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 917 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, int *)
-/* 918 */ _CFFI_OP(_CFFI_OP_NOOP, 892),
-/* 919 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 920 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
-/* 921 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 922 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, int32_t *)
-/* 923 */ _CFFI_OP(_CFFI_OP_NOOP, 892),
-/* 924 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 925 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
-/* 926 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 927 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, int32_t const * *, size_t *)
-/* 928 */ _CFFI_OP(_CFFI_OP_NOOP, 892),
-/* 929 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 930 */ _CFFI_OP(_CFFI_OP_NOOP, 784),
-/* 931 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 932 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 933 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, size_t *)
-/* 934 */ _CFFI_OP(_CFFI_OP_NOOP, 892),
-/* 935 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 936 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 937 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 938 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, uint32_t *)
-/* 939 */ _CFFI_OP(_CFFI_OP_NOOP, 892),
-/* 940 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 941 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
-/* 942 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 943 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, uint32_t const * *, size_t *)
-/* 944 */ _CFFI_OP(_CFFI_OP_NOOP, 892),
-/* 945 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 946 */ _CFFI_OP(_CFFI_OP_POINTER, 2), // uint32_t const * *
-/* 947 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 948 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 949 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(int, clingo_ast_t * *, ...)
-/* 950 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 951 */ _CFFI_OP(_CFFI_OP_NOOP, 143),
-/* 952 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 1),
-/* 953 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(int, int, int32_t const *, size_t, void *)
-/* 954 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 955 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 956 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
-/* 957 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 958 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 959 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 960 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(int32_t const *, size_t, void *)
-/* 961 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
-/* 962 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 963 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 964 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 965 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(int32_t, clingo_weighted_literal_t const *, size_t, void *)
-/* 966 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 967 */ _CFFI_OP(_CFFI_OP_NOOP, 13),
-/* 968 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 969 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 970 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 971 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t const *, size_t, void *)
-/* 972 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
-/* 973 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 974 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 975 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 976 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, char const *, void *)
-/* 977 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 978 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 979 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 980 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 981 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, clingo_assignment_t const *, int32_t, void *, int32_t *)
-/* 982 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 983 */ _CFFI_OP(_CFFI_OP_NOOP, 96),
-/* 984 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 985 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 986 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
-/* 987 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 988 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, int, int, unsigned int, int32_t const *, size_t, void *)
-/* 989 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 990 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 991 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 992 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8),
-/* 993 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
-/* 994 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 995 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 996 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 997 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, int, uint32_t const *, size_t, void *)
-/* 998 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 999 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 1000 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
-/* 1001 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 1002 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1003 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1004 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, int, void *)
-/* 1005 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 1006 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 1007 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1008 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1009 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, uint32_t const *, size_t, int32_t const *, size_t, void *)
-/* 1010 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 1011 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
-/* 1012 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 1013 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 743 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 744 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 745 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 746 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, int32_t, uint32_t)
+/* 747 */ _CFFI_OP(_CFFI_OP_NOOP, 712),
+/* 748 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 749 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 750 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 751 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t *, void *)
+/* 752 */ _CFFI_OP(_CFFI_OP_NOOP, 712),
+/* 753 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 754 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 755 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t const *, clingo_symbolic_atoms_t const * *)
+/* 756 */ _CFFI_OP(_CFFI_OP_POINTER, 1270), // clingo_propagate_init_t const *
+/* 757 */ _CFFI_OP(_CFFI_OP_NOOP, 536),
+/* 758 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 759 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t const *, clingo_theory_atoms_t const * *)
+/* 760 */ _CFFI_OP(_CFFI_OP_NOOP, 756),
+/* 761 */ _CFFI_OP(_CFFI_OP_NOOP, 540),
+/* 762 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 763 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_propagate_init_t const *, int32_t, int32_t *)
+/* 764 */ _CFFI_OP(_CFFI_OP_NOOP, 756),
+/* 765 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 766 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
+/* 767 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 768 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_control_t *, int32_t const *, size_t)
+/* 769 */ _CFFI_OP(_CFFI_OP_POINTER, 1273), // clingo_solve_control_t *
+/* 770 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 771 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 772 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 773 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_control_t const *, clingo_symbolic_atoms_t const * *)
+/* 774 */ _CFFI_OP(_CFFI_OP_POINTER, 1273), // clingo_solve_control_t const *
+/* 775 */ _CFFI_OP(_CFFI_OP_NOOP, 536),
+/* 776 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 777 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_handle_t *)
+/* 778 */ _CFFI_OP(_CFFI_OP_POINTER, 1274), // clingo_solve_handle_t *
+/* 779 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 780 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_handle_t *, clingo_model_t const * *)
+/* 781 */ _CFFI_OP(_CFFI_OP_NOOP, 778),
+/* 782 */ _CFFI_OP(_CFFI_OP_POINTER, 585), // clingo_model_t const * *
+/* 783 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 784 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_handle_t *, int32_t const * *, size_t *)
+/* 785 */ _CFFI_OP(_CFFI_OP_NOOP, 778),
+/* 786 */ _CFFI_OP(_CFFI_OP_POINTER, 4), // int32_t const * *
+/* 787 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 788 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 789 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_solve_handle_t *, unsigned int *)
+/* 790 */ _CFFI_OP(_CFFI_OP_NOOP, 778),
+/* 791 */ _CFFI_OP(_CFFI_OP_NOOP, 434),
+/* 792 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 793 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t *, uint64_t, char const *, int, uint64_t *)
+/* 794 */ _CFFI_OP(_CFFI_OP_POINTER, 1275), // clingo_statistics_t *
+/* 795 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 796 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 797 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 798 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 799 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 800 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t *, uint64_t, double)
+/* 801 */ _CFFI_OP(_CFFI_OP_NOOP, 794),
+/* 802 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 803 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 14), // double
+/* 804 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 805 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t *, uint64_t, int, uint64_t *)
+/* 806 */ _CFFI_OP(_CFFI_OP_NOOP, 794),
+/* 807 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 808 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 809 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 810 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 811 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t *)
+/* 812 */ _CFFI_OP(_CFFI_OP_POINTER, 1275), // clingo_statistics_t const *
+/* 813 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 814 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 815 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, char const *, _Bool *)
+/* 816 */ _CFFI_OP(_CFFI_OP_NOOP, 812),
+/* 817 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 818 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 819 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 820 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 821 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, char const *, uint64_t *)
+/* 822 */ _CFFI_OP(_CFFI_OP_NOOP, 812),
+/* 823 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 824 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 825 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 826 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 827 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, double *)
+/* 828 */ _CFFI_OP(_CFFI_OP_NOOP, 812),
+/* 829 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 830 */ _CFFI_OP(_CFFI_OP_POINTER, 803), // double *
+/* 831 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 832 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, int *)
+/* 833 */ _CFFI_OP(_CFFI_OP_NOOP, 812),
+/* 834 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 835 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
+/* 836 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 837 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, size_t *)
+/* 838 */ _CFFI_OP(_CFFI_OP_NOOP, 812),
+/* 839 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 840 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 841 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 842 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, size_t, char const * *)
+/* 843 */ _CFFI_OP(_CFFI_OP_NOOP, 812),
+/* 844 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 845 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 846 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
+/* 847 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 848 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_statistics_t const *, uint64_t, size_t, uint64_t *)
+/* 849 */ _CFFI_OP(_CFFI_OP_NOOP, 812),
+/* 850 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 851 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 852 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 853 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 854 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, size_t *)
+/* 855 */ _CFFI_OP(_CFFI_OP_POINTER, 1276), // clingo_symbolic_atoms_t const *
+/* 856 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 857 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 858 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t *)
+/* 859 */ _CFFI_OP(_CFFI_OP_NOOP, 855),
+/* 860 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 861 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 862 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t *, size_t)
+/* 863 */ _CFFI_OP(_CFFI_OP_NOOP, 855),
+/* 864 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 865 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 866 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 867 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t const *, uint64_t *)
+/* 868 */ _CFFI_OP(_CFFI_OP_NOOP, 855),
+/* 869 */ _CFFI_OP(_CFFI_OP_NOOP, 79),
+/* 870 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 871 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 872 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t, _Bool *)
+/* 873 */ _CFFI_OP(_CFFI_OP_NOOP, 855),
+/* 874 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 875 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 876 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 877 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t, int32_t *)
+/* 878 */ _CFFI_OP(_CFFI_OP_NOOP, 855),
+/* 879 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 880 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
+/* 881 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 882 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t, uint64_t *)
+/* 883 */ _CFFI_OP(_CFFI_OP_NOOP, 855),
+/* 884 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 885 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 886 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 887 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_symbolic_atoms_t const *, uint64_t, uint64_t, _Bool *)
+/* 888 */ _CFFI_OP(_CFFI_OP_NOOP, 855),
+/* 889 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 890 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 891 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 892 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 893 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, size_t *)
+/* 894 */ _CFFI_OP(_CFFI_OP_POINTER, 1277), // clingo_theory_atoms_t const *
+/* 895 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 896 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 897 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, _Bool *)
+/* 898 */ _CFFI_OP(_CFFI_OP_NOOP, 894),
+/* 899 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 900 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 901 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 902 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, char *, size_t)
+/* 903 */ _CFFI_OP(_CFFI_OP_NOOP, 894),
+/* 904 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 905 */ _CFFI_OP(_CFFI_OP_NOOP, 138),
+/* 906 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 907 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 908 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, char const * *)
+/* 909 */ _CFFI_OP(_CFFI_OP_NOOP, 894),
+/* 910 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 911 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
+/* 912 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 913 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, char const * *, uint32_t *)
+/* 914 */ _CFFI_OP(_CFFI_OP_NOOP, 894),
+/* 915 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 916 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
+/* 917 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
+/* 918 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 919 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, int *)
+/* 920 */ _CFFI_OP(_CFFI_OP_NOOP, 894),
+/* 921 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 922 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
+/* 923 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 924 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, int32_t *)
+/* 925 */ _CFFI_OP(_CFFI_OP_NOOP, 894),
+/* 926 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 927 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
+/* 928 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 929 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, int32_t const * *, size_t *)
+/* 930 */ _CFFI_OP(_CFFI_OP_NOOP, 894),
+/* 931 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 932 */ _CFFI_OP(_CFFI_OP_NOOP, 786),
+/* 933 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 934 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 935 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, size_t *)
+/* 936 */ _CFFI_OP(_CFFI_OP_NOOP, 894),
+/* 937 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 938 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 939 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 940 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, uint32_t *)
+/* 941 */ _CFFI_OP(_CFFI_OP_NOOP, 894),
+/* 942 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 943 */ _CFFI_OP(_CFFI_OP_NOOP, 115),
+/* 944 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 945 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(clingo_theory_atoms_t const *, uint32_t, uint32_t const * *, size_t *)
+/* 946 */ _CFFI_OP(_CFFI_OP_NOOP, 894),
+/* 947 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 948 */ _CFFI_OP(_CFFI_OP_POINTER, 2), // uint32_t const * *
+/* 949 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 950 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 951 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(int, clingo_ast_t * *, ...)
+/* 952 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 953 */ _CFFI_OP(_CFFI_OP_NOOP, 143),
+/* 954 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 1),
+/* 955 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(int, int, int32_t const *, size_t, void *)
+/* 956 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 957 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 958 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 959 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 960 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 961 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 962 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(int32_t const *, size_t, void *)
+/* 963 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 964 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 965 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 966 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 967 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(int32_t, clingo_weighted_literal_t const *, size_t, void *)
+/* 968 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 969 */ _CFFI_OP(_CFFI_OP_NOOP, 13),
+/* 970 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 971 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 972 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 973 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t const *, size_t, void *)
+/* 974 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
+/* 975 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 976 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 977 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 978 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, char const *, void *)
+/* 979 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 980 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 981 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 982 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 983 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, clingo_assignment_t const *, int32_t, void *, int32_t *)
+/* 984 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 985 */ _CFFI_OP(_CFFI_OP_NOOP, 96),
+/* 986 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 987 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 988 */ _CFFI_OP(_CFFI_OP_NOOP, 120),
+/* 989 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 990 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, int, int, unsigned int, int32_t const *, size_t, void *)
+/* 991 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 992 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 993 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 994 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8),
+/* 995 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 996 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 997 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 998 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 999 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, int, uint32_t const *, size_t, void *)
+/* 1000 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 1001 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 1002 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
+/* 1003 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 1004 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1005 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1006 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, int, void *)
+/* 1007 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 1008 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 1009 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1010 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1011 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, uint32_t const *, size_t, int32_t const *, size_t, void *)
+/* 1012 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 1013 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
 /* 1014 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 1015 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1016 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1017 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, uint32_t, uint32_t const *, size_t, uint32_t, uint32_t, void *)
-/* 1018 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 1019 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 1020 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
-/* 1021 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 1022 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 1023 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 1024 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1025 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1026 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, uint32_t, uint32_t const *, size_t, void *)
-/* 1027 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 1028 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 1029 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
-/* 1030 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 1031 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1032 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1033 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t const *, size_t, void *)
-/* 1034 */ _CFFI_OP(_CFFI_OP_NOOP, 79),
-/* 1035 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 1036 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1037 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1038 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t)
-/* 1039 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1040 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1041 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, _Bool *)
-/* 1042 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1043 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 1044 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1045 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, char *, size_t)
-/* 1046 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1047 */ _CFFI_OP(_CFFI_OP_NOOP, 138),
-/* 1048 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 1049 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1050 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, char const * *)
-/* 1051 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1052 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
-/* 1053 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1054 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, int *)
-/* 1055 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1056 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
-/* 1057 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1058 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, int32_t const *, size_t, void *)
-/* 1059 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1060 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
-/* 1061 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 1062 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1063 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1064 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, size_t *)
-/* 1065 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1066 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 1067 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1068 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, uint32_t, void *)
-/* 1069 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1070 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
-/* 1071 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1072 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1073 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, uint64_t const * *, size_t *)
-/* 1074 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1075 */ _CFFI_OP(_CFFI_OP_POINTER, 79), // uint64_t const * *
-/* 1076 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
-/* 1077 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1078 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, uint64_t)
-/* 1079 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1080 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1081 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1082 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(unsigned int, void *, void *, _Bool *)
-/* 1083 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8),
-/* 1084 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1085 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1086 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 1087 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1088 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(void *)
-/* 1089 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1090 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1091 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(void *, char const *, void *)
-/* 1092 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1093 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 1015 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 1016 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 1017 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1018 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1019 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, uint32_t, uint32_t const *, size_t, uint32_t, uint32_t, void *)
+/* 1020 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 1021 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 1022 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
+/* 1023 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 1024 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 1025 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 1026 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1027 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1028 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint32_t, uint32_t, uint32_t const *, size_t, void *)
+/* 1029 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 1030 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 1031 */ _CFFI_OP(_CFFI_OP_NOOP, 2),
+/* 1032 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 1033 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1034 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1035 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t const *, size_t, void *)
+/* 1036 */ _CFFI_OP(_CFFI_OP_NOOP, 79),
+/* 1037 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 1038 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1039 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1040 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t)
+/* 1041 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1042 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1043 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, _Bool *)
+/* 1044 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1045 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 1046 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1047 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, char *, size_t)
+/* 1048 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1049 */ _CFFI_OP(_CFFI_OP_NOOP, 138),
+/* 1050 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 1051 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1052 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, char const * *)
+/* 1053 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1054 */ _CFFI_OP(_CFFI_OP_NOOP, 60),
+/* 1055 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1056 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, int *)
+/* 1057 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1058 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
+/* 1059 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1060 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, int32_t const *, size_t, void *)
+/* 1061 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1062 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 1063 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 1064 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1065 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1066 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, size_t *)
+/* 1067 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1068 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 1069 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1070 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, uint32_t, void *)
+/* 1071 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1072 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 22),
+/* 1073 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1074 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1075 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, uint64_t const * *, size_t *)
+/* 1076 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1077 */ _CFFI_OP(_CFFI_OP_POINTER, 79), // uint64_t const * *
+/* 1078 */ _CFFI_OP(_CFFI_OP_NOOP, 207),
+/* 1079 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1080 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(uint64_t, uint64_t)
+/* 1081 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1082 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1083 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1084 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(unsigned int, void *, void *, _Bool *)
+/* 1085 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 8),
+/* 1086 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1087 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1088 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 1089 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1090 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(void *)
+/* 1091 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1092 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1093 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(void *, char const *, void *)
 /* 1094 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1095 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1096 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(void *, char const *, void *, size_t, void *, void *, void *)
-/* 1097 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1098 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 1095 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 1096 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1097 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1098 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(void *, char const *, void *, size_t, void *, void *, void *)
 /* 1099 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1100 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 1100 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
 /* 1101 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1102 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1102 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
 /* 1103 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1104 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1105 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(void *, void *)
-/* 1106 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1107 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1108 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1109 */ _CFFI_OP(_CFFI_OP_FUNCTION, 40), // char const *()(char const *)
-/* 1110 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 1111 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1112 */ _CFFI_OP(_CFFI_OP_FUNCTION, 40), // char const *()(int)
-/* 1113 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 1114 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1115 */ _CFFI_OP(_CFFI_OP_FUNCTION, 40), // char const *()(uint64_t)
-/* 1116 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1117 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1118 */ _CFFI_OP(_CFFI_OP_FUNCTION, 40), // char const *()(void *)
-/* 1119 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1120 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1121 */ _CFFI_OP(_CFFI_OP_FUNCTION, 40), // char const *()(void)
+/* 1104 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1105 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1106 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1107 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1), // _Bool()(void *, void *)
+/* 1108 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1109 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1110 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1111 */ _CFFI_OP(_CFFI_OP_FUNCTION, 40), // char const *()(char const *)
+/* 1112 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 1113 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1114 */ _CFFI_OP(_CFFI_OP_FUNCTION, 40), // char const *()(int)
+/* 1115 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 1116 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1117 */ _CFFI_OP(_CFFI_OP_FUNCTION, 40), // char const *()(uint64_t)
+/* 1118 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1119 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1120 */ _CFFI_OP(_CFFI_OP_FUNCTION, 40), // char const *()(void *)
+/* 1121 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
 /* 1122 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1123 */ _CFFI_OP(_CFFI_OP_FUNCTION, 96), // clingo_assignment_t const *()(clingo_propagate_control_t const *)
-/* 1124 */ _CFFI_OP(_CFFI_OP_NOOP, 706),
-/* 1125 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1126 */ _CFFI_OP(_CFFI_OP_FUNCTION, 96), // clingo_assignment_t const *()(clingo_propagate_init_t const *)
-/* 1127 */ _CFFI_OP(_CFFI_OP_NOOP, 754),
-/* 1128 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1129 */ _CFFI_OP(_CFFI_OP_FUNCTION, 155), // int()(clingo_application_t *, char const * const *, size_t, void *)
-/* 1130 */ _CFFI_OP(_CFFI_OP_POINTER, 1249), // clingo_application_t *
-/* 1131 */ _CFFI_OP(_CFFI_OP_NOOP, 22),
-/* 1132 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 1133 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1134 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1135 */ _CFFI_OP(_CFFI_OP_FUNCTION, 155), // int()(clingo_propagate_init_t const *)
-/* 1136 */ _CFFI_OP(_CFFI_OP_NOOP, 754),
-/* 1137 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1138 */ _CFFI_OP(_CFFI_OP_FUNCTION, 155), // int()(uint64_t)
-/* 1139 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1140 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1141 */ _CFFI_OP(_CFFI_OP_FUNCTION, 155), // int()(void)
+/* 1123 */ _CFFI_OP(_CFFI_OP_FUNCTION, 40), // char const *()(void)
+/* 1124 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1125 */ _CFFI_OP(_CFFI_OP_FUNCTION, 96), // clingo_assignment_t const *()(clingo_propagate_control_t const *)
+/* 1126 */ _CFFI_OP(_CFFI_OP_NOOP, 708),
+/* 1127 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1128 */ _CFFI_OP(_CFFI_OP_FUNCTION, 96), // clingo_assignment_t const *()(clingo_propagate_init_t const *)
+/* 1129 */ _CFFI_OP(_CFFI_OP_NOOP, 756),
+/* 1130 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1131 */ _CFFI_OP(_CFFI_OP_FUNCTION, 155), // int()(clingo_application_t *, char const * const *, size_t, void *)
+/* 1132 */ _CFFI_OP(_CFFI_OP_POINTER, 1251), // clingo_application_t *
+/* 1133 */ _CFFI_OP(_CFFI_OP_NOOP, 22),
+/* 1134 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 1135 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1136 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1137 */ _CFFI_OP(_CFFI_OP_FUNCTION, 155), // int()(clingo_propagate_init_t const *)
+/* 1138 */ _CFFI_OP(_CFFI_OP_NOOP, 756),
+/* 1139 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1140 */ _CFFI_OP(_CFFI_OP_FUNCTION, 155), // int()(uint64_t)
+/* 1141 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
 /* 1142 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1143 */ _CFFI_OP(_CFFI_OP_FUNCTION, 3), // size_t()(clingo_assignment_t const *)
-/* 1144 */ _CFFI_OP(_CFFI_OP_NOOP, 96),
-/* 1145 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1146 */ _CFFI_OP(_CFFI_OP_FUNCTION, 3), // size_t()(clingo_ast_t *)
-/* 1147 */ _CFFI_OP(_CFFI_OP_NOOP, 137),
-/* 1148 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1149 */ _CFFI_OP(_CFFI_OP_FUNCTION, 3), // size_t()(uint64_t)
-/* 1150 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1151 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1152 */ _CFFI_OP(_CFFI_OP_FUNCTION, 69), // uint32_t()(clingo_assignment_t const *)
-/* 1153 */ _CFFI_OP(_CFFI_OP_NOOP, 96),
-/* 1154 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1155 */ _CFFI_OP(_CFFI_OP_FUNCTION, 69), // uint32_t()(clingo_propagate_control_t const *)
-/* 1156 */ _CFFI_OP(_CFFI_OP_NOOP, 706),
-/* 1157 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1158 */ _CFFI_OP(_CFFI_OP_FUNCTION, 69), // uint32_t()(uint64_t)
-/* 1159 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
-/* 1160 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1161 */ _CFFI_OP(_CFFI_OP_FUNCTION, 29), // unsigned int()(void *)
-/* 1162 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1163 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1164 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(clingo_ast_t *)
-/* 1165 */ _CFFI_OP(_CFFI_OP_NOOP, 137),
-/* 1166 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1167 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(clingo_control_t *)
-/* 1168 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
-/* 1169 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1170 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(clingo_propagate_control_t *, int32_t)
-/* 1171 */ _CFFI_OP(_CFFI_OP_NOOP, 677),
-/* 1172 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
-/* 1173 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1174 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(clingo_propagate_control_t const *, int32_t const *, size_t, void *)
-/* 1175 */ _CFFI_OP(_CFFI_OP_NOOP, 706),
-/* 1176 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
-/* 1177 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
-/* 1178 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1179 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1180 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(clingo_propagate_init_t *, int)
-/* 1181 */ _CFFI_OP(_CFFI_OP_NOOP, 710),
-/* 1182 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 1183 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1184 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(clingo_solve_handle_t *, double, _Bool *)
-/* 1185 */ _CFFI_OP(_CFFI_OP_NOOP, 776),
-/* 1186 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 14),
-/* 1187 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
-/* 1188 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1189 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(int *, int *, int *)
-/* 1190 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
-/* 1191 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
+/* 1143 */ _CFFI_OP(_CFFI_OP_FUNCTION, 155), // int()(void)
+/* 1144 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1145 */ _CFFI_OP(_CFFI_OP_FUNCTION, 3), // size_t()(clingo_assignment_t const *)
+/* 1146 */ _CFFI_OP(_CFFI_OP_NOOP, 96),
+/* 1147 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1148 */ _CFFI_OP(_CFFI_OP_FUNCTION, 3), // size_t()(clingo_ast_t *)
+/* 1149 */ _CFFI_OP(_CFFI_OP_NOOP, 137),
+/* 1150 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1151 */ _CFFI_OP(_CFFI_OP_FUNCTION, 3), // size_t()(uint64_t)
+/* 1152 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1153 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1154 */ _CFFI_OP(_CFFI_OP_FUNCTION, 69), // uint32_t()(clingo_assignment_t const *)
+/* 1155 */ _CFFI_OP(_CFFI_OP_NOOP, 96),
+/* 1156 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1157 */ _CFFI_OP(_CFFI_OP_FUNCTION, 69), // uint32_t()(clingo_propagate_control_t const *)
+/* 1158 */ _CFFI_OP(_CFFI_OP_NOOP, 708),
+/* 1159 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1160 */ _CFFI_OP(_CFFI_OP_FUNCTION, 69), // uint32_t()(uint64_t)
+/* 1161 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 24),
+/* 1162 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1163 */ _CFFI_OP(_CFFI_OP_FUNCTION, 29), // unsigned int()(void *)
+/* 1164 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1165 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1166 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(clingo_ast_t *)
+/* 1167 */ _CFFI_OP(_CFFI_OP_NOOP, 137),
+/* 1168 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1169 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(clingo_control_t *)
+/* 1170 */ _CFFI_OP(_CFFI_OP_NOOP, 26),
+/* 1171 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1172 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(clingo_propagate_control_t *, int32_t)
+/* 1173 */ _CFFI_OP(_CFFI_OP_NOOP, 679),
+/* 1174 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 21),
+/* 1175 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1176 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(clingo_propagate_control_t const *, int32_t const *, size_t, void *)
+/* 1177 */ _CFFI_OP(_CFFI_OP_NOOP, 708),
+/* 1178 */ _CFFI_OP(_CFFI_OP_NOOP, 4),
+/* 1179 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 28),
+/* 1180 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1181 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1182 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(clingo_propagate_init_t *, int)
+/* 1183 */ _CFFI_OP(_CFFI_OP_NOOP, 712),
+/* 1184 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 1185 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1186 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(clingo_solve_handle_t *, double, _Bool *)
+/* 1187 */ _CFFI_OP(_CFFI_OP_NOOP, 778),
+/* 1188 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 14),
+/* 1189 */ _CFFI_OP(_CFFI_OP_NOOP, 41),
+/* 1190 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1191 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(int *, int *, int *)
 /* 1192 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
-/* 1193 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1194 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(int, char const *)
-/* 1195 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 1196 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 1197 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1198 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(int, char const *, void *)
-/* 1199 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 1200 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
-/* 1201 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1202 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1203 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(int, uint64_t *)
-/* 1204 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
-/* 1205 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 1206 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1207 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(uint64_t *)
-/* 1208 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
-/* 1209 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1210 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1314), // void()(void *)
-/* 1211 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
-/* 1212 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
-/* 1213 */ _CFFI_OP(_CFFI_OP_POINTER, 0), // _Bool(*)(_Bool, uint32_t const *, size_t, int32_t const *, size_t, void *)
-/* 1214 */ _CFFI_OP(_CFFI_OP_POINTER, 8), // _Bool(*)(_Bool, uint32_t const *, size_t, int32_t, clingo_weighted_literal_t const *, size_t, void *)
-/* 1215 */ _CFFI_OP(_CFFI_OP_POINTER, 17), // _Bool(*)(_Bool, void *)
-/* 1216 */ _CFFI_OP(_CFFI_OP_POINTER, 39), // _Bool(*)(char const *, _Bool *, void *)
-/* 1217 */ _CFFI_OP(_CFFI_OP_POINTER, 256), // _Bool(*)(clingo_ast_t const *, void *)
-/* 1218 */ _CFFI_OP(_CFFI_OP_POINTER, 441), // _Bool(*)(clingo_control_t *, char const * const *, size_t, void *)
-/* 1219 */ _CFFI_OP(_CFFI_OP_POINTER, 511), // _Bool(*)(clingo_control_t *, void *)
-/* 1220 */ _CFFI_OP(_CFFI_OP_POINTER, 540), // _Bool(*)(clingo_location_t *, char const *, void *)
-/* 1221 */ _CFFI_OP(_CFFI_OP_POINTER, 545), // _Bool(*)(clingo_location_t *, char const *, void *, size_t, void *, void *, void *)
-/* 1222 */ _CFFI_OP(_CFFI_OP_POINTER, 554), // _Bool(*)(clingo_location_t const *, char const *, uint64_t const *, size_t, _Bool(*)(uint64_t const *, size_t, void *), void *, void *)
-/* 1223 */ _CFFI_OP(_CFFI_OP_POINTER, 572), // _Bool(*)(clingo_location_t const *, char const *, void *)
-/* 1224 */ _CFFI_OP(_CFFI_OP_POINTER, 586), // _Bool(*)(clingo_model_t const *, _Bool(*)(void *), void *, void *)
-/* 1225 */ _CFFI_OP(_CFFI_OP_POINTER, 665), // _Bool(*)(clingo_options_t *, void *)
-/* 1226 */ _CFFI_OP(_CFFI_OP_POINTER, 691), // _Bool(*)(clingo_propagate_control_t *, int32_t const *, size_t, void *)
-/* 1227 */ _CFFI_OP(_CFFI_OP_POINTER, 701), // _Bool(*)(clingo_propagate_control_t *, void *)
-/* 1228 */ _CFFI_OP(_CFFI_OP_POINTER, 749), // _Bool(*)(clingo_propagate_init_t *, void *)
-/* 1229 */ _CFFI_OP(_CFFI_OP_POINTER, 949), // _Bool(*)(int, clingo_ast_t * *, ...)
-/* 1230 */ _CFFI_OP(_CFFI_OP_POINTER, 953), // _Bool(*)(int, int, int32_t const *, size_t, void *)
-/* 1231 */ _CFFI_OP(_CFFI_OP_POINTER, 960), // _Bool(*)(int32_t const *, size_t, void *)
-/* 1232 */ _CFFI_OP(_CFFI_OP_POINTER, 965), // _Bool(*)(int32_t, clingo_weighted_literal_t const *, size_t, void *)
-/* 1233 */ _CFFI_OP(_CFFI_OP_POINTER, 971), // _Bool(*)(uint32_t const *, size_t, void *)
-/* 1234 */ _CFFI_OP(_CFFI_OP_POINTER, 976), // _Bool(*)(uint32_t, char const *, void *)
-/* 1235 */ _CFFI_OP(_CFFI_OP_POINTER, 981), // _Bool(*)(uint32_t, clingo_assignment_t const *, int32_t, void *, int32_t *)
-/* 1236 */ _CFFI_OP(_CFFI_OP_POINTER, 988), // _Bool(*)(uint32_t, int, int, unsigned int, int32_t const *, size_t, void *)
-/* 1237 */ _CFFI_OP(_CFFI_OP_POINTER, 997), // _Bool(*)(uint32_t, int, uint32_t const *, size_t, void *)
-/* 1238 */ _CFFI_OP(_CFFI_OP_POINTER, 1004), // _Bool(*)(uint32_t, int, void *)
-/* 1239 */ _CFFI_OP(_CFFI_OP_POINTER, 1009), // _Bool(*)(uint32_t, uint32_t const *, size_t, int32_t const *, size_t, void *)
-/* 1240 */ _CFFI_OP(_CFFI_OP_POINTER, 1017), // _Bool(*)(uint32_t, uint32_t, uint32_t const *, size_t, uint32_t, uint32_t, void *)
-/* 1241 */ _CFFI_OP(_CFFI_OP_POINTER, 1026), // _Bool(*)(uint32_t, uint32_t, uint32_t const *, size_t, void *)
-/* 1242 */ _CFFI_OP(_CFFI_OP_POINTER, 1058), // _Bool(*)(uint64_t, int32_t const *, size_t, void *)
-/* 1243 */ _CFFI_OP(_CFFI_OP_POINTER, 1068), // _Bool(*)(uint64_t, uint32_t, void *)
-/* 1244 */ _CFFI_OP(_CFFI_OP_POINTER, 1091), // _Bool(*)(void *, char const *, void *)
-/* 1245 */ _CFFI_OP(_CFFI_OP_POINTER, 1096), // _Bool(*)(void *, char const *, void *, size_t, void *, void *, void *)
-/* 1246 */ _CFFI_OP(_CFFI_OP_POINTER, 1105), // _Bool(*)(void *, void *)
-/* 1247 */ _CFFI_OP(_CFFI_OP_POINTER, 1118), // char const *(*)(void *)
-/* 1248 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 2), // char
-/* 1249 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 0), // clingo_application_t
-/* 1250 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 1), // clingo_assignment_t
-/* 1251 */ _CFFI_OP(_CFFI_OP_POINTER, 1252), // clingo_ast_argument_t const *
-/* 1252 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 3), // clingo_ast_argument_t
-/* 1253 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 4), // clingo_ast_attribute_names_t
-/* 1254 */ _CFFI_OP(_CFFI_OP_POINTER, 1255), // clingo_ast_constructor_t const *
-/* 1255 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 5), // clingo_ast_constructor_t
-/* 1256 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 6), // clingo_ast_constructors_t
-/* 1257 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 2), // clingo_ast_t
-/* 1258 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 7), // clingo_backend_t
-/* 1259 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 8), // clingo_configuration_t
-/* 1260 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 9), // clingo_control_t
-/* 1261 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 10), // clingo_ground_program_observer_t
-/* 1262 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 11), // clingo_location_t
-/* 1263 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 12), // clingo_model_t
-/* 1264 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 13), // clingo_options_t
-/* 1265 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 14), // clingo_part_t
-/* 1266 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 15), // clingo_program_builder_t
-/* 1267 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 16), // clingo_propagate_control_t
-/* 1268 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 17), // clingo_propagate_init_t
-/* 1269 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 18), // clingo_propagator_t
-/* 1270 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 19), // clingo_script_t
-/* 1271 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 20), // clingo_solve_control_t
-/* 1272 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 21), // clingo_solve_handle_t
-/* 1273 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 22), // clingo_statistics_t
-/* 1274 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 23), // clingo_symbolic_atoms_t
-/* 1275 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 24), // clingo_theory_atoms_t
-/* 1276 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 25), // clingo_weighted_literal_t
-/* 1277 */ _CFFI_OP(_CFFI_OP_ENUM, 0), // enum clingo_ast_aggregate_function_e
-/* 1278 */ _CFFI_OP(_CFFI_OP_ENUM, 1), // enum clingo_ast_attribute_e
-/* 1279 */ _CFFI_OP(_CFFI_OP_ENUM, 2), // enum clingo_ast_attribute_type_e
-/* 1280 */ _CFFI_OP(_CFFI_OP_ENUM, 3), // enum clingo_ast_binary_operator_e
-/* 1281 */ _CFFI_OP(_CFFI_OP_ENUM, 4), // enum clingo_ast_comparison_operator_e
-/* 1282 */ _CFFI_OP(_CFFI_OP_ENUM, 5), // enum clingo_ast_sign_e
-/* 1283 */ _CFFI_OP(_CFFI_OP_ENUM, 6), // enum clingo_ast_theory_atom_definition_type_e
-/* 1284 */ _CFFI_OP(_CFFI_OP_ENUM, 7), // enum clingo_ast_theory_operator_type_e
-/* 1285 */ _CFFI_OP(_CFFI_OP_ENUM, 8), // enum clingo_ast_theory_sequence_type_e
-/* 1286 */ _CFFI_OP(_CFFI_OP_ENUM, 9), // enum clingo_ast_type_e
-/* 1287 */ _CFFI_OP(_CFFI_OP_ENUM, 10), // enum clingo_ast_unary_operator_e
-/* 1288 */ _CFFI_OP(_CFFI_OP_ENUM, 11), // enum clingo_ast_unpool_type_e
-/* 1289 */ _CFFI_OP(_CFFI_OP_ENUM, 12), // enum clingo_clause_type_e
-/* 1290 */ _CFFI_OP(_CFFI_OP_ENUM, 13), // enum clingo_comment_type_e
-/* 1291 */ _CFFI_OP(_CFFI_OP_ENUM, 14), // enum clingo_configuration_type_e
-/* 1292 */ _CFFI_OP(_CFFI_OP_ENUM, 15), // enum clingo_consequence_e
-/* 1293 */ _CFFI_OP(_CFFI_OP_ENUM, 16), // enum clingo_error_e
-/* 1294 */ _CFFI_OP(_CFFI_OP_ENUM, 17), // enum clingo_external_type_e
-/* 1295 */ _CFFI_OP(_CFFI_OP_ENUM, 18), // enum clingo_heuristic_type_e
-/* 1296 */ _CFFI_OP(_CFFI_OP_ENUM, 19), // enum clingo_model_type_e
-/* 1297 */ _CFFI_OP(_CFFI_OP_ENUM, 20), // enum clingo_propagator_check_mode_e
-/* 1298 */ _CFFI_OP(_CFFI_OP_ENUM, 21), // enum clingo_propagator_undo_mode_e
-/* 1299 */ _CFFI_OP(_CFFI_OP_ENUM, 22), // enum clingo_show_type_e
-/* 1300 */ _CFFI_OP(_CFFI_OP_ENUM, 23), // enum clingo_solve_event_type_e
-/* 1301 */ _CFFI_OP(_CFFI_OP_ENUM, 24), // enum clingo_solve_mode_e
-/* 1302 */ _CFFI_OP(_CFFI_OP_ENUM, 25), // enum clingo_solve_result_e
-/* 1303 */ _CFFI_OP(_CFFI_OP_ENUM, 26), // enum clingo_statistics_type_e
-/* 1304 */ _CFFI_OP(_CFFI_OP_ENUM, 27), // enum clingo_symbol_type_e
-/* 1305 */ _CFFI_OP(_CFFI_OP_ENUM, 28), // enum clingo_theory_sequence_type_e
-/* 1306 */ _CFFI_OP(_CFFI_OP_ENUM, 29), // enum clingo_theory_term_type_e
-/* 1307 */ _CFFI_OP(_CFFI_OP_ENUM, 30), // enum clingo_truth_value_e
-/* 1308 */ _CFFI_OP(_CFFI_OP_ENUM, 31), // enum clingo_warning_e
-/* 1309 */ _CFFI_OP(_CFFI_OP_ENUM, 32), // enum clingo_weight_constraint_type_e
-/* 1310 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 23), // int64_t
-/* 1311 */ _CFFI_OP(_CFFI_OP_POINTER, 1161), // unsigned int(*)(void *)
-/* 1312 */ _CFFI_OP(_CFFI_OP_POINTER, 1174), // void(*)(clingo_propagate_control_t const *, int32_t const *, size_t, void *)
-/* 1313 */ _CFFI_OP(_CFFI_OP_POINTER, 1210), // void(*)(void *)
-/* 1314 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 0), // void
+/* 1193 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
+/* 1194 */ _CFFI_OP(_CFFI_OP_NOOP, 110),
+/* 1195 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1196 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(int, char const *)
+/* 1197 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 1198 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 1199 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1200 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(int, char const *, void *)
+/* 1201 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 1202 */ _CFFI_OP(_CFFI_OP_NOOP, 40),
+/* 1203 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1204 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1205 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(int, uint64_t *)
+/* 1206 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 7),
+/* 1207 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 1208 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1209 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(uint64_t *)
+/* 1210 */ _CFFI_OP(_CFFI_OP_NOOP, 56),
+/* 1211 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1212 */ _CFFI_OP(_CFFI_OP_FUNCTION, 1316), // void()(void *)
+/* 1213 */ _CFFI_OP(_CFFI_OP_NOOP, 6),
+/* 1214 */ _CFFI_OP(_CFFI_OP_FUNCTION_END, 0),
+/* 1215 */ _CFFI_OP(_CFFI_OP_POINTER, 0), // _Bool(*)(_Bool, uint32_t const *, size_t, int32_t const *, size_t, void *)
+/* 1216 */ _CFFI_OP(_CFFI_OP_POINTER, 8), // _Bool(*)(_Bool, uint32_t const *, size_t, int32_t, clingo_weighted_literal_t const *, size_t, void *)
+/* 1217 */ _CFFI_OP(_CFFI_OP_POINTER, 17), // _Bool(*)(_Bool, void *)
+/* 1218 */ _CFFI_OP(_CFFI_OP_POINTER, 39), // _Bool(*)(char const *, _Bool *, void *)
+/* 1219 */ _CFFI_OP(_CFFI_OP_POINTER, 256), // _Bool(*)(clingo_ast_t const *, void *)
+/* 1220 */ _CFFI_OP(_CFFI_OP_POINTER, 443), // _Bool(*)(clingo_control_t *, char const * const *, size_t, void *)
+/* 1221 */ _CFFI_OP(_CFFI_OP_POINTER, 513), // _Bool(*)(clingo_control_t *, void *)
+/* 1222 */ _CFFI_OP(_CFFI_OP_POINTER, 542), // _Bool(*)(clingo_location_t *, char const *, void *)
+/* 1223 */ _CFFI_OP(_CFFI_OP_POINTER, 547), // _Bool(*)(clingo_location_t *, char const *, void *, size_t, void *, void *, void *)
+/* 1224 */ _CFFI_OP(_CFFI_OP_POINTER, 556), // _Bool(*)(clingo_location_t const *, char const *, uint64_t const *, size_t, _Bool(*)(uint64_t const *, size_t, void *), void *, void *)
+/* 1225 */ _CFFI_OP(_CFFI_OP_POINTER, 574), // _Bool(*)(clingo_location_t const *, char const *, void *)
+/* 1226 */ _CFFI_OP(_CFFI_OP_POINTER, 588), // _Bool(*)(clingo_model_t const *, _Bool(*)(void *), void *, void *)
+/* 1227 */ _CFFI_OP(_CFFI_OP_POINTER, 667), // _Bool(*)(clingo_options_t *, void *)
+/* 1228 */ _CFFI_OP(_CFFI_OP_POINTER, 693), // _Bool(*)(clingo_propagate_control_t *, int32_t const *, size_t, void *)
+/* 1229 */ _CFFI_OP(_CFFI_OP_POINTER, 703), // _Bool(*)(clingo_propagate_control_t *, void *)
+/* 1230 */ _CFFI_OP(_CFFI_OP_POINTER, 751), // _Bool(*)(clingo_propagate_init_t *, void *)
+/* 1231 */ _CFFI_OP(_CFFI_OP_POINTER, 951), // _Bool(*)(int, clingo_ast_t * *, ...)
+/* 1232 */ _CFFI_OP(_CFFI_OP_POINTER, 955), // _Bool(*)(int, int, int32_t const *, size_t, void *)
+/* 1233 */ _CFFI_OP(_CFFI_OP_POINTER, 962), // _Bool(*)(int32_t const *, size_t, void *)
+/* 1234 */ _CFFI_OP(_CFFI_OP_POINTER, 967), // _Bool(*)(int32_t, clingo_weighted_literal_t const *, size_t, void *)
+/* 1235 */ _CFFI_OP(_CFFI_OP_POINTER, 973), // _Bool(*)(uint32_t const *, size_t, void *)
+/* 1236 */ _CFFI_OP(_CFFI_OP_POINTER, 978), // _Bool(*)(uint32_t, char const *, void *)
+/* 1237 */ _CFFI_OP(_CFFI_OP_POINTER, 983), // _Bool(*)(uint32_t, clingo_assignment_t const *, int32_t, void *, int32_t *)
+/* 1238 */ _CFFI_OP(_CFFI_OP_POINTER, 990), // _Bool(*)(uint32_t, int, int, unsigned int, int32_t const *, size_t, void *)
+/* 1239 */ _CFFI_OP(_CFFI_OP_POINTER, 999), // _Bool(*)(uint32_t, int, uint32_t const *, size_t, void *)
+/* 1240 */ _CFFI_OP(_CFFI_OP_POINTER, 1006), // _Bool(*)(uint32_t, int, void *)
+/* 1241 */ _CFFI_OP(_CFFI_OP_POINTER, 1011), // _Bool(*)(uint32_t, uint32_t const *, size_t, int32_t const *, size_t, void *)
+/* 1242 */ _CFFI_OP(_CFFI_OP_POINTER, 1019), // _Bool(*)(uint32_t, uint32_t, uint32_t const *, size_t, uint32_t, uint32_t, void *)
+/* 1243 */ _CFFI_OP(_CFFI_OP_POINTER, 1028), // _Bool(*)(uint32_t, uint32_t, uint32_t const *, size_t, void *)
+/* 1244 */ _CFFI_OP(_CFFI_OP_POINTER, 1060), // _Bool(*)(uint64_t, int32_t const *, size_t, void *)
+/* 1245 */ _CFFI_OP(_CFFI_OP_POINTER, 1070), // _Bool(*)(uint64_t, uint32_t, void *)
+/* 1246 */ _CFFI_OP(_CFFI_OP_POINTER, 1093), // _Bool(*)(void *, char const *, void *)
+/* 1247 */ _CFFI_OP(_CFFI_OP_POINTER, 1098), // _Bool(*)(void *, char const *, void *, size_t, void *, void *, void *)
+/* 1248 */ _CFFI_OP(_CFFI_OP_POINTER, 1107), // _Bool(*)(void *, void *)
+/* 1249 */ _CFFI_OP(_CFFI_OP_POINTER, 1120), // char const *(*)(void *)
+/* 1250 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 2), // char
+/* 1251 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 0), // clingo_application_t
+/* 1252 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 1), // clingo_assignment_t
+/* 1253 */ _CFFI_OP(_CFFI_OP_POINTER, 1254), // clingo_ast_argument_t const *
+/* 1254 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 3), // clingo_ast_argument_t
+/* 1255 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 4), // clingo_ast_attribute_names_t
+/* 1256 */ _CFFI_OP(_CFFI_OP_POINTER, 1257), // clingo_ast_constructor_t const *
+/* 1257 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 5), // clingo_ast_constructor_t
+/* 1258 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 6), // clingo_ast_constructors_t
+/* 1259 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 2), // clingo_ast_t
+/* 1260 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 7), // clingo_backend_t
+/* 1261 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 8), // clingo_configuration_t
+/* 1262 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 9), // clingo_control_t
+/* 1263 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 10), // clingo_ground_program_observer_t
+/* 1264 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 11), // clingo_location_t
+/* 1265 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 12), // clingo_model_t
+/* 1266 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 13), // clingo_options_t
+/* 1267 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 14), // clingo_part_t
+/* 1268 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 15), // clingo_program_builder_t
+/* 1269 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 16), // clingo_propagate_control_t
+/* 1270 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 17), // clingo_propagate_init_t
+/* 1271 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 18), // clingo_propagator_t
+/* 1272 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 19), // clingo_script_t
+/* 1273 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 20), // clingo_solve_control_t
+/* 1274 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 21), // clingo_solve_handle_t
+/* 1275 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 22), // clingo_statistics_t
+/* 1276 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 23), // clingo_symbolic_atoms_t
+/* 1277 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 24), // clingo_theory_atoms_t
+/* 1278 */ _CFFI_OP(_CFFI_OP_STRUCT_UNION, 25), // clingo_weighted_literal_t
+/* 1279 */ _CFFI_OP(_CFFI_OP_ENUM, 0), // enum clingo_ast_aggregate_function_e
+/* 1280 */ _CFFI_OP(_CFFI_OP_ENUM, 1), // enum clingo_ast_attribute_e
+/* 1281 */ _CFFI_OP(_CFFI_OP_ENUM, 2), // enum clingo_ast_attribute_type_e
+/* 1282 */ _CFFI_OP(_CFFI_OP_ENUM, 3), // enum clingo_ast_binary_operator_e
+/* 1283 */ _CFFI_OP(_CFFI_OP_ENUM, 4), // enum clingo_ast_comparison_operator_e
+/* 1284 */ _CFFI_OP(_CFFI_OP_ENUM, 5), // enum clingo_ast_sign_e
+/* 1285 */ _CFFI_OP(_CFFI_OP_ENUM, 6), // enum clingo_ast_theory_atom_definition_type_e
+/* 1286 */ _CFFI_OP(_CFFI_OP_ENUM, 7), // enum clingo_ast_theory_operator_type_e
+/* 1287 */ _CFFI_OP(_CFFI_OP_ENUM, 8), // enum clingo_ast_theory_sequence_type_e
+/* 1288 */ _CFFI_OP(_CFFI_OP_ENUM, 9), // enum clingo_ast_type_e
+/* 1289 */ _CFFI_OP(_CFFI_OP_ENUM, 10), // enum clingo_ast_unary_operator_e
+/* 1290 */ _CFFI_OP(_CFFI_OP_ENUM, 11), // enum clingo_ast_unpool_type_e
+/* 1291 */ _CFFI_OP(_CFFI_OP_ENUM, 12), // enum clingo_clause_type_e
+/* 1292 */ _CFFI_OP(_CFFI_OP_ENUM, 13), // enum clingo_comment_type_e
+/* 1293 */ _CFFI_OP(_CFFI_OP_ENUM, 14), // enum clingo_configuration_type_e
+/* 1294 */ _CFFI_OP(_CFFI_OP_ENUM, 15), // enum clingo_consequence_e
+/* 1295 */ _CFFI_OP(_CFFI_OP_ENUM, 16), // enum clingo_error_e
+/* 1296 */ _CFFI_OP(_CFFI_OP_ENUM, 17), // enum clingo_external_type_e
+/* 1297 */ _CFFI_OP(_CFFI_OP_ENUM, 18), // enum clingo_heuristic_type_e
+/* 1298 */ _CFFI_OP(_CFFI_OP_ENUM, 19), // enum clingo_model_type_e
+/* 1299 */ _CFFI_OP(_CFFI_OP_ENUM, 20), // enum clingo_propagator_check_mode_e
+/* 1300 */ _CFFI_OP(_CFFI_OP_ENUM, 21), // enum clingo_propagator_undo_mode_e
+/* 1301 */ _CFFI_OP(_CFFI_OP_ENUM, 22), // enum clingo_show_type_e
+/* 1302 */ _CFFI_OP(_CFFI_OP_ENUM, 23), // enum clingo_solve_event_type_e
+/* 1303 */ _CFFI_OP(_CFFI_OP_ENUM, 24), // enum clingo_solve_mode_e
+/* 1304 */ _CFFI_OP(_CFFI_OP_ENUM, 25), // enum clingo_solve_result_e
+/* 1305 */ _CFFI_OP(_CFFI_OP_ENUM, 26), // enum clingo_statistics_type_e
+/* 1306 */ _CFFI_OP(_CFFI_OP_ENUM, 27), // enum clingo_symbol_type_e
+/* 1307 */ _CFFI_OP(_CFFI_OP_ENUM, 28), // enum clingo_theory_sequence_type_e
+/* 1308 */ _CFFI_OP(_CFFI_OP_ENUM, 29), // enum clingo_theory_term_type_e
+/* 1309 */ _CFFI_OP(_CFFI_OP_ENUM, 30), // enum clingo_truth_value_e
+/* 1310 */ _CFFI_OP(_CFFI_OP_ENUM, 31), // enum clingo_warning_e
+/* 1311 */ _CFFI_OP(_CFFI_OP_ENUM, 32), // enum clingo_weight_constraint_type_e
+/* 1312 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 23), // int64_t
+/* 1313 */ _CFFI_OP(_CFFI_OP_POINTER, 1163), // unsigned int(*)(void *)
+/* 1314 */ _CFFI_OP(_CFFI_OP_POINTER, 1176), // void(*)(clingo_propagate_control_t const *, int32_t const *, size_t, void *)
+/* 1315 */ _CFFI_OP(_CFFI_OP_POINTER, 1212), // void(*)(void *)
+/* 1316 */ _CFFI_OP(_CFFI_OP_PRIMITIVE, 0), // void
 };
 
 static struct _cffi_externpy_s _cffi_externpy__pyclingo_call =
@@ -4064,17 +4065,17 @@ static int _cffi_const_clingo_theory_sequence_type_tuple(unsigned long long *o)
   return n;
 }
 
-static int _cffi_const_clingo_theory_sequence_type_list(unsigned long long *o)
-{
-  int n = (clingo_theory_sequence_type_list) <= 0;
-  *o = (unsigned long long)((clingo_theory_sequence_type_list) | 0);  /* check that clingo_theory_sequence_type_list is an integer */
-  return n;
-}
-
 static int _cffi_const_clingo_theory_sequence_type_set(unsigned long long *o)
 {
   int n = (clingo_theory_sequence_type_set) <= 0;
   *o = (unsigned long long)((clingo_theory_sequence_type_set) | 0);  /* check that clingo_theory_sequence_type_set is an integer */
+  return n;
+}
+
+static int _cffi_const_clingo_theory_sequence_type_list(unsigned long long *o)
+{
+  int n = (clingo_theory_sequence_type_list) <= 0;
+  *o = (unsigned long long)((clingo_theory_sequence_type_list) | 0);  /* check that clingo_theory_sequence_type_list is an integer */
   return n;
 }
 
@@ -8532,9 +8533,9 @@ _cffi_f_clingo_backend_rule(PyObject *self, PyObject *args)
 #  define _cffi_f_clingo_backend_rule _cffi_d_clingo_backend_rule
 #endif
 
-static _Bool _cffi_d_clingo_backend_theory_atom(clingo_backend_t * x0, uint32_t x1, uint32_t x2, uint32_t const * x3, size_t x4)
+static _Bool _cffi_d_clingo_backend_theory_atom(clingo_backend_t * x0, uint32_t x1, uint32_t x2, uint32_t const * x3, size_t x4, uint32_t * x5)
 {
-  return clingo_backend_theory_atom(x0, x1, x2, x3, x4);
+  return clingo_backend_theory_atom(x0, x1, x2, x3, x4, x5);
 }
 #ifndef PYPY_VERSION
 static PyObject *
@@ -8545,6 +8546,7 @@ _cffi_f_clingo_backend_theory_atom(PyObject *self, PyObject *args)
   uint32_t x2;
   uint32_t const * x3;
   size_t x4;
+  uint32_t * x5;
   Py_ssize_t datasize;
   struct _cffi_freeme_s *large_args_free = NULL;
   _Bool result;
@@ -8554,8 +8556,9 @@ _cffi_f_clingo_backend_theory_atom(PyObject *self, PyObject *args)
   PyObject *arg2;
   PyObject *arg3;
   PyObject *arg4;
+  PyObject *arg5;
 
-  if (!PyArg_UnpackTuple(args, "clingo_backend_theory_atom", 5, 5, &arg0, &arg1, &arg2, &arg3, &arg4))
+  if (!PyArg_UnpackTuple(args, "clingo_backend_theory_atom", 6, 6, &arg0, &arg1, &arg2, &arg3, &arg4, &arg5))
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
@@ -8588,9 +8591,18 @@ _cffi_f_clingo_backend_theory_atom(PyObject *self, PyObject *args)
   if (x4 == (size_t)-1 && PyErr_Occurred())
     return NULL;
 
+  datasize = _cffi_prepare_pointer_call_argument(
+      _cffi_type(115), arg5, (char **)&x5);
+  if (datasize != 0) {
+    x5 = ((size_t)datasize) <= 640 ? (uint32_t *)alloca((size_t)datasize) : NULL;
+    if (_cffi_convert_array_argument(_cffi_type(115), arg5, (char **)&x5,
+            datasize, &large_args_free) < 0)
+      return NULL;
+  }
+
   Py_BEGIN_ALLOW_THREADS
   _cffi_restore_errno();
-  { result = clingo_backend_theory_atom(x0, x1, x2, x3, x4); }
+  { result = clingo_backend_theory_atom(x0, x1, x2, x3, x4, x5); }
   _cffi_save_errno();
   Py_END_ALLOW_THREADS
 
@@ -8603,9 +8615,9 @@ _cffi_f_clingo_backend_theory_atom(PyObject *self, PyObject *args)
 #  define _cffi_f_clingo_backend_theory_atom _cffi_d_clingo_backend_theory_atom
 #endif
 
-static _Bool _cffi_d_clingo_backend_theory_atom_with_guard(clingo_backend_t * x0, uint32_t x1, uint32_t x2, uint32_t const * x3, size_t x4, char const * x5, uint32_t x6)
+static _Bool _cffi_d_clingo_backend_theory_atom_with_guard(clingo_backend_t * x0, uint32_t x1, uint32_t x2, uint32_t const * x3, size_t x4, char const * x5, uint32_t x6, uint32_t * x7)
 {
-  return clingo_backend_theory_atom_with_guard(x0, x1, x2, x3, x4, x5, x6);
+  return clingo_backend_theory_atom_with_guard(x0, x1, x2, x3, x4, x5, x6, x7);
 }
 #ifndef PYPY_VERSION
 static PyObject *
@@ -8618,6 +8630,7 @@ _cffi_f_clingo_backend_theory_atom_with_guard(PyObject *self, PyObject *args)
   size_t x4;
   char const * x5;
   uint32_t x6;
+  uint32_t * x7;
   Py_ssize_t datasize;
   struct _cffi_freeme_s *large_args_free = NULL;
   _Bool result;
@@ -8629,8 +8642,9 @@ _cffi_f_clingo_backend_theory_atom_with_guard(PyObject *self, PyObject *args)
   PyObject *arg4;
   PyObject *arg5;
   PyObject *arg6;
+  PyObject *arg7;
 
-  if (!PyArg_UnpackTuple(args, "clingo_backend_theory_atom_with_guard", 7, 7, &arg0, &arg1, &arg2, &arg3, &arg4, &arg5, &arg6))
+  if (!PyArg_UnpackTuple(args, "clingo_backend_theory_atom_with_guard", 8, 8, &arg0, &arg1, &arg2, &arg3, &arg4, &arg5, &arg6, &arg7))
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
@@ -8676,9 +8690,18 @@ _cffi_f_clingo_backend_theory_atom_with_guard(PyObject *self, PyObject *args)
   if (x6 == (uint32_t)-1 && PyErr_Occurred())
     return NULL;
 
+  datasize = _cffi_prepare_pointer_call_argument(
+      _cffi_type(115), arg7, (char **)&x7);
+  if (datasize != 0) {
+    x7 = ((size_t)datasize) <= 640 ? (uint32_t *)alloca((size_t)datasize) : NULL;
+    if (_cffi_convert_array_argument(_cffi_type(115), arg7, (char **)&x7,
+            datasize, &large_args_free) < 0)
+      return NULL;
+  }
+
   Py_BEGIN_ALLOW_THREADS
   _cffi_restore_errno();
-  { result = clingo_backend_theory_atom_with_guard(x0, x1, x2, x3, x4, x5, x6); }
+  { result = clingo_backend_theory_atom_with_guard(x0, x1, x2, x3, x4, x5, x6, x7); }
   _cffi_save_errno();
   Py_END_ALLOW_THREADS
 
@@ -9230,10 +9253,10 @@ _cffi_f_clingo_configuration_array_at(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9293,10 +9316,10 @@ _cffi_f_clingo_configuration_array_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9352,10 +9375,10 @@ _cffi_f_clingo_configuration_description(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9413,10 +9436,10 @@ _cffi_f_clingo_configuration_map_at(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9483,10 +9506,10 @@ _cffi_f_clingo_configuration_map_has_subkey(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9551,10 +9574,10 @@ _cffi_f_clingo_configuration_map_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9612,10 +9635,10 @@ _cffi_f_clingo_configuration_map_subkey_name(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9673,10 +9696,10 @@ _cffi_f_clingo_configuration_root(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9728,10 +9751,10 @@ _cffi_f_clingo_configuration_type(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9741,10 +9764,10 @@ _cffi_f_clingo_configuration_type(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(432), arg2, (char **)&x2);
+      _cffi_type(434), arg2, (char **)&x2);
   if (datasize != 0) {
     x2 = ((size_t)datasize) <= 640 ? (unsigned int *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(432), arg2, (char **)&x2,
+    if (_cffi_convert_array_argument(_cffi_type(434), arg2, (char **)&x2,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9789,10 +9812,10 @@ _cffi_f_clingo_configuration_value_get(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9852,10 +9875,10 @@ _cffi_f_clingo_configuration_value_get_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9911,10 +9934,10 @@ _cffi_f_clingo_configuration_value_is_assigned(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(381), arg0, (char **)&x0);
+      _cffi_type(383), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(381), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(383), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -9970,10 +9993,10 @@ _cffi_f_clingo_configuration_value_set(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(376), arg0, (char **)&x0);
+      _cffi_type(378), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_configuration_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(376), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(378), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -10171,10 +10194,10 @@ _cffi_f_clingo_control_backend(PyObject *self, PyObject *args)
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(460), arg1, (char **)&x1);
+      _cffi_type(462), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_backend_t * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(460), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(462), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -10224,10 +10247,10 @@ _cffi_f_clingo_control_clasp_facade(PyObject *self, PyObject *args)
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(509), arg1, (char **)&x1);
+      _cffi_type(511), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (void * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(509), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(511), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -10315,10 +10338,10 @@ _cffi_f_clingo_control_configuration(PyObject *self, PyObject *args)
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(464), arg1, (char **)&x1);
+      _cffi_type(466), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_configuration_t * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(464), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(466), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -10397,10 +10420,10 @@ _cffi_f_clingo_control_get_const(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(516), arg0, (char **)&x0);
+      _cffi_type(518), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_control_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(516), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(518), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -10550,10 +10573,10 @@ _cffi_f_clingo_control_ground(PyObject *self, PyObject *args)
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(474), arg1, (char **)&x1);
+      _cffi_type(476), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_part_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(474), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(476), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -10562,7 +10585,7 @@ _cffi_f_clingo_control_ground(PyObject *self, PyObject *args)
   if (x2 == (size_t)-1 && PyErr_Occurred())
     return NULL;
 
-  x3 = (_Bool(*)(clingo_location_t const *, char const *, uint64_t const *, size_t, void *, _Bool(*)(uint64_t const *, size_t, void *), void *))_cffi_to_c_pointer(arg3, _cffi_type(476));
+  x3 = (_Bool(*)(clingo_location_t const *, char const *, uint64_t const *, size_t, void *, _Bool(*)(uint64_t const *, size_t, void *), void *))_cffi_to_c_pointer(arg3, _cffi_type(478));
   if (x3 == (_Bool(*)(clingo_location_t const *, char const *, uint64_t const *, size_t, void *, _Bool(*)(uint64_t const *, size_t, void *), void *))NULL && PyErr_Occurred())
     return NULL;
 
@@ -10613,10 +10636,10 @@ _cffi_f_clingo_control_has_const(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(516), arg0, (char **)&x0);
+      _cffi_type(518), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_control_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(516), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(518), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -10705,10 +10728,10 @@ _cffi_f_clingo_control_is_conflicting(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(516), arg0, (char **)&x0);
+      _cffi_type(518), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_control_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(516), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(518), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -10897,10 +10920,10 @@ _cffi_f_clingo_control_register_observer(PyObject *self, PyObject *args)
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(468), arg1, (char **)&x1);
+      _cffi_type(470), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_ground_program_observer_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(468), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(470), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -10967,10 +10990,10 @@ _cffi_f_clingo_control_register_propagator(PyObject *self, PyObject *args)
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(485), arg1, (char **)&x1);
+      _cffi_type(487), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_propagator_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(485), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(487), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11203,7 +11226,7 @@ _cffi_f_clingo_control_solve(PyObject *self, PyObject *args)
   if (x3 == (size_t)-1 && PyErr_Occurred())
     return NULL;
 
-  x4 = (_Bool(*)(unsigned int, void *, void *, _Bool *))_cffi_to_c_pointer(arg4, _cffi_type(503));
+  x4 = (_Bool(*)(unsigned int, void *, void *, _Bool *))_cffi_to_c_pointer(arg4, _cffi_type(505));
   if (x4 == (_Bool(*)(unsigned int, void *, void *, _Bool *))NULL && PyErr_Occurred())
     return NULL;
 
@@ -11217,10 +11240,10 @@ _cffi_f_clingo_control_solve(PyObject *self, PyObject *args)
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(505), arg6, (char **)&x6);
+      _cffi_type(507), arg6, (char **)&x6);
   if (datasize != 0) {
     x6 = ((size_t)datasize) <= 640 ? (clingo_solve_handle_t * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(505), arg6, (char **)&x6,
+    if (_cffi_convert_array_argument(_cffi_type(507), arg6, (char **)&x6,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11261,19 +11284,19 @@ _cffi_f_clingo_control_statistics(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(516), arg0, (char **)&x0);
+      _cffi_type(518), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_control_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(516), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(518), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(530), arg1, (char **)&x1);
+      _cffi_type(532), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_statistics_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(530), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(532), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11314,19 +11337,19 @@ _cffi_f_clingo_control_symbolic_atoms(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(516), arg0, (char **)&x0);
+      _cffi_type(518), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_control_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(516), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(518), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(534), arg1, (char **)&x1);
+      _cffi_type(536), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(534), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(536), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11367,19 +11390,19 @@ _cffi_f_clingo_control_theory_atoms(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(516), arg0, (char **)&x0);
+      _cffi_type(518), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_control_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(516), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(518), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(538), arg1, (char **)&x1);
+      _cffi_type(540), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(538), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(540), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11506,10 +11529,10 @@ _cffi_f_clingo_main(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(1130), arg0, (char **)&x0);
+      _cffi_type(1132), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_application_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(1130), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(1132), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11574,10 +11597,10 @@ _cffi_f_clingo_model_contains(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11631,19 +11654,19 @@ _cffi_f_clingo_model_context(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(594), arg1, (char **)&x1);
+      _cffi_type(596), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_solve_control_t * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(594), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(596), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11686,19 +11709,19 @@ _cffi_f_clingo_model_cost(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(617), arg1, (char **)&x1);
+      _cffi_type(619), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (int64_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(617), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(619), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11743,10 +11766,10 @@ _cffi_f_clingo_model_cost_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11798,10 +11821,10 @@ _cffi_f_clingo_model_extend(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(578), arg0, (char **)&x0);
+      _cffi_type(580), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(578), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(580), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11857,10 +11880,10 @@ _cffi_f_clingo_model_is_consequence(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11916,10 +11939,10 @@ _cffi_f_clingo_model_is_true(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -11973,10 +11996,10 @@ _cffi_f_clingo_model_number(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12026,10 +12049,10 @@ _cffi_f_clingo_model_optimality_proven(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12081,10 +12104,10 @@ _cffi_f_clingo_model_priority(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12142,10 +12165,10 @@ _cffi_f_clingo_model_symbols(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12205,10 +12228,10 @@ _cffi_f_clingo_model_symbols_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12262,10 +12285,10 @@ _cffi_f_clingo_model_thread_id(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12315,10 +12338,10 @@ _cffi_f_clingo_model_type(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(583), arg0, (char **)&x0);
+      _cffi_type(585), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_model_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(583), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(585), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12380,10 +12403,10 @@ _cffi_f_clingo_options_add(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(649), arg0, (char **)&x0);
+      _cffi_type(651), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_options_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(649), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(651), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12415,7 +12438,7 @@ _cffi_f_clingo_options_add(PyObject *self, PyObject *args)
       return NULL;
   }
 
-  x4 = (_Bool(*)(char const *, void *))_cffi_to_c_pointer(arg4, _cffi_type(660));
+  x4 = (_Bool(*)(char const *, void *))_cffi_to_c_pointer(arg4, _cffi_type(662));
   if (x4 == (_Bool(*)(char const *, void *))NULL && PyErr_Occurred())
     return NULL;
 
@@ -12483,10 +12506,10 @@ _cffi_f_clingo_options_add_flag(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(649), arg0, (char **)&x0);
+      _cffi_type(651), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_options_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(649), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(651), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12639,10 +12662,10 @@ _cffi_f_clingo_program_builder_add(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(670), arg0, (char **)&x0);
+      _cffi_type(672), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_program_builder_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(670), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(672), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12686,10 +12709,10 @@ _cffi_f_clingo_program_builder_begin(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(670), arg0, (char **)&x0);
+      _cffi_type(672), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_program_builder_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(670), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(672), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12724,10 +12747,10 @@ _cffi_f_clingo_program_builder_end(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(670), arg0, (char **)&x0);
+      _cffi_type(672), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_program_builder_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(670), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(672), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12777,10 +12800,10 @@ _cffi_f_clingo_program_builder_init(PyObject *self, PyObject *args)
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(481), arg1, (char **)&x1);
+      _cffi_type(483), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_program_builder_t * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(481), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(483), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12827,10 +12850,10 @@ _cffi_f_clingo_propagate_control_add_clause(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(677), arg0, (char **)&x0);
+      _cffi_type(679), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_control_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(677), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(679), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12897,10 +12920,10 @@ _cffi_f_clingo_propagate_control_add_literal(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(677), arg0, (char **)&x0);
+      _cffi_type(679), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_control_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(677), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(679), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12950,10 +12973,10 @@ _cffi_f_clingo_propagate_control_add_watch(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(677), arg0, (char **)&x0);
+      _cffi_type(679), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_control_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(677), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(679), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -12992,10 +13015,10 @@ _cffi_f_clingo_propagate_control_assignment(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(706), arg0, (char **)&x0);
+      _cffi_type(708), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_control_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(706), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(708), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13036,10 +13059,10 @@ _cffi_f_clingo_propagate_control_has_watch(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(706), arg0, (char **)&x0);
+      _cffi_type(708), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_control_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(706), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(708), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13084,10 +13107,10 @@ _cffi_f_clingo_propagate_control_propagate(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(677), arg0, (char **)&x0);
+      _cffi_type(679), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_control_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(677), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(679), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13135,10 +13158,10 @@ _cffi_f_clingo_propagate_control_remove_watch(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(677), arg0, (char **)&x0);
+      _cffi_type(679), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_control_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(677), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(679), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13177,10 +13200,10 @@ _cffi_f_clingo_propagate_control_thread_id(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(706), arg0, (char **)&x0);
+      _cffi_type(708), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_control_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(706), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(708), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13225,10 +13248,10 @@ _cffi_f_clingo_propagate_init_add_clause(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13293,10 +13316,10 @@ _cffi_f_clingo_propagate_init_add_literal(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13354,10 +13377,10 @@ _cffi_f_clingo_propagate_init_add_minimize(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13410,10 +13433,10 @@ _cffi_f_clingo_propagate_init_add_watch(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13460,10 +13483,10 @@ _cffi_f_clingo_propagate_init_add_watch_to_thread(PyObject *self, PyObject *args
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13524,10 +13547,10 @@ _cffi_f_clingo_propagate_init_add_weight_constraint(PyObject *self, PyObject *ar
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13600,10 +13623,10 @@ _cffi_f_clingo_propagate_init_assignment(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(754), arg0, (char **)&x0);
+      _cffi_type(756), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(754), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(756), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13644,10 +13667,10 @@ _cffi_f_clingo_propagate_init_freeze_literal(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13686,10 +13709,10 @@ _cffi_f_clingo_propagate_init_get_check_mode(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(754), arg0, (char **)&x0);
+      _cffi_type(756), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(754), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(756), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13724,10 +13747,10 @@ _cffi_f_clingo_propagate_init_get_undo_mode(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(754), arg0, (char **)&x0);
+      _cffi_type(756), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(754), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(756), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13762,10 +13785,10 @@ _cffi_f_clingo_propagate_init_number_of_threads(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(754), arg0, (char **)&x0);
+      _cffi_type(756), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(754), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(756), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13806,10 +13829,10 @@ _cffi_f_clingo_propagate_init_propagate(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13859,10 +13882,10 @@ _cffi_f_clingo_propagate_init_remove_watch(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13909,10 +13932,10 @@ _cffi_f_clingo_propagate_init_remove_watch_from_thread(PyObject *self, PyObject 
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -13959,10 +13982,10 @@ _cffi_f_clingo_propagate_init_set_check_mode(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14005,10 +14028,10 @@ _cffi_f_clingo_propagate_init_set_undo_mode(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(710), arg0, (char **)&x0);
+      _cffi_type(712), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(710), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(712), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14055,10 +14078,10 @@ _cffi_f_clingo_propagate_init_solver_literal(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(754), arg0, (char **)&x0);
+      _cffi_type(756), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(754), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(756), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14112,19 +14135,19 @@ _cffi_f_clingo_propagate_init_symbolic_atoms(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(754), arg0, (char **)&x0);
+      _cffi_type(756), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(754), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(756), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(534), arg1, (char **)&x1);
+      _cffi_type(536), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(534), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(536), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14165,19 +14188,19 @@ _cffi_f_clingo_propagate_init_theory_atoms(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(754), arg0, (char **)&x0);
+      _cffi_type(756), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_propagate_init_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(754), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(756), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(538), arg1, (char **)&x1);
+      _cffi_type(540), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(538), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(540), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14663,10 +14686,10 @@ _cffi_f_clingo_solve_control_add_clause(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(767), arg0, (char **)&x0);
+      _cffi_type(769), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_solve_control_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(767), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(769), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14720,19 +14743,19 @@ _cffi_f_clingo_solve_control_symbolic_atoms(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(772), arg0, (char **)&x0);
+      _cffi_type(774), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_solve_control_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(772), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(774), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(534), arg1, (char **)&x1);
+      _cffi_type(536), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(534), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(536), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14767,10 +14790,10 @@ _cffi_f_clingo_solve_handle_cancel(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(776), arg0, (char **)&x0);
+      _cffi_type(778), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_solve_handle_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(776), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(778), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14805,10 +14828,10 @@ _cffi_f_clingo_solve_handle_close(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(776), arg0, (char **)&x0);
+      _cffi_type(778), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_solve_handle_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(776), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(778), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14851,19 +14874,19 @@ _cffi_f_clingo_solve_handle_core(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(776), arg0, (char **)&x0);
+      _cffi_type(778), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_solve_handle_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(776), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(778), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(784), arg1, (char **)&x1);
+      _cffi_type(786), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (int32_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(784), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(786), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14913,19 +14936,19 @@ _cffi_f_clingo_solve_handle_get(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(776), arg0, (char **)&x0);
+      _cffi_type(778), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_solve_handle_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(776), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(778), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(432), arg1, (char **)&x1);
+      _cffi_type(434), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (unsigned int *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(432), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(434), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -14966,19 +14989,19 @@ _cffi_f_clingo_solve_handle_model(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(776), arg0, (char **)&x0);
+      _cffi_type(778), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_solve_handle_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(776), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(778), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(780), arg1, (char **)&x1);
+      _cffi_type(782), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (clingo_model_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(780), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(782), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -15013,10 +15036,10 @@ _cffi_f_clingo_solve_handle_resume(PyObject *self, PyObject *arg0)
   PyObject *pyresult;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(776), arg0, (char **)&x0);
+      _cffi_type(778), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_solve_handle_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(776), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(778), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -15057,10 +15080,10 @@ _cffi_f_clingo_solve_handle_wait(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(776), arg0, (char **)&x0);
+      _cffi_type(778), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_solve_handle_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(776), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(778), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -15118,10 +15141,10 @@ _cffi_f_clingo_statistics_array_at(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(810), arg0, (char **)&x0);
+      _cffi_type(812), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(810), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(812), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -15183,10 +15206,10 @@ _cffi_f_clingo_statistics_array_push(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(792), arg0, (char **)&x0);
+      _cffi_type(794), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(792), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(794), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -15246,10 +15269,10 @@ _cffi_f_clingo_statistics_array_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(810), arg0, (char **)&x0);
+      _cffi_type(812), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(810), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(812), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -15309,10 +15332,10 @@ _cffi_f_clingo_statistics_map_add_subkey(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(792), arg0, (char **)&x0);
+      _cffi_type(794), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(792), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(794), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -15383,10 +15406,10 @@ _cffi_f_clingo_statistics_map_at(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(810), arg0, (char **)&x0);
+      _cffi_type(812), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(810), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(812), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -15453,10 +15476,10 @@ _cffi_f_clingo_statistics_map_has_subkey(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(810), arg0, (char **)&x0);
+      _cffi_type(812), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(810), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(812), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -15521,10 +15544,10 @@ _cffi_f_clingo_statistics_map_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(810), arg0, (char **)&x0);
+      _cffi_type(812), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(810), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(812), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -15582,10 +15605,10 @@ _cffi_f_clingo_statistics_map_subkey_name(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(810), arg0, (char **)&x0);
+      _cffi_type(812), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(810), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(812), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -15643,10 +15666,10 @@ _cffi_f_clingo_statistics_root(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(810), arg0, (char **)&x0);
+      _cffi_type(812), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(810), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(812), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -15698,10 +15721,10 @@ _cffi_f_clingo_statistics_type(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(810), arg0, (char **)&x0);
+      _cffi_type(812), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(810), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(812), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -15757,10 +15780,10 @@ _cffi_f_clingo_statistics_value_get(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(810), arg0, (char **)&x0);
+      _cffi_type(812), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(810), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(812), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -15770,10 +15793,10 @@ _cffi_f_clingo_statistics_value_get(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(828), arg2, (char **)&x2);
+      _cffi_type(830), arg2, (char **)&x2);
   if (datasize != 0) {
     x2 = ((size_t)datasize) <= 640 ? (double *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(828), arg2, (char **)&x2,
+    if (_cffi_convert_array_argument(_cffi_type(830), arg2, (char **)&x2,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -15816,10 +15839,10 @@ _cffi_f_clingo_statistics_value_set(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(792), arg0, (char **)&x0);
+      _cffi_type(794), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_statistics_t *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(792), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(794), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -15874,10 +15897,10 @@ _cffi_f_clingo_symbol_arguments(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(1075), arg1, (char **)&x1);
+      _cffi_type(1077), arg1, (char **)&x1);
   if (datasize != 0) {
     x1 = ((size_t)datasize) <= 640 ? (uint64_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(1075), arg1, (char **)&x1,
+    if (_cffi_convert_array_argument(_cffi_type(1077), arg1, (char **)&x1,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16717,10 +16740,10 @@ _cffi_f_clingo_symbolic_atoms_begin(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16779,10 +16802,10 @@ _cffi_f_clingo_symbolic_atoms_end(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16834,10 +16857,10 @@ _cffi_f_clingo_symbolic_atoms_find(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16893,10 +16916,10 @@ _cffi_f_clingo_symbolic_atoms_is_external(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -16952,10 +16975,10 @@ _cffi_f_clingo_symbolic_atoms_is_fact(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17011,10 +17034,10 @@ _cffi_f_clingo_symbolic_atoms_is_valid(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17072,10 +17095,10 @@ _cffi_f_clingo_symbolic_atoms_iterator_is_equal_to(PyObject *self, PyObject *arg
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17135,10 +17158,10 @@ _cffi_f_clingo_symbolic_atoms_literal(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17194,10 +17217,10 @@ _cffi_f_clingo_symbolic_atoms_next(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17253,10 +17276,10 @@ _cffi_f_clingo_symbolic_atoms_signatures(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17310,10 +17333,10 @@ _cffi_f_clingo_symbolic_atoms_signatures_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17363,10 +17386,10 @@ _cffi_f_clingo_symbolic_atoms_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17418,10 +17441,10 @@ _cffi_f_clingo_symbolic_atoms_symbol(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(853), arg0, (char **)&x0);
+      _cffi_type(855), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_symbolic_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(853), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(855), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17479,10 +17502,10 @@ _cffi_f_clingo_theory_atoms_atom_elements(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17492,10 +17515,10 @@ _cffi_f_clingo_theory_atoms_atom_elements(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(946), arg2, (char **)&x2);
+      _cffi_type(948), arg2, (char **)&x2);
   if (datasize != 0) {
     x2 = ((size_t)datasize) <= 640 ? (uint32_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(946), arg2, (char **)&x2,
+    if (_cffi_convert_array_argument(_cffi_type(948), arg2, (char **)&x2,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17549,10 +17572,10 @@ _cffi_f_clingo_theory_atoms_atom_guard(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17617,10 +17640,10 @@ _cffi_f_clingo_theory_atoms_atom_has_guard(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17676,10 +17699,10 @@ _cffi_f_clingo_theory_atoms_atom_literal(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17735,10 +17758,10 @@ _cffi_f_clingo_theory_atoms_atom_term(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17796,10 +17819,10 @@ _cffi_f_clingo_theory_atoms_atom_to_string(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17859,10 +17882,10 @@ _cffi_f_clingo_theory_atoms_atom_to_string_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17920,10 +17943,10 @@ _cffi_f_clingo_theory_atoms_element_condition(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17933,10 +17956,10 @@ _cffi_f_clingo_theory_atoms_element_condition(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(784), arg2, (char **)&x2);
+      _cffi_type(786), arg2, (char **)&x2);
   if (datasize != 0) {
     x2 = ((size_t)datasize) <= 640 ? (int32_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(784), arg2, (char **)&x2,
+    if (_cffi_convert_array_argument(_cffi_type(786), arg2, (char **)&x2,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -17988,10 +18011,10 @@ _cffi_f_clingo_theory_atoms_element_condition_id(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -18049,10 +18072,10 @@ _cffi_f_clingo_theory_atoms_element_to_string(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -18112,10 +18135,10 @@ _cffi_f_clingo_theory_atoms_element_to_string_size(PyObject *self, PyObject *arg
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -18173,10 +18196,10 @@ _cffi_f_clingo_theory_atoms_element_tuple(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -18186,10 +18209,10 @@ _cffi_f_clingo_theory_atoms_element_tuple(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(946), arg2, (char **)&x2);
+      _cffi_type(948), arg2, (char **)&x2);
   if (datasize != 0) {
     x2 = ((size_t)datasize) <= 640 ? (uint32_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(946), arg2, (char **)&x2,
+    if (_cffi_convert_array_argument(_cffi_type(948), arg2, (char **)&x2,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -18239,10 +18262,10 @@ _cffi_f_clingo_theory_atoms_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -18296,10 +18319,10 @@ _cffi_f_clingo_theory_atoms_term_arguments(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -18309,10 +18332,10 @@ _cffi_f_clingo_theory_atoms_term_arguments(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(946), arg2, (char **)&x2);
+      _cffi_type(948), arg2, (char **)&x2);
   if (datasize != 0) {
     x2 = ((size_t)datasize) <= 640 ? (uint32_t const * *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(946), arg2, (char **)&x2,
+    if (_cffi_convert_array_argument(_cffi_type(948), arg2, (char **)&x2,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -18364,10 +18387,10 @@ _cffi_f_clingo_theory_atoms_term_name(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -18423,10 +18446,10 @@ _cffi_f_clingo_theory_atoms_term_number(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -18484,10 +18507,10 @@ _cffi_f_clingo_theory_atoms_term_to_string(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -18547,10 +18570,10 @@ _cffi_f_clingo_theory_atoms_term_to_string_size(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -18606,10 +18629,10 @@ _cffi_f_clingo_theory_atoms_term_type(PyObject *self, PyObject *args)
     return NULL;
 
   datasize = _cffi_prepare_pointer_call_argument(
-      _cffi_type(892), arg0, (char **)&x0);
+      _cffi_type(894), arg0, (char **)&x0);
   if (datasize != 0) {
     x0 = ((size_t)datasize) <= 640 ? (clingo_theory_atoms_t const *)alloca((size_t)datasize) : NULL;
-    if (_cffi_convert_array_argument(_cffi_type(892), arg0, (char **)&x0,
+    if (_cffi_convert_array_argument(_cffi_type(894), arg0, (char **)&x0,
             datasize, &large_args_free) < 0)
       return NULL;
   }
@@ -18894,7 +18917,7 @@ static const struct _cffi_global_s _cffi_globals[] = {
   { "clingo_add_string", (void *)_cffi_f_clingo_add_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 58), (void *)_cffi_d_clingo_add_string },
   { "clingo_assignment_at", (void *)_cffi_f_clingo_assignment_at, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 117), (void *)_cffi_d_clingo_assignment_at },
   { "clingo_assignment_decision", (void *)_cffi_f_clingo_assignment_decision, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 126), (void *)_cffi_d_clingo_assignment_decision },
-  { "clingo_assignment_decision_level", (void *)_cffi_f_clingo_assignment_decision_level, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1152), (void *)_cffi_d_clingo_assignment_decision_level },
+  { "clingo_assignment_decision_level", (void *)_cffi_f_clingo_assignment_decision_level, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1154), (void *)_cffi_d_clingo_assignment_decision_level },
   { "clingo_assignment_has_conflict", (void *)_cffi_f_clingo_assignment_has_conflict, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 95), (void *)_cffi_d_clingo_assignment_has_conflict },
   { "clingo_assignment_has_literal", (void *)_cffi_f_clingo_assignment_has_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 98), (void *)_cffi_d_clingo_assignment_has_literal },
   { "clingo_assignment_is_false", (void *)_cffi_f_clingo_assignment_is_false, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 102), (void *)_cffi_d_clingo_assignment_is_false },
@@ -18902,14 +18925,14 @@ static const struct _cffi_global_s _cffi_globals[] = {
   { "clingo_assignment_is_total", (void *)_cffi_f_clingo_assignment_is_total, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 95), (void *)_cffi_d_clingo_assignment_is_total },
   { "clingo_assignment_is_true", (void *)_cffi_f_clingo_assignment_is_true, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 102), (void *)_cffi_d_clingo_assignment_is_true },
   { "clingo_assignment_level", (void *)_cffi_f_clingo_assignment_level, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 112), (void *)_cffi_d_clingo_assignment_level },
-  { "clingo_assignment_root_level", (void *)_cffi_f_clingo_assignment_root_level, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1152), (void *)_cffi_d_clingo_assignment_root_level },
-  { "clingo_assignment_size", (void *)_cffi_f_clingo_assignment_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1143), (void *)_cffi_d_clingo_assignment_size },
+  { "clingo_assignment_root_level", (void *)_cffi_f_clingo_assignment_root_level, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1154), (void *)_cffi_d_clingo_assignment_root_level },
+  { "clingo_assignment_size", (void *)_cffi_f_clingo_assignment_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1145), (void *)_cffi_d_clingo_assignment_size },
   { "clingo_assignment_trail_at", (void *)_cffi_f_clingo_assignment_trail_at, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 126), (void *)_cffi_d_clingo_assignment_trail_at },
   { "clingo_assignment_trail_begin", (void *)_cffi_f_clingo_assignment_trail_begin, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 131), (void *)_cffi_d_clingo_assignment_trail_begin },
   { "clingo_assignment_trail_end", (void *)_cffi_f_clingo_assignment_trail_end, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 131), (void *)_cffi_d_clingo_assignment_trail_end },
   { "clingo_assignment_trail_size", (void *)_cffi_f_clingo_assignment_trail_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 122), (void *)_cffi_d_clingo_assignment_trail_size },
   { "clingo_assignment_truth_value", (void *)_cffi_f_clingo_assignment_truth_value, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 107), (void *)_cffi_d_clingo_assignment_truth_value },
-  { "clingo_ast_acquire", (void *)_cffi_f_clingo_ast_acquire, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1164), (void *)_cffi_d_clingo_ast_acquire },
+  { "clingo_ast_acquire", (void *)_cffi_f_clingo_ast_acquire, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1166), (void *)_cffi_d_clingo_ast_acquire },
   { "clingo_ast_aggregate_function_count", (void *)_cffi_const_clingo_ast_aggregate_function_count, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_ast_aggregate_function_max", (void *)_cffi_const_clingo_ast_aggregate_function_max, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_ast_aggregate_function_min", (void *)_cffi_const_clingo_ast_aggregate_function_min, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
@@ -19000,7 +19023,7 @@ static const struct _cffi_global_s _cffi_globals[] = {
   { "clingo_ast_binary_operator_plus", (void *)_cffi_const_clingo_ast_binary_operator_plus, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_ast_binary_operator_power", (void *)_cffi_const_clingo_ast_binary_operator_power, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_ast_binary_operator_xor", (void *)_cffi_const_clingo_ast_binary_operator_xor, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_ast_build", (void *)_cffi_const_clingo_ast_build, _CFFI_OP(_CFFI_OP_CONSTANT, 1229), (void *)0 },
+  { "clingo_ast_build", (void *)_cffi_const_clingo_ast_build, _CFFI_OP(_CFFI_OP_CONSTANT, 1231), (void *)0 },
   { "clingo_ast_comparison_operator_equal", (void *)_cffi_const_clingo_ast_comparison_operator_equal, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_ast_comparison_operator_greater_equal", (void *)_cffi_const_clingo_ast_comparison_operator_greater_equal, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_ast_comparison_operator_greater_than", (void *)_cffi_const_clingo_ast_comparison_operator_greater_than, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
@@ -19012,11 +19035,11 @@ static const struct _cffi_global_s _cffi_globals[] = {
   { "clingo_ast_equal", (void *)_cffi_f_clingo_ast_equal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 145), (void *)_cffi_d_clingo_ast_equal },
   { "clingo_ast_get_type", (void *)_cffi_f_clingo_ast_get_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 149), (void *)_cffi_d_clingo_ast_get_type },
   { "clingo_ast_has_attribute", (void *)_cffi_f_clingo_ast_has_attribute, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 153), (void *)_cffi_d_clingo_ast_has_attribute },
-  { "clingo_ast_hash", (void *)_cffi_f_clingo_ast_hash, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1146), (void *)_cffi_d_clingo_ast_hash },
+  { "clingo_ast_hash", (void *)_cffi_f_clingo_ast_hash, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1148), (void *)_cffi_d_clingo_ast_hash },
   { "clingo_ast_less_than", (void *)_cffi_f_clingo_ast_less_than, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 145), (void *)_cffi_d_clingo_ast_less_than },
   { "clingo_ast_parse_files", (void *)_cffi_f_clingo_ast_parse_files, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 21), (void *)_cffi_d_clingo_ast_parse_files },
   { "clingo_ast_parse_string", (void *)_cffi_f_clingo_ast_parse_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 44), (void *)_cffi_d_clingo_ast_parse_string },
-  { "clingo_ast_release", (void *)_cffi_f_clingo_ast_release, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1164), (void *)_cffi_d_clingo_ast_release },
+  { "clingo_ast_release", (void *)_cffi_f_clingo_ast_release, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1166), (void *)_cffi_d_clingo_ast_release },
   { "clingo_ast_sign_double_negation", (void *)_cffi_const_clingo_ast_sign_double_negation, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_ast_sign_negation", (void *)_cffi_const_clingo_ast_sign_negation, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_ast_sign_no_sign", (void *)_cffi_const_clingo_ast_sign_no_sign, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
@@ -19086,7 +19109,7 @@ static const struct _cffi_global_s _cffi_globals[] = {
   { "clingo_ast_unpool_type_condition", (void *)_cffi_const_clingo_ast_unpool_type_condition, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_ast_unpool_type_other", (void *)_cffi_const_clingo_ast_unpool_type_other, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_backend_acyc_edge", (void *)_cffi_f_clingo_backend_acyc_edge, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 292), (void *)_cffi_d_clingo_backend_acyc_edge },
-  { "clingo_backend_add_atom", (void *)_cffi_f_clingo_backend_add_atom, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 365), (void *)_cffi_d_clingo_backend_add_atom },
+  { "clingo_backend_add_atom", (void *)_cffi_f_clingo_backend_add_atom, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 367), (void *)_cffi_d_clingo_backend_add_atom },
   { "clingo_backend_assume", (void *)_cffi_f_clingo_backend_assume, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 311), (void *)_cffi_d_clingo_backend_assume },
   { "clingo_backend_begin", (void *)_cffi_f_clingo_backend_begin, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 260), (void *)_cffi_d_clingo_backend_begin },
   { "clingo_backend_end", (void *)_cffi_f_clingo_backend_end, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 260), (void *)_cffi_d_clingo_backend_end },
@@ -19095,14 +19118,14 @@ static const struct _cffi_global_s _cffi_globals[] = {
   { "clingo_backend_minimize", (void *)_cffi_f_clingo_backend_minimize, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 316), (void *)_cffi_d_clingo_backend_minimize },
   { "clingo_backend_project", (void *)_cffi_f_clingo_backend_project, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 322), (void *)_cffi_d_clingo_backend_project },
   { "clingo_backend_rule", (void *)_cffi_f_clingo_backend_rule, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 263), (void *)_cffi_d_clingo_backend_rule },
-  { "clingo_backend_theory_atom", (void *)_cffi_f_clingo_backend_theory_atom, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 349), (void *)_cffi_d_clingo_backend_theory_atom },
-  { "clingo_backend_theory_atom_with_guard", (void *)_cffi_f_clingo_backend_theory_atom_with_guard, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 356), (void *)_cffi_d_clingo_backend_theory_atom_with_guard },
+  { "clingo_backend_theory_atom", (void *)_cffi_f_clingo_backend_theory_atom, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 359), (void *)_cffi_d_clingo_backend_theory_atom },
+  { "clingo_backend_theory_atom_with_guard", (void *)_cffi_f_clingo_backend_theory_atom_with_guard, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 349), (void *)_cffi_d_clingo_backend_theory_atom_with_guard },
   { "clingo_backend_theory_element", (void *)_cffi_f_clingo_backend_theory_element, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 327), (void *)_cffi_d_clingo_backend_theory_element },
   { "clingo_backend_theory_term_function", (void *)_cffi_f_clingo_backend_theory_term_function, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 285), (void *)_cffi_d_clingo_backend_theory_term_function },
   { "clingo_backend_theory_term_number", (void *)_cffi_f_clingo_backend_theory_term_number, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 299), (void *)_cffi_d_clingo_backend_theory_term_number },
   { "clingo_backend_theory_term_sequence", (void *)_cffi_f_clingo_backend_theory_term_sequence, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 304), (void *)_cffi_d_clingo_backend_theory_term_sequence },
   { "clingo_backend_theory_term_string", (void *)_cffi_f_clingo_backend_theory_term_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 280), (void *)_cffi_d_clingo_backend_theory_term_string },
-  { "clingo_backend_theory_term_symbol", (void *)_cffi_f_clingo_backend_theory_term_symbol, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 370), (void *)_cffi_d_clingo_backend_theory_term_symbol },
+  { "clingo_backend_theory_term_symbol", (void *)_cffi_f_clingo_backend_theory_term_symbol, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 372), (void *)_cffi_d_clingo_backend_theory_term_symbol },
   { "clingo_backend_weight_rule", (void *)_cffi_f_clingo_backend_weight_rule, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 271), (void *)_cffi_d_clingo_backend_weight_rule },
   { "clingo_clause_type_learnt", (void *)_cffi_const_clingo_clause_type_learnt, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_clause_type_static", (void *)_cffi_const_clingo_clause_type_static, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
@@ -19110,56 +19133,56 @@ static const struct _cffi_global_s _cffi_globals[] = {
   { "clingo_clause_type_volatile_static", (void *)_cffi_const_clingo_clause_type_volatile_static, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_comment_type_block", (void *)_cffi_const_clingo_comment_type_block, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_comment_type_line", (void *)_cffi_const_clingo_comment_type_line, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_configuration_array_at", (void *)_cffi_f_clingo_configuration_array_at, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 423), (void *)_cffi_d_clingo_configuration_array_at },
-  { "clingo_configuration_array_size", (void *)_cffi_f_clingo_configuration_array_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 412), (void *)_cffi_d_clingo_configuration_array_size },
-  { "clingo_configuration_description", (void *)_cffi_f_clingo_configuration_description, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 395), (void *)_cffi_d_clingo_configuration_description },
-  { "clingo_configuration_map_at", (void *)_cffi_f_clingo_configuration_map_at, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 406), (void *)_cffi_d_clingo_configuration_map_at },
-  { "clingo_configuration_map_has_subkey", (void *)_cffi_f_clingo_configuration_map_has_subkey, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 400), (void *)_cffi_d_clingo_configuration_map_has_subkey },
-  { "clingo_configuration_map_size", (void *)_cffi_f_clingo_configuration_map_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 412), (void *)_cffi_d_clingo_configuration_map_size },
-  { "clingo_configuration_map_subkey_name", (void *)_cffi_f_clingo_configuration_map_subkey_name, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 417), (void *)_cffi_d_clingo_configuration_map_subkey_name },
-  { "clingo_configuration_root", (void *)_cffi_f_clingo_configuration_root, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 380), (void *)_cffi_d_clingo_configuration_root },
-  { "clingo_configuration_type", (void *)_cffi_f_clingo_configuration_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 429), (void *)_cffi_d_clingo_configuration_type },
+  { "clingo_configuration_array_at", (void *)_cffi_f_clingo_configuration_array_at, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 425), (void *)_cffi_d_clingo_configuration_array_at },
+  { "clingo_configuration_array_size", (void *)_cffi_f_clingo_configuration_array_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 414), (void *)_cffi_d_clingo_configuration_array_size },
+  { "clingo_configuration_description", (void *)_cffi_f_clingo_configuration_description, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 397), (void *)_cffi_d_clingo_configuration_description },
+  { "clingo_configuration_map_at", (void *)_cffi_f_clingo_configuration_map_at, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 408), (void *)_cffi_d_clingo_configuration_map_at },
+  { "clingo_configuration_map_has_subkey", (void *)_cffi_f_clingo_configuration_map_has_subkey, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 402), (void *)_cffi_d_clingo_configuration_map_has_subkey },
+  { "clingo_configuration_map_size", (void *)_cffi_f_clingo_configuration_map_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 414), (void *)_cffi_d_clingo_configuration_map_size },
+  { "clingo_configuration_map_subkey_name", (void *)_cffi_f_clingo_configuration_map_subkey_name, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 419), (void *)_cffi_d_clingo_configuration_map_subkey_name },
+  { "clingo_configuration_root", (void *)_cffi_f_clingo_configuration_root, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 382), (void *)_cffi_d_clingo_configuration_root },
+  { "clingo_configuration_type", (void *)_cffi_f_clingo_configuration_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 431), (void *)_cffi_d_clingo_configuration_type },
   { "clingo_configuration_type_array", (void *)_cffi_const_clingo_configuration_type_array, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_configuration_type_map", (void *)_cffi_const_clingo_configuration_type_map, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_configuration_type_value", (void *)_cffi_const_clingo_configuration_type_value, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_configuration_value_get", (void *)_cffi_f_clingo_configuration_value_get, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 389), (void *)_cffi_d_clingo_configuration_value_get },
-  { "clingo_configuration_value_get_size", (void *)_cffi_f_clingo_configuration_value_get_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 412), (void *)_cffi_d_clingo_configuration_value_get_size },
-  { "clingo_configuration_value_is_assigned", (void *)_cffi_f_clingo_configuration_value_is_assigned, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 384), (void *)_cffi_d_clingo_configuration_value_is_assigned },
-  { "clingo_configuration_value_set", (void *)_cffi_f_clingo_configuration_value_set, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 375), (void *)_cffi_d_clingo_configuration_value_set },
+  { "clingo_configuration_value_get", (void *)_cffi_f_clingo_configuration_value_get, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 391), (void *)_cffi_d_clingo_configuration_value_get },
+  { "clingo_configuration_value_get_size", (void *)_cffi_f_clingo_configuration_value_get_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 414), (void *)_cffi_d_clingo_configuration_value_get_size },
+  { "clingo_configuration_value_is_assigned", (void *)_cffi_f_clingo_configuration_value_is_assigned, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 386), (void *)_cffi_d_clingo_configuration_value_is_assigned },
+  { "clingo_configuration_value_set", (void *)_cffi_f_clingo_configuration_value_set, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 377), (void *)_cffi_d_clingo_configuration_value_set },
   { "clingo_consequence_false", (void *)_cffi_const_clingo_consequence_false, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_consequence_true", (void *)_cffi_const_clingo_consequence_true, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_consequence_unknown", (void *)_cffi_const_clingo_consequence_unknown, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_control_add", (void *)_cffi_f_clingo_control_add, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 451), (void *)_cffi_d_clingo_control_add },
-  { "clingo_control_assign_external", (void *)_cffi_f_clingo_control_assign_external, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 493), (void *)_cffi_d_clingo_control_assign_external },
-  { "clingo_control_backend", (void *)_cffi_f_clingo_control_backend, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 458), (void *)_cffi_d_clingo_control_backend },
-  { "clingo_control_clasp_facade", (void *)_cffi_f_clingo_control_clasp_facade, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 507), (void *)_cffi_d_clingo_control_clasp_facade },
-  { "clingo_control_cleanup", (void *)_cffi_f_clingo_control_cleanup, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 434), (void *)_cffi_d_clingo_control_cleanup },
-  { "clingo_control_configuration", (void *)_cffi_f_clingo_control_configuration, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 462), (void *)_cffi_d_clingo_control_configuration },
-  { "clingo_control_free", (void *)_cffi_f_clingo_control_free, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1167), (void *)_cffi_d_clingo_control_free },
-  { "clingo_control_get_const", (void *)_cffi_f_clingo_control_get_const, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 523), (void *)_cffi_d_clingo_control_get_const },
-  { "clingo_control_get_enable_cleanup", (void *)_cffi_f_clingo_control_get_enable_cleanup, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 434), (void *)_cffi_d_clingo_control_get_enable_cleanup },
-  { "clingo_control_get_enable_enumeration_assumption", (void *)_cffi_f_clingo_control_get_enable_enumeration_assumption, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 434), (void *)_cffi_d_clingo_control_get_enable_enumeration_assumption },
-  { "clingo_control_ground", (void *)_cffi_f_clingo_control_ground, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 472), (void *)_cffi_d_clingo_control_ground },
-  { "clingo_control_has_const", (void *)_cffi_f_clingo_control_has_const, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 518), (void *)_cffi_d_clingo_control_has_const },
-  { "clingo_control_interrupt", (void *)_cffi_f_clingo_control_interrupt, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1167), (void *)_cffi_d_clingo_control_interrupt },
-  { "clingo_control_is_conflicting", (void *)_cffi_f_clingo_control_is_conflicting, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 515), (void *)_cffi_d_clingo_control_is_conflicting },
-  { "clingo_control_load", (void *)_cffi_f_clingo_control_load, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 447), (void *)_cffi_d_clingo_control_load },
+  { "clingo_control_add", (void *)_cffi_f_clingo_control_add, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 453), (void *)_cffi_d_clingo_control_add },
+  { "clingo_control_assign_external", (void *)_cffi_f_clingo_control_assign_external, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 495), (void *)_cffi_d_clingo_control_assign_external },
+  { "clingo_control_backend", (void *)_cffi_f_clingo_control_backend, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 460), (void *)_cffi_d_clingo_control_backend },
+  { "clingo_control_clasp_facade", (void *)_cffi_f_clingo_control_clasp_facade, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 509), (void *)_cffi_d_clingo_control_clasp_facade },
+  { "clingo_control_cleanup", (void *)_cffi_f_clingo_control_cleanup, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 436), (void *)_cffi_d_clingo_control_cleanup },
+  { "clingo_control_configuration", (void *)_cffi_f_clingo_control_configuration, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 464), (void *)_cffi_d_clingo_control_configuration },
+  { "clingo_control_free", (void *)_cffi_f_clingo_control_free, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1169), (void *)_cffi_d_clingo_control_free },
+  { "clingo_control_get_const", (void *)_cffi_f_clingo_control_get_const, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 525), (void *)_cffi_d_clingo_control_get_const },
+  { "clingo_control_get_enable_cleanup", (void *)_cffi_f_clingo_control_get_enable_cleanup, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 436), (void *)_cffi_d_clingo_control_get_enable_cleanup },
+  { "clingo_control_get_enable_enumeration_assumption", (void *)_cffi_f_clingo_control_get_enable_enumeration_assumption, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 436), (void *)_cffi_d_clingo_control_get_enable_enumeration_assumption },
+  { "clingo_control_ground", (void *)_cffi_f_clingo_control_ground, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 474), (void *)_cffi_d_clingo_control_ground },
+  { "clingo_control_has_const", (void *)_cffi_f_clingo_control_has_const, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 520), (void *)_cffi_d_clingo_control_has_const },
+  { "clingo_control_interrupt", (void *)_cffi_f_clingo_control_interrupt, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1169), (void *)_cffi_d_clingo_control_interrupt },
+  { "clingo_control_is_conflicting", (void *)_cffi_f_clingo_control_is_conflicting, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 517), (void *)_cffi_d_clingo_control_is_conflicting },
+  { "clingo_control_load", (void *)_cffi_f_clingo_control_load, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 449), (void *)_cffi_d_clingo_control_load },
   { "clingo_control_new", (void *)_cffi_f_clingo_control_new, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 31), (void *)_cffi_d_clingo_control_new },
-  { "clingo_control_register_observer", (void *)_cffi_f_clingo_control_register_observer, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 466), (void *)_cffi_d_clingo_control_register_observer },
-  { "clingo_control_register_propagator", (void *)_cffi_f_clingo_control_register_propagator, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 483), (void *)_cffi_d_clingo_control_register_propagator },
-  { "clingo_control_release_external", (void *)_cffi_f_clingo_control_release_external, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 489), (void *)_cffi_d_clingo_control_release_external },
-  { "clingo_control_set_enable_cleanup", (void *)_cffi_f_clingo_control_set_enable_cleanup, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 437), (void *)_cffi_d_clingo_control_set_enable_cleanup },
-  { "clingo_control_set_enable_enumeration_assumption", (void *)_cffi_f_clingo_control_set_enable_enumeration_assumption, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 437), (void *)_cffi_d_clingo_control_set_enable_enumeration_assumption },
-  { "clingo_control_solve", (void *)_cffi_f_clingo_control_solve, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 498), (void *)_cffi_d_clingo_control_solve },
-  { "clingo_control_statistics", (void *)_cffi_f_clingo_control_statistics, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 528), (void *)_cffi_d_clingo_control_statistics },
-  { "clingo_control_symbolic_atoms", (void *)_cffi_f_clingo_control_symbolic_atoms, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 532), (void *)_cffi_d_clingo_control_symbolic_atoms },
-  { "clingo_control_theory_atoms", (void *)_cffi_f_clingo_control_theory_atoms, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 536), (void *)_cffi_d_clingo_control_theory_atoms },
+  { "clingo_control_register_observer", (void *)_cffi_f_clingo_control_register_observer, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 468), (void *)_cffi_d_clingo_control_register_observer },
+  { "clingo_control_register_propagator", (void *)_cffi_f_clingo_control_register_propagator, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 485), (void *)_cffi_d_clingo_control_register_propagator },
+  { "clingo_control_release_external", (void *)_cffi_f_clingo_control_release_external, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 491), (void *)_cffi_d_clingo_control_release_external },
+  { "clingo_control_set_enable_cleanup", (void *)_cffi_f_clingo_control_set_enable_cleanup, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 439), (void *)_cffi_d_clingo_control_set_enable_cleanup },
+  { "clingo_control_set_enable_enumeration_assumption", (void *)_cffi_f_clingo_control_set_enable_enumeration_assumption, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 439), (void *)_cffi_d_clingo_control_set_enable_enumeration_assumption },
+  { "clingo_control_solve", (void *)_cffi_f_clingo_control_solve, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 500), (void *)_cffi_d_clingo_control_solve },
+  { "clingo_control_statistics", (void *)_cffi_f_clingo_control_statistics, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 530), (void *)_cffi_d_clingo_control_statistics },
+  { "clingo_control_symbolic_atoms", (void *)_cffi_f_clingo_control_symbolic_atoms, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 534), (void *)_cffi_d_clingo_control_symbolic_atoms },
+  { "clingo_control_theory_atoms", (void *)_cffi_f_clingo_control_theory_atoms, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 538), (void *)_cffi_d_clingo_control_theory_atoms },
   { "clingo_error_bad_alloc", (void *)_cffi_const_clingo_error_bad_alloc, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_error_code", (void *)_cffi_f_clingo_error_code, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_N, 1141), (void *)_cffi_d_clingo_error_code },
+  { "clingo_error_code", (void *)_cffi_f_clingo_error_code, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_N, 1143), (void *)_cffi_d_clingo_error_code },
   { "clingo_error_logic", (void *)_cffi_const_clingo_error_logic, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_error_message", (void *)_cffi_f_clingo_error_message, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_N, 1121), (void *)_cffi_d_clingo_error_message },
+  { "clingo_error_message", (void *)_cffi_f_clingo_error_message, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_N, 1123), (void *)_cffi_d_clingo_error_message },
   { "clingo_error_runtime", (void *)_cffi_const_clingo_error_runtime, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_error_string", (void *)_cffi_f_clingo_error_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1112), (void *)_cffi_d_clingo_error_string },
+  { "clingo_error_string", (void *)_cffi_f_clingo_error_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1114), (void *)_cffi_d_clingo_error_string },
   { "clingo_error_success", (void *)_cffi_const_clingo_error_success, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_error_unknown", (void *)_cffi_const_clingo_error_unknown, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_external_type_false", (void *)_cffi_const_clingo_external_type_false, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
@@ -19172,58 +19195,58 @@ static const struct _cffi_global_s _cffi_globals[] = {
   { "clingo_heuristic_type_level", (void *)_cffi_const_clingo_heuristic_type_level, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_heuristic_type_sign", (void *)_cffi_const_clingo_heuristic_type_sign, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_heuristic_type_true", (void *)_cffi_const_clingo_heuristic_type_true, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_main", (void *)_cffi_f_clingo_main, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1129), (void *)_cffi_d_clingo_main },
-  { "clingo_model_contains", (void *)_cffi_f_clingo_model_contains, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 632), (void *)_cffi_d_clingo_model_contains },
-  { "clingo_model_context", (void *)_cffi_f_clingo_model_context, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 592), (void *)_cffi_d_clingo_model_context },
-  { "clingo_model_cost", (void *)_cffi_f_clingo_model_cost, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 615), (void *)_cffi_d_clingo_model_cost },
-  { "clingo_model_cost_size", (void *)_cffi_f_clingo_model_cost_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 620), (void *)_cffi_d_clingo_model_cost_size },
-  { "clingo_model_extend", (void *)_cffi_f_clingo_model_extend, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 577), (void *)_cffi_d_clingo_model_extend },
-  { "clingo_model_is_consequence", (void *)_cffi_f_clingo_model_is_consequence, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 610), (void *)_cffi_d_clingo_model_is_consequence },
-  { "clingo_model_is_true", (void *)_cffi_f_clingo_model_is_true, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 605), (void *)_cffi_d_clingo_model_is_true },
-  { "clingo_model_number", (void *)_cffi_f_clingo_model_number, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 628), (void *)_cffi_d_clingo_model_number },
-  { "clingo_model_optimality_proven", (void *)_cffi_f_clingo_model_optimality_proven, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 582), (void *)_cffi_d_clingo_model_optimality_proven },
-  { "clingo_model_priority", (void *)_cffi_f_clingo_model_priority, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 600), (void *)_cffi_d_clingo_model_priority },
-  { "clingo_model_symbols", (void *)_cffi_f_clingo_model_symbols, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 642), (void *)_cffi_d_clingo_model_symbols },
-  { "clingo_model_symbols_size", (void *)_cffi_f_clingo_model_symbols_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 637), (void *)_cffi_d_clingo_model_symbols_size },
-  { "clingo_model_thread_id", (void *)_cffi_f_clingo_model_thread_id, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 624), (void *)_cffi_d_clingo_model_thread_id },
-  { "clingo_model_type", (void *)_cffi_f_clingo_model_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 596), (void *)_cffi_d_clingo_model_type },
+  { "clingo_main", (void *)_cffi_f_clingo_main, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1131), (void *)_cffi_d_clingo_main },
+  { "clingo_model_contains", (void *)_cffi_f_clingo_model_contains, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 634), (void *)_cffi_d_clingo_model_contains },
+  { "clingo_model_context", (void *)_cffi_f_clingo_model_context, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 594), (void *)_cffi_d_clingo_model_context },
+  { "clingo_model_cost", (void *)_cffi_f_clingo_model_cost, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 617), (void *)_cffi_d_clingo_model_cost },
+  { "clingo_model_cost_size", (void *)_cffi_f_clingo_model_cost_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 622), (void *)_cffi_d_clingo_model_cost_size },
+  { "clingo_model_extend", (void *)_cffi_f_clingo_model_extend, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 579), (void *)_cffi_d_clingo_model_extend },
+  { "clingo_model_is_consequence", (void *)_cffi_f_clingo_model_is_consequence, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 612), (void *)_cffi_d_clingo_model_is_consequence },
+  { "clingo_model_is_true", (void *)_cffi_f_clingo_model_is_true, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 607), (void *)_cffi_d_clingo_model_is_true },
+  { "clingo_model_number", (void *)_cffi_f_clingo_model_number, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 630), (void *)_cffi_d_clingo_model_number },
+  { "clingo_model_optimality_proven", (void *)_cffi_f_clingo_model_optimality_proven, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 584), (void *)_cffi_d_clingo_model_optimality_proven },
+  { "clingo_model_priority", (void *)_cffi_f_clingo_model_priority, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 602), (void *)_cffi_d_clingo_model_priority },
+  { "clingo_model_symbols", (void *)_cffi_f_clingo_model_symbols, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 644), (void *)_cffi_d_clingo_model_symbols },
+  { "clingo_model_symbols_size", (void *)_cffi_f_clingo_model_symbols_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 639), (void *)_cffi_d_clingo_model_symbols_size },
+  { "clingo_model_thread_id", (void *)_cffi_f_clingo_model_thread_id, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 626), (void *)_cffi_d_clingo_model_thread_id },
+  { "clingo_model_type", (void *)_cffi_f_clingo_model_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 598), (void *)_cffi_d_clingo_model_type },
   { "clingo_model_type_brave_consequences", (void *)_cffi_const_clingo_model_type_brave_consequences, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_model_type_cautious_consequences", (void *)_cffi_const_clingo_model_type_cautious_consequences, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_model_type_stable_model", (void *)_cffi_const_clingo_model_type_stable_model, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_options_add", (void *)_cffi_f_clingo_options_add, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 655), (void *)_cffi_d_clingo_options_add },
-  { "clingo_options_add_flag", (void *)_cffi_f_clingo_options_add_flag, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 648), (void *)_cffi_d_clingo_options_add_flag },
+  { "clingo_options_add", (void *)_cffi_f_clingo_options_add, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 657), (void *)_cffi_d_clingo_options_add },
+  { "clingo_options_add_flag", (void *)_cffi_f_clingo_options_add_flag, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 650), (void *)_cffi_d_clingo_options_add_flag },
   { "clingo_parse_term", (void *)_cffi_f_clingo_parse_term, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 88), (void *)_cffi_d_clingo_parse_term },
-  { "clingo_program_builder_add", (void *)_cffi_f_clingo_program_builder_add, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 672), (void *)_cffi_d_clingo_program_builder_add },
-  { "clingo_program_builder_begin", (void *)_cffi_f_clingo_program_builder_begin, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 669), (void *)_cffi_d_clingo_program_builder_begin },
-  { "clingo_program_builder_end", (void *)_cffi_f_clingo_program_builder_end, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 669), (void *)_cffi_d_clingo_program_builder_end },
-  { "clingo_program_builder_init", (void *)_cffi_f_clingo_program_builder_init, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 479), (void *)_cffi_d_clingo_program_builder_init },
-  { "clingo_propagate_control_add_clause", (void *)_cffi_f_clingo_propagate_control_add_clause, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 684), (void *)_cffi_d_clingo_propagate_control_add_clause },
-  { "clingo_propagate_control_add_literal", (void *)_cffi_f_clingo_propagate_control_add_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 680), (void *)_cffi_d_clingo_propagate_control_add_literal },
-  { "clingo_propagate_control_add_watch", (void *)_cffi_f_clingo_propagate_control_add_watch, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 697), (void *)_cffi_d_clingo_propagate_control_add_watch },
-  { "clingo_propagate_control_assignment", (void *)_cffi_f_clingo_propagate_control_assignment, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1123), (void *)_cffi_d_clingo_propagate_control_assignment },
-  { "clingo_propagate_control_has_watch", (void *)_cffi_f_clingo_propagate_control_has_watch, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 705), (void *)_cffi_d_clingo_propagate_control_has_watch },
-  { "clingo_propagate_control_propagate", (void *)_cffi_f_clingo_propagate_control_propagate, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 676), (void *)_cffi_d_clingo_propagate_control_propagate },
-  { "clingo_propagate_control_remove_watch", (void *)_cffi_f_clingo_propagate_control_remove_watch, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1170), (void *)_cffi_d_clingo_propagate_control_remove_watch },
-  { "clingo_propagate_control_thread_id", (void *)_cffi_f_clingo_propagate_control_thread_id, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1155), (void *)_cffi_d_clingo_propagate_control_thread_id },
-  { "clingo_propagate_init_add_clause", (void *)_cffi_f_clingo_propagate_init_add_clause, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 718), (void *)_cffi_d_clingo_propagate_init_add_clause },
-  { "clingo_propagate_init_add_literal", (void *)_cffi_f_clingo_propagate_init_add_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 713), (void *)_cffi_d_clingo_propagate_init_add_literal },
-  { "clingo_propagate_init_add_minimize", (void *)_cffi_f_clingo_propagate_init_add_minimize, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 738), (void *)_cffi_d_clingo_propagate_init_add_minimize },
-  { "clingo_propagate_init_add_watch", (void *)_cffi_f_clingo_propagate_init_add_watch, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 724), (void *)_cffi_d_clingo_propagate_init_add_watch },
-  { "clingo_propagate_init_add_watch_to_thread", (void *)_cffi_f_clingo_propagate_init_add_watch_to_thread, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 744), (void *)_cffi_d_clingo_propagate_init_add_watch_to_thread },
-  { "clingo_propagate_init_add_weight_constraint", (void *)_cffi_f_clingo_propagate_init_add_weight_constraint, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 728), (void *)_cffi_d_clingo_propagate_init_add_weight_constraint },
-  { "clingo_propagate_init_assignment", (void *)_cffi_f_clingo_propagate_init_assignment, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1126), (void *)_cffi_d_clingo_propagate_init_assignment },
-  { "clingo_propagate_init_freeze_literal", (void *)_cffi_f_clingo_propagate_init_freeze_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 724), (void *)_cffi_d_clingo_propagate_init_freeze_literal },
-  { "clingo_propagate_init_get_check_mode", (void *)_cffi_f_clingo_propagate_init_get_check_mode, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1135), (void *)_cffi_d_clingo_propagate_init_get_check_mode },
-  { "clingo_propagate_init_get_undo_mode", (void *)_cffi_f_clingo_propagate_init_get_undo_mode, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1135), (void *)_cffi_d_clingo_propagate_init_get_undo_mode },
-  { "clingo_propagate_init_number_of_threads", (void *)_cffi_f_clingo_propagate_init_number_of_threads, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1135), (void *)_cffi_d_clingo_propagate_init_number_of_threads },
-  { "clingo_propagate_init_propagate", (void *)_cffi_f_clingo_propagate_init_propagate, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 709), (void *)_cffi_d_clingo_propagate_init_propagate },
-  { "clingo_propagate_init_remove_watch", (void *)_cffi_f_clingo_propagate_init_remove_watch, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 724), (void *)_cffi_d_clingo_propagate_init_remove_watch },
-  { "clingo_propagate_init_remove_watch_from_thread", (void *)_cffi_f_clingo_propagate_init_remove_watch_from_thread, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 744), (void *)_cffi_d_clingo_propagate_init_remove_watch_from_thread },
-  { "clingo_propagate_init_set_check_mode", (void *)_cffi_f_clingo_propagate_init_set_check_mode, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1180), (void *)_cffi_d_clingo_propagate_init_set_check_mode },
-  { "clingo_propagate_init_set_undo_mode", (void *)_cffi_f_clingo_propagate_init_set_undo_mode, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1180), (void *)_cffi_d_clingo_propagate_init_set_undo_mode },
-  { "clingo_propagate_init_solver_literal", (void *)_cffi_f_clingo_propagate_init_solver_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 761), (void *)_cffi_d_clingo_propagate_init_solver_literal },
-  { "clingo_propagate_init_symbolic_atoms", (void *)_cffi_f_clingo_propagate_init_symbolic_atoms, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 753), (void *)_cffi_d_clingo_propagate_init_symbolic_atoms },
-  { "clingo_propagate_init_theory_atoms", (void *)_cffi_f_clingo_propagate_init_theory_atoms, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 757), (void *)_cffi_d_clingo_propagate_init_theory_atoms },
+  { "clingo_program_builder_add", (void *)_cffi_f_clingo_program_builder_add, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 674), (void *)_cffi_d_clingo_program_builder_add },
+  { "clingo_program_builder_begin", (void *)_cffi_f_clingo_program_builder_begin, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 671), (void *)_cffi_d_clingo_program_builder_begin },
+  { "clingo_program_builder_end", (void *)_cffi_f_clingo_program_builder_end, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 671), (void *)_cffi_d_clingo_program_builder_end },
+  { "clingo_program_builder_init", (void *)_cffi_f_clingo_program_builder_init, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 481), (void *)_cffi_d_clingo_program_builder_init },
+  { "clingo_propagate_control_add_clause", (void *)_cffi_f_clingo_propagate_control_add_clause, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 686), (void *)_cffi_d_clingo_propagate_control_add_clause },
+  { "clingo_propagate_control_add_literal", (void *)_cffi_f_clingo_propagate_control_add_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 682), (void *)_cffi_d_clingo_propagate_control_add_literal },
+  { "clingo_propagate_control_add_watch", (void *)_cffi_f_clingo_propagate_control_add_watch, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 699), (void *)_cffi_d_clingo_propagate_control_add_watch },
+  { "clingo_propagate_control_assignment", (void *)_cffi_f_clingo_propagate_control_assignment, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1125), (void *)_cffi_d_clingo_propagate_control_assignment },
+  { "clingo_propagate_control_has_watch", (void *)_cffi_f_clingo_propagate_control_has_watch, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 707), (void *)_cffi_d_clingo_propagate_control_has_watch },
+  { "clingo_propagate_control_propagate", (void *)_cffi_f_clingo_propagate_control_propagate, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 678), (void *)_cffi_d_clingo_propagate_control_propagate },
+  { "clingo_propagate_control_remove_watch", (void *)_cffi_f_clingo_propagate_control_remove_watch, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1172), (void *)_cffi_d_clingo_propagate_control_remove_watch },
+  { "clingo_propagate_control_thread_id", (void *)_cffi_f_clingo_propagate_control_thread_id, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1157), (void *)_cffi_d_clingo_propagate_control_thread_id },
+  { "clingo_propagate_init_add_clause", (void *)_cffi_f_clingo_propagate_init_add_clause, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 720), (void *)_cffi_d_clingo_propagate_init_add_clause },
+  { "clingo_propagate_init_add_literal", (void *)_cffi_f_clingo_propagate_init_add_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 715), (void *)_cffi_d_clingo_propagate_init_add_literal },
+  { "clingo_propagate_init_add_minimize", (void *)_cffi_f_clingo_propagate_init_add_minimize, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 740), (void *)_cffi_d_clingo_propagate_init_add_minimize },
+  { "clingo_propagate_init_add_watch", (void *)_cffi_f_clingo_propagate_init_add_watch, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 726), (void *)_cffi_d_clingo_propagate_init_add_watch },
+  { "clingo_propagate_init_add_watch_to_thread", (void *)_cffi_f_clingo_propagate_init_add_watch_to_thread, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 746), (void *)_cffi_d_clingo_propagate_init_add_watch_to_thread },
+  { "clingo_propagate_init_add_weight_constraint", (void *)_cffi_f_clingo_propagate_init_add_weight_constraint, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 730), (void *)_cffi_d_clingo_propagate_init_add_weight_constraint },
+  { "clingo_propagate_init_assignment", (void *)_cffi_f_clingo_propagate_init_assignment, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1128), (void *)_cffi_d_clingo_propagate_init_assignment },
+  { "clingo_propagate_init_freeze_literal", (void *)_cffi_f_clingo_propagate_init_freeze_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 726), (void *)_cffi_d_clingo_propagate_init_freeze_literal },
+  { "clingo_propagate_init_get_check_mode", (void *)_cffi_f_clingo_propagate_init_get_check_mode, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1137), (void *)_cffi_d_clingo_propagate_init_get_check_mode },
+  { "clingo_propagate_init_get_undo_mode", (void *)_cffi_f_clingo_propagate_init_get_undo_mode, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1137), (void *)_cffi_d_clingo_propagate_init_get_undo_mode },
+  { "clingo_propagate_init_number_of_threads", (void *)_cffi_f_clingo_propagate_init_number_of_threads, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1137), (void *)_cffi_d_clingo_propagate_init_number_of_threads },
+  { "clingo_propagate_init_propagate", (void *)_cffi_f_clingo_propagate_init_propagate, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 711), (void *)_cffi_d_clingo_propagate_init_propagate },
+  { "clingo_propagate_init_remove_watch", (void *)_cffi_f_clingo_propagate_init_remove_watch, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 726), (void *)_cffi_d_clingo_propagate_init_remove_watch },
+  { "clingo_propagate_init_remove_watch_from_thread", (void *)_cffi_f_clingo_propagate_init_remove_watch_from_thread, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 746), (void *)_cffi_d_clingo_propagate_init_remove_watch_from_thread },
+  { "clingo_propagate_init_set_check_mode", (void *)_cffi_f_clingo_propagate_init_set_check_mode, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1182), (void *)_cffi_d_clingo_propagate_init_set_check_mode },
+  { "clingo_propagate_init_set_undo_mode", (void *)_cffi_f_clingo_propagate_init_set_undo_mode, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1182), (void *)_cffi_d_clingo_propagate_init_set_undo_mode },
+  { "clingo_propagate_init_solver_literal", (void *)_cffi_f_clingo_propagate_init_solver_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 763), (void *)_cffi_d_clingo_propagate_init_solver_literal },
+  { "clingo_propagate_init_symbolic_atoms", (void *)_cffi_f_clingo_propagate_init_symbolic_atoms, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 755), (void *)_cffi_d_clingo_propagate_init_symbolic_atoms },
+  { "clingo_propagate_init_theory_atoms", (void *)_cffi_f_clingo_propagate_init_theory_atoms, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 759), (void *)_cffi_d_clingo_propagate_init_theory_atoms },
   { "clingo_propagator_check_mode_both", (void *)_cffi_const_clingo_propagator_check_mode_both, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_propagator_check_mode_fixpoint", (void *)_cffi_const_clingo_propagator_check_mode_fixpoint, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_propagator_check_mode_none", (void *)_cffi_const_clingo_propagator_check_mode_none, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
@@ -19231,112 +19254,112 @@ static const struct _cffi_global_s _cffi_globals[] = {
   { "clingo_propagator_undo_mode_always", (void *)_cffi_const_clingo_propagator_undo_mode_always, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_propagator_undo_mode_default", (void *)_cffi_const_clingo_propagator_undo_mode_default, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_register_script", (void *)_cffi_f_clingo_register_script, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 62), (void *)_cffi_d_clingo_register_script },
-  { "clingo_script_version", (void *)_cffi_f_clingo_script_version, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1109), (void *)_cffi_d_clingo_script_version },
-  { "clingo_set_error", (void *)_cffi_f_clingo_set_error, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1194), (void *)_cffi_d_clingo_set_error },
+  { "clingo_script_version", (void *)_cffi_f_clingo_script_version, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1111), (void *)_cffi_d_clingo_script_version },
+  { "clingo_set_error", (void *)_cffi_f_clingo_set_error, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1196), (void *)_cffi_d_clingo_set_error },
   { "clingo_show_type_all", (void *)_cffi_const_clingo_show_type_all, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_show_type_atoms", (void *)_cffi_const_clingo_show_type_atoms, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_show_type_complement", (void *)_cffi_const_clingo_show_type_complement, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_show_type_shown", (void *)_cffi_const_clingo_show_type_shown, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_show_type_terms", (void *)_cffi_const_clingo_show_type_terms, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_show_type_theory", (void *)_cffi_const_clingo_show_type_theory, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_signature_arity", (void *)_cffi_f_clingo_signature_arity, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1158), (void *)_cffi_d_clingo_signature_arity },
+  { "clingo_signature_arity", (void *)_cffi_f_clingo_signature_arity, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1160), (void *)_cffi_d_clingo_signature_arity },
   { "clingo_signature_create", (void *)_cffi_f_clingo_signature_create, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 67), (void *)_cffi_d_clingo_signature_create },
-  { "clingo_signature_hash", (void *)_cffi_f_clingo_signature_hash, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1149), (void *)_cffi_d_clingo_signature_hash },
-  { "clingo_signature_is_equal_to", (void *)_cffi_f_clingo_signature_is_equal_to, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1078), (void *)_cffi_d_clingo_signature_is_equal_to },
-  { "clingo_signature_is_less_than", (void *)_cffi_f_clingo_signature_is_less_than, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1078), (void *)_cffi_d_clingo_signature_is_less_than },
-  { "clingo_signature_is_negative", (void *)_cffi_f_clingo_signature_is_negative, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1038), (void *)_cffi_d_clingo_signature_is_negative },
-  { "clingo_signature_is_positive", (void *)_cffi_f_clingo_signature_is_positive, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1038), (void *)_cffi_d_clingo_signature_is_positive },
-  { "clingo_signature_name", (void *)_cffi_f_clingo_signature_name, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1115), (void *)_cffi_d_clingo_signature_name },
-  { "clingo_solve_control_add_clause", (void *)_cffi_f_clingo_solve_control_add_clause, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 766), (void *)_cffi_d_clingo_solve_control_add_clause },
-  { "clingo_solve_control_symbolic_atoms", (void *)_cffi_f_clingo_solve_control_symbolic_atoms, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 771), (void *)_cffi_d_clingo_solve_control_symbolic_atoms },
+  { "clingo_signature_hash", (void *)_cffi_f_clingo_signature_hash, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1151), (void *)_cffi_d_clingo_signature_hash },
+  { "clingo_signature_is_equal_to", (void *)_cffi_f_clingo_signature_is_equal_to, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1080), (void *)_cffi_d_clingo_signature_is_equal_to },
+  { "clingo_signature_is_less_than", (void *)_cffi_f_clingo_signature_is_less_than, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1080), (void *)_cffi_d_clingo_signature_is_less_than },
+  { "clingo_signature_is_negative", (void *)_cffi_f_clingo_signature_is_negative, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1040), (void *)_cffi_d_clingo_signature_is_negative },
+  { "clingo_signature_is_positive", (void *)_cffi_f_clingo_signature_is_positive, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1040), (void *)_cffi_d_clingo_signature_is_positive },
+  { "clingo_signature_name", (void *)_cffi_f_clingo_signature_name, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1117), (void *)_cffi_d_clingo_signature_name },
+  { "clingo_solve_control_add_clause", (void *)_cffi_f_clingo_solve_control_add_clause, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 768), (void *)_cffi_d_clingo_solve_control_add_clause },
+  { "clingo_solve_control_symbolic_atoms", (void *)_cffi_f_clingo_solve_control_symbolic_atoms, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 773), (void *)_cffi_d_clingo_solve_control_symbolic_atoms },
   { "clingo_solve_event_type_finish", (void *)_cffi_const_clingo_solve_event_type_finish, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_solve_event_type_model", (void *)_cffi_const_clingo_solve_event_type_model, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_solve_event_type_statistics", (void *)_cffi_const_clingo_solve_event_type_statistics, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_solve_event_type_unsat", (void *)_cffi_const_clingo_solve_event_type_unsat, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_solve_handle_cancel", (void *)_cffi_f_clingo_solve_handle_cancel, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 775), (void *)_cffi_d_clingo_solve_handle_cancel },
-  { "clingo_solve_handle_close", (void *)_cffi_f_clingo_solve_handle_close, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 775), (void *)_cffi_d_clingo_solve_handle_close },
-  { "clingo_solve_handle_core", (void *)_cffi_f_clingo_solve_handle_core, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 782), (void *)_cffi_d_clingo_solve_handle_core },
-  { "clingo_solve_handle_get", (void *)_cffi_f_clingo_solve_handle_get, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 787), (void *)_cffi_d_clingo_solve_handle_get },
-  { "clingo_solve_handle_model", (void *)_cffi_f_clingo_solve_handle_model, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 778), (void *)_cffi_d_clingo_solve_handle_model },
-  { "clingo_solve_handle_resume", (void *)_cffi_f_clingo_solve_handle_resume, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 775), (void *)_cffi_d_clingo_solve_handle_resume },
-  { "clingo_solve_handle_wait", (void *)_cffi_f_clingo_solve_handle_wait, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1184), (void *)_cffi_d_clingo_solve_handle_wait },
+  { "clingo_solve_handle_cancel", (void *)_cffi_f_clingo_solve_handle_cancel, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 777), (void *)_cffi_d_clingo_solve_handle_cancel },
+  { "clingo_solve_handle_close", (void *)_cffi_f_clingo_solve_handle_close, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 777), (void *)_cffi_d_clingo_solve_handle_close },
+  { "clingo_solve_handle_core", (void *)_cffi_f_clingo_solve_handle_core, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 784), (void *)_cffi_d_clingo_solve_handle_core },
+  { "clingo_solve_handle_get", (void *)_cffi_f_clingo_solve_handle_get, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 789), (void *)_cffi_d_clingo_solve_handle_get },
+  { "clingo_solve_handle_model", (void *)_cffi_f_clingo_solve_handle_model, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 780), (void *)_cffi_d_clingo_solve_handle_model },
+  { "clingo_solve_handle_resume", (void *)_cffi_f_clingo_solve_handle_resume, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 777), (void *)_cffi_d_clingo_solve_handle_resume },
+  { "clingo_solve_handle_wait", (void *)_cffi_f_clingo_solve_handle_wait, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1186), (void *)_cffi_d_clingo_solve_handle_wait },
   { "clingo_solve_mode_async", (void *)_cffi_const_clingo_solve_mode_async, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_solve_mode_yield", (void *)_cffi_const_clingo_solve_mode_yield, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_solve_result_exhausted", (void *)_cffi_const_clingo_solve_result_exhausted, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_solve_result_interrupted", (void *)_cffi_const_clingo_solve_result_interrupted, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_solve_result_satisfiable", (void *)_cffi_const_clingo_solve_result_satisfiable, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_solve_result_unsatisfiable", (void *)_cffi_const_clingo_solve_result_unsatisfiable, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_statistics_array_at", (void *)_cffi_f_clingo_statistics_array_at, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 846), (void *)_cffi_d_clingo_statistics_array_at },
-  { "clingo_statistics_array_push", (void *)_cffi_f_clingo_statistics_array_push, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 803), (void *)_cffi_d_clingo_statistics_array_push },
-  { "clingo_statistics_array_size", (void *)_cffi_f_clingo_statistics_array_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 835), (void *)_cffi_d_clingo_statistics_array_size },
-  { "clingo_statistics_map_add_subkey", (void *)_cffi_f_clingo_statistics_map_add_subkey, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 791), (void *)_cffi_d_clingo_statistics_map_add_subkey },
-  { "clingo_statistics_map_at", (void *)_cffi_f_clingo_statistics_map_at, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 819), (void *)_cffi_d_clingo_statistics_map_at },
-  { "clingo_statistics_map_has_subkey", (void *)_cffi_f_clingo_statistics_map_has_subkey, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 813), (void *)_cffi_d_clingo_statistics_map_has_subkey },
-  { "clingo_statistics_map_size", (void *)_cffi_f_clingo_statistics_map_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 835), (void *)_cffi_d_clingo_statistics_map_size },
-  { "clingo_statistics_map_subkey_name", (void *)_cffi_f_clingo_statistics_map_subkey_name, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 840), (void *)_cffi_d_clingo_statistics_map_subkey_name },
-  { "clingo_statistics_root", (void *)_cffi_f_clingo_statistics_root, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 809), (void *)_cffi_d_clingo_statistics_root },
-  { "clingo_statistics_type", (void *)_cffi_f_clingo_statistics_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 830), (void *)_cffi_d_clingo_statistics_type },
+  { "clingo_statistics_array_at", (void *)_cffi_f_clingo_statistics_array_at, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 848), (void *)_cffi_d_clingo_statistics_array_at },
+  { "clingo_statistics_array_push", (void *)_cffi_f_clingo_statistics_array_push, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 805), (void *)_cffi_d_clingo_statistics_array_push },
+  { "clingo_statistics_array_size", (void *)_cffi_f_clingo_statistics_array_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 837), (void *)_cffi_d_clingo_statistics_array_size },
+  { "clingo_statistics_map_add_subkey", (void *)_cffi_f_clingo_statistics_map_add_subkey, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 793), (void *)_cffi_d_clingo_statistics_map_add_subkey },
+  { "clingo_statistics_map_at", (void *)_cffi_f_clingo_statistics_map_at, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 821), (void *)_cffi_d_clingo_statistics_map_at },
+  { "clingo_statistics_map_has_subkey", (void *)_cffi_f_clingo_statistics_map_has_subkey, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 815), (void *)_cffi_d_clingo_statistics_map_has_subkey },
+  { "clingo_statistics_map_size", (void *)_cffi_f_clingo_statistics_map_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 837), (void *)_cffi_d_clingo_statistics_map_size },
+  { "clingo_statistics_map_subkey_name", (void *)_cffi_f_clingo_statistics_map_subkey_name, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 842), (void *)_cffi_d_clingo_statistics_map_subkey_name },
+  { "clingo_statistics_root", (void *)_cffi_f_clingo_statistics_root, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 811), (void *)_cffi_d_clingo_statistics_root },
+  { "clingo_statistics_type", (void *)_cffi_f_clingo_statistics_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 832), (void *)_cffi_d_clingo_statistics_type },
   { "clingo_statistics_type_array", (void *)_cffi_const_clingo_statistics_type_array, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_statistics_type_empty", (void *)_cffi_const_clingo_statistics_type_empty, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_statistics_type_map", (void *)_cffi_const_clingo_statistics_type_map, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_statistics_type_value", (void *)_cffi_const_clingo_statistics_type_value, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_statistics_value_get", (void *)_cffi_f_clingo_statistics_value_get, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 825), (void *)_cffi_d_clingo_statistics_value_get },
-  { "clingo_statistics_value_set", (void *)_cffi_f_clingo_statistics_value_set, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 798), (void *)_cffi_d_clingo_statistics_value_set },
-  { "clingo_symbol_arguments", (void *)_cffi_f_clingo_symbol_arguments, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1073), (void *)_cffi_d_clingo_symbol_arguments },
+  { "clingo_statistics_value_get", (void *)_cffi_f_clingo_statistics_value_get, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 827), (void *)_cffi_d_clingo_statistics_value_get },
+  { "clingo_statistics_value_set", (void *)_cffi_f_clingo_statistics_value_set, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 800), (void *)_cffi_d_clingo_statistics_value_set },
+  { "clingo_symbol_arguments", (void *)_cffi_f_clingo_symbol_arguments, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1075), (void *)_cffi_d_clingo_symbol_arguments },
   { "clingo_symbol_create_function", (void *)_cffi_f_clingo_symbol_create_function, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 77), (void *)_cffi_d_clingo_symbol_create_function },
   { "clingo_symbol_create_id", (void *)_cffi_f_clingo_symbol_create_id, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 53), (void *)_cffi_d_clingo_symbol_create_id },
-  { "clingo_symbol_create_infimum", (void *)_cffi_f_clingo_symbol_create_infimum, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1207), (void *)_cffi_d_clingo_symbol_create_infimum },
-  { "clingo_symbol_create_number", (void *)_cffi_f_clingo_symbol_create_number, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1203), (void *)_cffi_d_clingo_symbol_create_number },
+  { "clingo_symbol_create_infimum", (void *)_cffi_f_clingo_symbol_create_infimum, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1209), (void *)_cffi_d_clingo_symbol_create_infimum },
+  { "clingo_symbol_create_number", (void *)_cffi_f_clingo_symbol_create_number, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1205), (void *)_cffi_d_clingo_symbol_create_number },
   { "clingo_symbol_create_string", (void *)_cffi_f_clingo_symbol_create_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 73), (void *)_cffi_d_clingo_symbol_create_string },
-  { "clingo_symbol_create_supremum", (void *)_cffi_f_clingo_symbol_create_supremum, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1207), (void *)_cffi_d_clingo_symbol_create_supremum },
-  { "clingo_symbol_hash", (void *)_cffi_f_clingo_symbol_hash, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1149), (void *)_cffi_d_clingo_symbol_hash },
-  { "clingo_symbol_is_equal_to", (void *)_cffi_f_clingo_symbol_is_equal_to, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1078), (void *)_cffi_d_clingo_symbol_is_equal_to },
-  { "clingo_symbol_is_less_than", (void *)_cffi_f_clingo_symbol_is_less_than, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1078), (void *)_cffi_d_clingo_symbol_is_less_than },
-  { "clingo_symbol_is_negative", (void *)_cffi_f_clingo_symbol_is_negative, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1041), (void *)_cffi_d_clingo_symbol_is_negative },
-  { "clingo_symbol_is_positive", (void *)_cffi_f_clingo_symbol_is_positive, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1041), (void *)_cffi_d_clingo_symbol_is_positive },
-  { "clingo_symbol_name", (void *)_cffi_f_clingo_symbol_name, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1050), (void *)_cffi_d_clingo_symbol_name },
-  { "clingo_symbol_number", (void *)_cffi_f_clingo_symbol_number, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1054), (void *)_cffi_d_clingo_symbol_number },
-  { "clingo_symbol_string", (void *)_cffi_f_clingo_symbol_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1050), (void *)_cffi_d_clingo_symbol_string },
-  { "clingo_symbol_to_string", (void *)_cffi_f_clingo_symbol_to_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1045), (void *)_cffi_d_clingo_symbol_to_string },
-  { "clingo_symbol_to_string_size", (void *)_cffi_f_clingo_symbol_to_string_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1064), (void *)_cffi_d_clingo_symbol_to_string_size },
-  { "clingo_symbol_type", (void *)_cffi_f_clingo_symbol_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1138), (void *)_cffi_d_clingo_symbol_type },
+  { "clingo_symbol_create_supremum", (void *)_cffi_f_clingo_symbol_create_supremum, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1209), (void *)_cffi_d_clingo_symbol_create_supremum },
+  { "clingo_symbol_hash", (void *)_cffi_f_clingo_symbol_hash, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1151), (void *)_cffi_d_clingo_symbol_hash },
+  { "clingo_symbol_is_equal_to", (void *)_cffi_f_clingo_symbol_is_equal_to, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1080), (void *)_cffi_d_clingo_symbol_is_equal_to },
+  { "clingo_symbol_is_less_than", (void *)_cffi_f_clingo_symbol_is_less_than, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1080), (void *)_cffi_d_clingo_symbol_is_less_than },
+  { "clingo_symbol_is_negative", (void *)_cffi_f_clingo_symbol_is_negative, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1043), (void *)_cffi_d_clingo_symbol_is_negative },
+  { "clingo_symbol_is_positive", (void *)_cffi_f_clingo_symbol_is_positive, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1043), (void *)_cffi_d_clingo_symbol_is_positive },
+  { "clingo_symbol_name", (void *)_cffi_f_clingo_symbol_name, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1052), (void *)_cffi_d_clingo_symbol_name },
+  { "clingo_symbol_number", (void *)_cffi_f_clingo_symbol_number, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1056), (void *)_cffi_d_clingo_symbol_number },
+  { "clingo_symbol_string", (void *)_cffi_f_clingo_symbol_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1052), (void *)_cffi_d_clingo_symbol_string },
+  { "clingo_symbol_to_string", (void *)_cffi_f_clingo_symbol_to_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1047), (void *)_cffi_d_clingo_symbol_to_string },
+  { "clingo_symbol_to_string_size", (void *)_cffi_f_clingo_symbol_to_string_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1066), (void *)_cffi_d_clingo_symbol_to_string_size },
+  { "clingo_symbol_type", (void *)_cffi_f_clingo_symbol_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1140), (void *)_cffi_d_clingo_symbol_type },
   { "clingo_symbol_type_function", (void *)_cffi_const_clingo_symbol_type_function, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_symbol_type_infimum", (void *)_cffi_const_clingo_symbol_type_infimum, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_symbol_type_number", (void *)_cffi_const_clingo_symbol_type_number, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_symbol_type_string", (void *)_cffi_const_clingo_symbol_type_string, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_symbol_type_supremum", (void *)_cffi_const_clingo_symbol_type_supremum, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_symbolic_atoms_begin", (void *)_cffi_f_clingo_symbolic_atoms_begin, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 865), (void *)_cffi_d_clingo_symbolic_atoms_begin },
-  { "clingo_symbolic_atoms_end", (void *)_cffi_f_clingo_symbolic_atoms_end, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 856), (void *)_cffi_d_clingo_symbolic_atoms_end },
-  { "clingo_symbolic_atoms_find", (void *)_cffi_f_clingo_symbolic_atoms_find, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 880), (void *)_cffi_d_clingo_symbolic_atoms_find },
-  { "clingo_symbolic_atoms_is_external", (void *)_cffi_f_clingo_symbolic_atoms_is_external, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 870), (void *)_cffi_d_clingo_symbolic_atoms_is_external },
-  { "clingo_symbolic_atoms_is_fact", (void *)_cffi_f_clingo_symbolic_atoms_is_fact, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 870), (void *)_cffi_d_clingo_symbolic_atoms_is_fact },
-  { "clingo_symbolic_atoms_is_valid", (void *)_cffi_f_clingo_symbolic_atoms_is_valid, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 870), (void *)_cffi_d_clingo_symbolic_atoms_is_valid },
-  { "clingo_symbolic_atoms_iterator_is_equal_to", (void *)_cffi_f_clingo_symbolic_atoms_iterator_is_equal_to, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 885), (void *)_cffi_d_clingo_symbolic_atoms_iterator_is_equal_to },
-  { "clingo_symbolic_atoms_literal", (void *)_cffi_f_clingo_symbolic_atoms_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 875), (void *)_cffi_d_clingo_symbolic_atoms_literal },
-  { "clingo_symbolic_atoms_next", (void *)_cffi_f_clingo_symbolic_atoms_next, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 880), (void *)_cffi_d_clingo_symbolic_atoms_next },
-  { "clingo_symbolic_atoms_signatures", (void *)_cffi_f_clingo_symbolic_atoms_signatures, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 860), (void *)_cffi_d_clingo_symbolic_atoms_signatures },
-  { "clingo_symbolic_atoms_signatures_size", (void *)_cffi_f_clingo_symbolic_atoms_signatures_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 852), (void *)_cffi_d_clingo_symbolic_atoms_signatures_size },
-  { "clingo_symbolic_atoms_size", (void *)_cffi_f_clingo_symbolic_atoms_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 852), (void *)_cffi_d_clingo_symbolic_atoms_size },
-  { "clingo_symbolic_atoms_symbol", (void *)_cffi_f_clingo_symbolic_atoms_symbol, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 880), (void *)_cffi_d_clingo_symbolic_atoms_symbol },
-  { "clingo_theory_atoms_atom_elements", (void *)_cffi_f_clingo_theory_atoms_atom_elements, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 943), (void *)_cffi_d_clingo_theory_atoms_atom_elements },
-  { "clingo_theory_atoms_atom_guard", (void *)_cffi_f_clingo_theory_atoms_atom_guard, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 911), (void *)_cffi_d_clingo_theory_atoms_atom_guard },
-  { "clingo_theory_atoms_atom_has_guard", (void *)_cffi_f_clingo_theory_atoms_atom_has_guard, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 895), (void *)_cffi_d_clingo_theory_atoms_atom_has_guard },
-  { "clingo_theory_atoms_atom_literal", (void *)_cffi_f_clingo_theory_atoms_atom_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 922), (void *)_cffi_d_clingo_theory_atoms_atom_literal },
-  { "clingo_theory_atoms_atom_term", (void *)_cffi_f_clingo_theory_atoms_atom_term, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 938), (void *)_cffi_d_clingo_theory_atoms_atom_term },
-  { "clingo_theory_atoms_atom_to_string", (void *)_cffi_f_clingo_theory_atoms_atom_to_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 900), (void *)_cffi_d_clingo_theory_atoms_atom_to_string },
-  { "clingo_theory_atoms_atom_to_string_size", (void *)_cffi_f_clingo_theory_atoms_atom_to_string_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 933), (void *)_cffi_d_clingo_theory_atoms_atom_to_string_size },
-  { "clingo_theory_atoms_element_condition", (void *)_cffi_f_clingo_theory_atoms_element_condition, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 927), (void *)_cffi_d_clingo_theory_atoms_element_condition },
-  { "clingo_theory_atoms_element_condition_id", (void *)_cffi_f_clingo_theory_atoms_element_condition_id, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 922), (void *)_cffi_d_clingo_theory_atoms_element_condition_id },
-  { "clingo_theory_atoms_element_to_string", (void *)_cffi_f_clingo_theory_atoms_element_to_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 900), (void *)_cffi_d_clingo_theory_atoms_element_to_string },
-  { "clingo_theory_atoms_element_to_string_size", (void *)_cffi_f_clingo_theory_atoms_element_to_string_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 933), (void *)_cffi_d_clingo_theory_atoms_element_to_string_size },
-  { "clingo_theory_atoms_element_tuple", (void *)_cffi_f_clingo_theory_atoms_element_tuple, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 943), (void *)_cffi_d_clingo_theory_atoms_element_tuple },
-  { "clingo_theory_atoms_size", (void *)_cffi_f_clingo_theory_atoms_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 891), (void *)_cffi_d_clingo_theory_atoms_size },
-  { "clingo_theory_atoms_term_arguments", (void *)_cffi_f_clingo_theory_atoms_term_arguments, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 943), (void *)_cffi_d_clingo_theory_atoms_term_arguments },
-  { "clingo_theory_atoms_term_name", (void *)_cffi_f_clingo_theory_atoms_term_name, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 906), (void *)_cffi_d_clingo_theory_atoms_term_name },
-  { "clingo_theory_atoms_term_number", (void *)_cffi_f_clingo_theory_atoms_term_number, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 917), (void *)_cffi_d_clingo_theory_atoms_term_number },
-  { "clingo_theory_atoms_term_to_string", (void *)_cffi_f_clingo_theory_atoms_term_to_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 900), (void *)_cffi_d_clingo_theory_atoms_term_to_string },
-  { "clingo_theory_atoms_term_to_string_size", (void *)_cffi_f_clingo_theory_atoms_term_to_string_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 933), (void *)_cffi_d_clingo_theory_atoms_term_to_string_size },
-  { "clingo_theory_atoms_term_type", (void *)_cffi_f_clingo_theory_atoms_term_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 917), (void *)_cffi_d_clingo_theory_atoms_term_type },
+  { "clingo_symbolic_atoms_begin", (void *)_cffi_f_clingo_symbolic_atoms_begin, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 867), (void *)_cffi_d_clingo_symbolic_atoms_begin },
+  { "clingo_symbolic_atoms_end", (void *)_cffi_f_clingo_symbolic_atoms_end, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 858), (void *)_cffi_d_clingo_symbolic_atoms_end },
+  { "clingo_symbolic_atoms_find", (void *)_cffi_f_clingo_symbolic_atoms_find, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 882), (void *)_cffi_d_clingo_symbolic_atoms_find },
+  { "clingo_symbolic_atoms_is_external", (void *)_cffi_f_clingo_symbolic_atoms_is_external, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 872), (void *)_cffi_d_clingo_symbolic_atoms_is_external },
+  { "clingo_symbolic_atoms_is_fact", (void *)_cffi_f_clingo_symbolic_atoms_is_fact, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 872), (void *)_cffi_d_clingo_symbolic_atoms_is_fact },
+  { "clingo_symbolic_atoms_is_valid", (void *)_cffi_f_clingo_symbolic_atoms_is_valid, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 872), (void *)_cffi_d_clingo_symbolic_atoms_is_valid },
+  { "clingo_symbolic_atoms_iterator_is_equal_to", (void *)_cffi_f_clingo_symbolic_atoms_iterator_is_equal_to, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 887), (void *)_cffi_d_clingo_symbolic_atoms_iterator_is_equal_to },
+  { "clingo_symbolic_atoms_literal", (void *)_cffi_f_clingo_symbolic_atoms_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 877), (void *)_cffi_d_clingo_symbolic_atoms_literal },
+  { "clingo_symbolic_atoms_next", (void *)_cffi_f_clingo_symbolic_atoms_next, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 882), (void *)_cffi_d_clingo_symbolic_atoms_next },
+  { "clingo_symbolic_atoms_signatures", (void *)_cffi_f_clingo_symbolic_atoms_signatures, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 862), (void *)_cffi_d_clingo_symbolic_atoms_signatures },
+  { "clingo_symbolic_atoms_signatures_size", (void *)_cffi_f_clingo_symbolic_atoms_signatures_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 854), (void *)_cffi_d_clingo_symbolic_atoms_signatures_size },
+  { "clingo_symbolic_atoms_size", (void *)_cffi_f_clingo_symbolic_atoms_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 854), (void *)_cffi_d_clingo_symbolic_atoms_size },
+  { "clingo_symbolic_atoms_symbol", (void *)_cffi_f_clingo_symbolic_atoms_symbol, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 882), (void *)_cffi_d_clingo_symbolic_atoms_symbol },
+  { "clingo_theory_atoms_atom_elements", (void *)_cffi_f_clingo_theory_atoms_atom_elements, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 945), (void *)_cffi_d_clingo_theory_atoms_atom_elements },
+  { "clingo_theory_atoms_atom_guard", (void *)_cffi_f_clingo_theory_atoms_atom_guard, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 913), (void *)_cffi_d_clingo_theory_atoms_atom_guard },
+  { "clingo_theory_atoms_atom_has_guard", (void *)_cffi_f_clingo_theory_atoms_atom_has_guard, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 897), (void *)_cffi_d_clingo_theory_atoms_atom_has_guard },
+  { "clingo_theory_atoms_atom_literal", (void *)_cffi_f_clingo_theory_atoms_atom_literal, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 924), (void *)_cffi_d_clingo_theory_atoms_atom_literal },
+  { "clingo_theory_atoms_atom_term", (void *)_cffi_f_clingo_theory_atoms_atom_term, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 940), (void *)_cffi_d_clingo_theory_atoms_atom_term },
+  { "clingo_theory_atoms_atom_to_string", (void *)_cffi_f_clingo_theory_atoms_atom_to_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 902), (void *)_cffi_d_clingo_theory_atoms_atom_to_string },
+  { "clingo_theory_atoms_atom_to_string_size", (void *)_cffi_f_clingo_theory_atoms_atom_to_string_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 935), (void *)_cffi_d_clingo_theory_atoms_atom_to_string_size },
+  { "clingo_theory_atoms_element_condition", (void *)_cffi_f_clingo_theory_atoms_element_condition, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 929), (void *)_cffi_d_clingo_theory_atoms_element_condition },
+  { "clingo_theory_atoms_element_condition_id", (void *)_cffi_f_clingo_theory_atoms_element_condition_id, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 924), (void *)_cffi_d_clingo_theory_atoms_element_condition_id },
+  { "clingo_theory_atoms_element_to_string", (void *)_cffi_f_clingo_theory_atoms_element_to_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 902), (void *)_cffi_d_clingo_theory_atoms_element_to_string },
+  { "clingo_theory_atoms_element_to_string_size", (void *)_cffi_f_clingo_theory_atoms_element_to_string_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 935), (void *)_cffi_d_clingo_theory_atoms_element_to_string_size },
+  { "clingo_theory_atoms_element_tuple", (void *)_cffi_f_clingo_theory_atoms_element_tuple, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 945), (void *)_cffi_d_clingo_theory_atoms_element_tuple },
+  { "clingo_theory_atoms_size", (void *)_cffi_f_clingo_theory_atoms_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 893), (void *)_cffi_d_clingo_theory_atoms_size },
+  { "clingo_theory_atoms_term_arguments", (void *)_cffi_f_clingo_theory_atoms_term_arguments, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 945), (void *)_cffi_d_clingo_theory_atoms_term_arguments },
+  { "clingo_theory_atoms_term_name", (void *)_cffi_f_clingo_theory_atoms_term_name, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 908), (void *)_cffi_d_clingo_theory_atoms_term_name },
+  { "clingo_theory_atoms_term_number", (void *)_cffi_f_clingo_theory_atoms_term_number, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 919), (void *)_cffi_d_clingo_theory_atoms_term_number },
+  { "clingo_theory_atoms_term_to_string", (void *)_cffi_f_clingo_theory_atoms_term_to_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 902), (void *)_cffi_d_clingo_theory_atoms_term_to_string },
+  { "clingo_theory_atoms_term_to_string_size", (void *)_cffi_f_clingo_theory_atoms_term_to_string_size, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 935), (void *)_cffi_d_clingo_theory_atoms_term_to_string_size },
+  { "clingo_theory_atoms_term_type", (void *)_cffi_f_clingo_theory_atoms_term_type, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 919), (void *)_cffi_d_clingo_theory_atoms_term_type },
   { "clingo_theory_sequence_type_list", (void *)_cffi_const_clingo_theory_sequence_type_list, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_theory_sequence_type_set", (void *)_cffi_const_clingo_theory_sequence_type_set, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_theory_sequence_type_tuple", (void *)_cffi_const_clingo_theory_sequence_type_tuple, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
@@ -19349,92 +19372,92 @@ static const struct _cffi_global_s _cffi_globals[] = {
   { "clingo_truth_value_false", (void *)_cffi_const_clingo_truth_value_false, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_truth_value_free", (void *)_cffi_const_clingo_truth_value_free, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_truth_value_true", (void *)_cffi_const_clingo_truth_value_true, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_version", (void *)_cffi_f_clingo_version, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1189), (void *)_cffi_d_clingo_version },
+  { "clingo_version", (void *)_cffi_f_clingo_version, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_V, 1191), (void *)_cffi_d_clingo_version },
   { "clingo_warning_atom_undefined", (void *)_cffi_const_clingo_warning_atom_undefined, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_warning_file_included", (void *)_cffi_const_clingo_warning_file_included, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_warning_global_variable", (void *)_cffi_const_clingo_warning_global_variable, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_warning_operation_undefined", (void *)_cffi_const_clingo_warning_operation_undefined, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_warning_other", (void *)_cffi_const_clingo_warning_other, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_warning_runtime_error", (void *)_cffi_const_clingo_warning_runtime_error, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "clingo_warning_string", (void *)_cffi_f_clingo_warning_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1112), (void *)_cffi_d_clingo_warning_string },
+  { "clingo_warning_string", (void *)_cffi_f_clingo_warning_string, _CFFI_OP(_CFFI_OP_CPYTHON_BLTN_O, 1114), (void *)_cffi_d_clingo_warning_string },
   { "clingo_warning_variable_unbounded", (void *)_cffi_const_clingo_warning_variable_unbounded, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_weight_constraint_type_equivalence", (void *)_cffi_const_clingo_weight_constraint_type_equivalence, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_weight_constraint_type_implication_left", (void *)_cffi_const_clingo_weight_constraint_type_implication_left, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
   { "clingo_weight_constraint_type_implication_right", (void *)_cffi_const_clingo_weight_constraint_type_implication_right, _CFFI_OP(_CFFI_OP_ENUM, -1), (void *)0 },
-  { "g_clingo_ast_attribute_names", (void *)_cffi_var_g_clingo_ast_attribute_names, _CFFI_OP(_CFFI_OP_GLOBAL_VAR_F, 1253), (void *)0 },
-  { "g_clingo_ast_constructors", (void *)_cffi_var_g_clingo_ast_constructors, _CFFI_OP(_CFFI_OP_GLOBAL_VAR_F, 1256), (void *)0 },
+  { "g_clingo_ast_attribute_names", (void *)_cffi_var_g_clingo_ast_attribute_names, _CFFI_OP(_CFFI_OP_GLOBAL_VAR_F, 1255), (void *)0 },
+  { "g_clingo_ast_constructors", (void *)_cffi_var_g_clingo_ast_constructors, _CFFI_OP(_CFFI_OP_GLOBAL_VAR_F, 1258), (void *)0 },
   { "pyclingo_application_logger", (void *)&_cffi_externpy__pyclingo_application_logger, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 27), (void *)pyclingo_application_logger },
-  { "pyclingo_application_main", (void *)&_cffi_externpy__pyclingo_application_main, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1218), (void *)pyclingo_application_main },
-  { "pyclingo_application_message_limit", (void *)&_cffi_externpy__pyclingo_application_message_limit, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1311), (void *)pyclingo_application_message_limit },
-  { "pyclingo_application_options_parse", (void *)&_cffi_externpy__pyclingo_application_options_parse, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 660), (void *)pyclingo_application_options_parse },
-  { "pyclingo_application_print_model", (void *)&_cffi_externpy__pyclingo_application_print_model, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1224), (void *)pyclingo_application_print_model },
-  { "pyclingo_application_program_name", (void *)&_cffi_externpy__pyclingo_application_program_name, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1247), (void *)pyclingo_application_program_name },
-  { "pyclingo_application_register_options", (void *)&_cffi_externpy__pyclingo_application_register_options, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1225), (void *)pyclingo_application_register_options },
-  { "pyclingo_application_validate_options", (void *)&_cffi_externpy__pyclingo_application_validate_options, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 588), (void *)pyclingo_application_validate_options },
-  { "pyclingo_application_version", (void *)&_cffi_externpy__pyclingo_application_version, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1247), (void *)pyclingo_application_version },
-  { "pyclingo_ast_callback", (void *)&_cffi_externpy__pyclingo_ast_callback, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1217), (void *)pyclingo_ast_callback },
-  { "pyclingo_call", (void *)&_cffi_externpy__pyclingo_call, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1245), (void *)pyclingo_call },
-  { "pyclingo_callable", (void *)&_cffi_externpy__pyclingo_callable, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1216), (void *)pyclingo_callable },
-  { "pyclingo_execute", (void *)&_cffi_externpy__pyclingo_execute, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1244), (void *)pyclingo_execute },
-  { "pyclingo_ground_callback", (void *)&_cffi_externpy__pyclingo_ground_callback, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 476), (void *)pyclingo_ground_callback },
+  { "pyclingo_application_main", (void *)&_cffi_externpy__pyclingo_application_main, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1220), (void *)pyclingo_application_main },
+  { "pyclingo_application_message_limit", (void *)&_cffi_externpy__pyclingo_application_message_limit, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1313), (void *)pyclingo_application_message_limit },
+  { "pyclingo_application_options_parse", (void *)&_cffi_externpy__pyclingo_application_options_parse, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 662), (void *)pyclingo_application_options_parse },
+  { "pyclingo_application_print_model", (void *)&_cffi_externpy__pyclingo_application_print_model, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1226), (void *)pyclingo_application_print_model },
+  { "pyclingo_application_program_name", (void *)&_cffi_externpy__pyclingo_application_program_name, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1249), (void *)pyclingo_application_program_name },
+  { "pyclingo_application_register_options", (void *)&_cffi_externpy__pyclingo_application_register_options, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1227), (void *)pyclingo_application_register_options },
+  { "pyclingo_application_validate_options", (void *)&_cffi_externpy__pyclingo_application_validate_options, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 590), (void *)pyclingo_application_validate_options },
+  { "pyclingo_application_version", (void *)&_cffi_externpy__pyclingo_application_version, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1249), (void *)pyclingo_application_version },
+  { "pyclingo_ast_callback", (void *)&_cffi_externpy__pyclingo_ast_callback, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1219), (void *)pyclingo_ast_callback },
+  { "pyclingo_call", (void *)&_cffi_externpy__pyclingo_call, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1247), (void *)pyclingo_call },
+  { "pyclingo_callable", (void *)&_cffi_externpy__pyclingo_callable, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1218), (void *)pyclingo_callable },
+  { "pyclingo_execute", (void *)&_cffi_externpy__pyclingo_execute, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1246), (void *)pyclingo_execute },
+  { "pyclingo_ground_callback", (void *)&_cffi_externpy__pyclingo_ground_callback, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 478), (void *)pyclingo_ground_callback },
   { "pyclingo_logger_callback", (void *)&_cffi_externpy__pyclingo_logger_callback, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 27), (void *)pyclingo_logger_callback },
-  { "pyclingo_main", (void *)&_cffi_externpy__pyclingo_main, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1246), (void *)pyclingo_main },
-  { "pyclingo_observer_acyc_edge", (void *)&_cffi_externpy__pyclingo_observer_acyc_edge, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1230), (void *)pyclingo_observer_acyc_edge },
-  { "pyclingo_observer_assume", (void *)&_cffi_externpy__pyclingo_observer_assume, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1231), (void *)pyclingo_observer_assume },
-  { "pyclingo_observer_begin_step", (void *)&_cffi_externpy__pyclingo_observer_begin_step, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 588), (void *)pyclingo_observer_begin_step },
-  { "pyclingo_observer_end_step", (void *)&_cffi_externpy__pyclingo_observer_end_step, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 588), (void *)pyclingo_observer_end_step },
-  { "pyclingo_observer_external", (void *)&_cffi_externpy__pyclingo_observer_external, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1238), (void *)pyclingo_observer_external },
-  { "pyclingo_observer_heuristic", (void *)&_cffi_externpy__pyclingo_observer_heuristic, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1236), (void *)pyclingo_observer_heuristic },
-  { "pyclingo_observer_init_program", (void *)&_cffi_externpy__pyclingo_observer_init_program, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1215), (void *)pyclingo_observer_init_program },
-  { "pyclingo_observer_minimize", (void *)&_cffi_externpy__pyclingo_observer_minimize, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1232), (void *)pyclingo_observer_minimize },
-  { "pyclingo_observer_output_atom", (void *)&_cffi_externpy__pyclingo_observer_output_atom, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1243), (void *)pyclingo_observer_output_atom },
-  { "pyclingo_observer_output_term", (void *)&_cffi_externpy__pyclingo_observer_output_term, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1242), (void *)pyclingo_observer_output_term },
-  { "pyclingo_observer_project", (void *)&_cffi_externpy__pyclingo_observer_project, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1233), (void *)pyclingo_observer_project },
-  { "pyclingo_observer_rule", (void *)&_cffi_externpy__pyclingo_observer_rule, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1213), (void *)pyclingo_observer_rule },
-  { "pyclingo_observer_theory_atom", (void *)&_cffi_externpy__pyclingo_observer_theory_atom, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1241), (void *)pyclingo_observer_theory_atom },
-  { "pyclingo_observer_theory_atom_with_guard", (void *)&_cffi_externpy__pyclingo_observer_theory_atom_with_guard, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1240), (void *)pyclingo_observer_theory_atom_with_guard },
-  { "pyclingo_observer_theory_element", (void *)&_cffi_externpy__pyclingo_observer_theory_element, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1239), (void *)pyclingo_observer_theory_element },
-  { "pyclingo_observer_theory_term_compound", (void *)&_cffi_externpy__pyclingo_observer_theory_term_compound, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1237), (void *)pyclingo_observer_theory_term_compound },
-  { "pyclingo_observer_theory_term_number", (void *)&_cffi_externpy__pyclingo_observer_theory_term_number, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1238), (void *)pyclingo_observer_theory_term_number },
-  { "pyclingo_observer_theory_term_string", (void *)&_cffi_externpy__pyclingo_observer_theory_term_string, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1234), (void *)pyclingo_observer_theory_term_string },
-  { "pyclingo_observer_weight_rule", (void *)&_cffi_externpy__pyclingo_observer_weight_rule, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1214), (void *)pyclingo_observer_weight_rule },
-  { "pyclingo_propagator_check", (void *)&_cffi_externpy__pyclingo_propagator_check, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1227), (void *)pyclingo_propagator_check },
-  { "pyclingo_propagator_decide", (void *)&_cffi_externpy__pyclingo_propagator_decide, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1235), (void *)pyclingo_propagator_decide },
-  { "pyclingo_propagator_init", (void *)&_cffi_externpy__pyclingo_propagator_init, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1228), (void *)pyclingo_propagator_init },
-  { "pyclingo_propagator_propagate", (void *)&_cffi_externpy__pyclingo_propagator_propagate, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1226), (void *)pyclingo_propagator_propagate },
-  { "pyclingo_propagator_undo", (void *)&_cffi_externpy__pyclingo_propagator_undo, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1312), (void *)pyclingo_propagator_undo },
-  { "pyclingo_script_call", (void *)&_cffi_externpy__pyclingo_script_call, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1221), (void *)pyclingo_script_call },
-  { "pyclingo_script_callable", (void *)&_cffi_externpy__pyclingo_script_callable, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1216), (void *)pyclingo_script_callable },
-  { "pyclingo_script_execute", (void *)&_cffi_externpy__pyclingo_script_execute, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1220), (void *)pyclingo_script_execute },
-  { "pyclingo_script_main", (void *)&_cffi_externpy__pyclingo_script_main, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1219), (void *)pyclingo_script_main },
-  { "pyclingo_solve_event_callback", (void *)&_cffi_externpy__pyclingo_solve_event_callback, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 503), (void *)pyclingo_solve_event_callback },
+  { "pyclingo_main", (void *)&_cffi_externpy__pyclingo_main, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1248), (void *)pyclingo_main },
+  { "pyclingo_observer_acyc_edge", (void *)&_cffi_externpy__pyclingo_observer_acyc_edge, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1232), (void *)pyclingo_observer_acyc_edge },
+  { "pyclingo_observer_assume", (void *)&_cffi_externpy__pyclingo_observer_assume, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1233), (void *)pyclingo_observer_assume },
+  { "pyclingo_observer_begin_step", (void *)&_cffi_externpy__pyclingo_observer_begin_step, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 590), (void *)pyclingo_observer_begin_step },
+  { "pyclingo_observer_end_step", (void *)&_cffi_externpy__pyclingo_observer_end_step, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 590), (void *)pyclingo_observer_end_step },
+  { "pyclingo_observer_external", (void *)&_cffi_externpy__pyclingo_observer_external, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1240), (void *)pyclingo_observer_external },
+  { "pyclingo_observer_heuristic", (void *)&_cffi_externpy__pyclingo_observer_heuristic, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1238), (void *)pyclingo_observer_heuristic },
+  { "pyclingo_observer_init_program", (void *)&_cffi_externpy__pyclingo_observer_init_program, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1217), (void *)pyclingo_observer_init_program },
+  { "pyclingo_observer_minimize", (void *)&_cffi_externpy__pyclingo_observer_minimize, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1234), (void *)pyclingo_observer_minimize },
+  { "pyclingo_observer_output_atom", (void *)&_cffi_externpy__pyclingo_observer_output_atom, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1245), (void *)pyclingo_observer_output_atom },
+  { "pyclingo_observer_output_term", (void *)&_cffi_externpy__pyclingo_observer_output_term, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1244), (void *)pyclingo_observer_output_term },
+  { "pyclingo_observer_project", (void *)&_cffi_externpy__pyclingo_observer_project, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1235), (void *)pyclingo_observer_project },
+  { "pyclingo_observer_rule", (void *)&_cffi_externpy__pyclingo_observer_rule, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1215), (void *)pyclingo_observer_rule },
+  { "pyclingo_observer_theory_atom", (void *)&_cffi_externpy__pyclingo_observer_theory_atom, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1243), (void *)pyclingo_observer_theory_atom },
+  { "pyclingo_observer_theory_atom_with_guard", (void *)&_cffi_externpy__pyclingo_observer_theory_atom_with_guard, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1242), (void *)pyclingo_observer_theory_atom_with_guard },
+  { "pyclingo_observer_theory_element", (void *)&_cffi_externpy__pyclingo_observer_theory_element, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1241), (void *)pyclingo_observer_theory_element },
+  { "pyclingo_observer_theory_term_compound", (void *)&_cffi_externpy__pyclingo_observer_theory_term_compound, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1239), (void *)pyclingo_observer_theory_term_compound },
+  { "pyclingo_observer_theory_term_number", (void *)&_cffi_externpy__pyclingo_observer_theory_term_number, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1240), (void *)pyclingo_observer_theory_term_number },
+  { "pyclingo_observer_theory_term_string", (void *)&_cffi_externpy__pyclingo_observer_theory_term_string, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1236), (void *)pyclingo_observer_theory_term_string },
+  { "pyclingo_observer_weight_rule", (void *)&_cffi_externpy__pyclingo_observer_weight_rule, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1216), (void *)pyclingo_observer_weight_rule },
+  { "pyclingo_propagator_check", (void *)&_cffi_externpy__pyclingo_propagator_check, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1229), (void *)pyclingo_propagator_check },
+  { "pyclingo_propagator_decide", (void *)&_cffi_externpy__pyclingo_propagator_decide, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1237), (void *)pyclingo_propagator_decide },
+  { "pyclingo_propagator_init", (void *)&_cffi_externpy__pyclingo_propagator_init, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1230), (void *)pyclingo_propagator_init },
+  { "pyclingo_propagator_propagate", (void *)&_cffi_externpy__pyclingo_propagator_propagate, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1228), (void *)pyclingo_propagator_propagate },
+  { "pyclingo_propagator_undo", (void *)&_cffi_externpy__pyclingo_propagator_undo, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1314), (void *)pyclingo_propagator_undo },
+  { "pyclingo_script_call", (void *)&_cffi_externpy__pyclingo_script_call, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1223), (void *)pyclingo_script_call },
+  { "pyclingo_script_callable", (void *)&_cffi_externpy__pyclingo_script_callable, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1218), (void *)pyclingo_script_callable },
+  { "pyclingo_script_execute", (void *)&_cffi_externpy__pyclingo_script_execute, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1222), (void *)pyclingo_script_execute },
+  { "pyclingo_script_main", (void *)&_cffi_externpy__pyclingo_script_main, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 1221), (void *)pyclingo_script_main },
+  { "pyclingo_solve_event_callback", (void *)&_cffi_externpy__pyclingo_solve_event_callback, _CFFI_OP(_CFFI_OP_EXTERN_PYTHON, 505), (void *)pyclingo_solve_event_callback },
 };
 
 static const struct _cffi_field_s _cffi_fields[] = {
   { "program_name", offsetof(clingo_application_t, program_name),
                     sizeof(((clingo_application_t *)0)->program_name),
-                    _CFFI_OP(_CFFI_OP_NOOP, 1247) },
+                    _CFFI_OP(_CFFI_OP_NOOP, 1249) },
   { "version", offsetof(clingo_application_t, version),
                sizeof(((clingo_application_t *)0)->version),
-               _CFFI_OP(_CFFI_OP_NOOP, 1247) },
+               _CFFI_OP(_CFFI_OP_NOOP, 1249) },
   { "message_limit", offsetof(clingo_application_t, message_limit),
                      sizeof(((clingo_application_t *)0)->message_limit),
-                     _CFFI_OP(_CFFI_OP_NOOP, 1311) },
+                     _CFFI_OP(_CFFI_OP_NOOP, 1313) },
   { "main", offsetof(clingo_application_t, main),
             sizeof(((clingo_application_t *)0)->main),
-            _CFFI_OP(_CFFI_OP_NOOP, 1218) },
+            _CFFI_OP(_CFFI_OP_NOOP, 1220) },
   { "logger", offsetof(clingo_application_t, logger),
               sizeof(((clingo_application_t *)0)->logger),
               _CFFI_OP(_CFFI_OP_NOOP, 27) },
   { "printer", offsetof(clingo_application_t, printer),
                sizeof(((clingo_application_t *)0)->printer),
-               _CFFI_OP(_CFFI_OP_NOOP, 1224) },
+               _CFFI_OP(_CFFI_OP_NOOP, 1226) },
   { "register_options", offsetof(clingo_application_t, register_options),
                         sizeof(((clingo_application_t *)0)->register_options),
-                        _CFFI_OP(_CFFI_OP_NOOP, 1225) },
+                        _CFFI_OP(_CFFI_OP_NOOP, 1227) },
   { "validate_options", offsetof(clingo_application_t, validate_options),
                         sizeof(((clingo_application_t *)0)->validate_options),
-                        _CFFI_OP(_CFFI_OP_NOOP, 588) },
+                        _CFFI_OP(_CFFI_OP_NOOP, 590) },
   { "attribute", offsetof(clingo_ast_argument_t, attribute),
                  sizeof(((clingo_ast_argument_t *)0)->attribute),
                  _CFFI_OP(_CFFI_OP_NOOP, 155) },
@@ -19452,73 +19475,73 @@ static const struct _cffi_field_s _cffi_fields[] = {
             _CFFI_OP(_CFFI_OP_NOOP, 40) },
   { "arguments", offsetof(clingo_ast_constructor_t, arguments),
                  sizeof(((clingo_ast_constructor_t *)0)->arguments),
-                 _CFFI_OP(_CFFI_OP_NOOP, 1251) },
+                 _CFFI_OP(_CFFI_OP_NOOP, 1253) },
   { "size", offsetof(clingo_ast_constructor_t, size),
             sizeof(((clingo_ast_constructor_t *)0)->size),
             _CFFI_OP(_CFFI_OP_NOOP, 3) },
   { "constructors", offsetof(clingo_ast_constructors_t, constructors),
                     sizeof(((clingo_ast_constructors_t *)0)->constructors),
-                    _CFFI_OP(_CFFI_OP_NOOP, 1254) },
+                    _CFFI_OP(_CFFI_OP_NOOP, 1256) },
   { "size", offsetof(clingo_ast_constructors_t, size),
             sizeof(((clingo_ast_constructors_t *)0)->size),
             _CFFI_OP(_CFFI_OP_NOOP, 3) },
   { "init_program", offsetof(clingo_ground_program_observer_t, init_program),
                     sizeof(((clingo_ground_program_observer_t *)0)->init_program),
-                    _CFFI_OP(_CFFI_OP_NOOP, 1215) },
+                    _CFFI_OP(_CFFI_OP_NOOP, 1217) },
   { "begin_step", offsetof(clingo_ground_program_observer_t, begin_step),
                   sizeof(((clingo_ground_program_observer_t *)0)->begin_step),
-                  _CFFI_OP(_CFFI_OP_NOOP, 588) },
+                  _CFFI_OP(_CFFI_OP_NOOP, 590) },
   { "end_step", offsetof(clingo_ground_program_observer_t, end_step),
                 sizeof(((clingo_ground_program_observer_t *)0)->end_step),
-                _CFFI_OP(_CFFI_OP_NOOP, 588) },
+                _CFFI_OP(_CFFI_OP_NOOP, 590) },
   { "rule", offsetof(clingo_ground_program_observer_t, rule),
             sizeof(((clingo_ground_program_observer_t *)0)->rule),
-            _CFFI_OP(_CFFI_OP_NOOP, 1213) },
+            _CFFI_OP(_CFFI_OP_NOOP, 1215) },
   { "weight_rule", offsetof(clingo_ground_program_observer_t, weight_rule),
                    sizeof(((clingo_ground_program_observer_t *)0)->weight_rule),
-                   _CFFI_OP(_CFFI_OP_NOOP, 1214) },
+                   _CFFI_OP(_CFFI_OP_NOOP, 1216) },
   { "minimize", offsetof(clingo_ground_program_observer_t, minimize),
                 sizeof(((clingo_ground_program_observer_t *)0)->minimize),
-                _CFFI_OP(_CFFI_OP_NOOP, 1232) },
+                _CFFI_OP(_CFFI_OP_NOOP, 1234) },
   { "project", offsetof(clingo_ground_program_observer_t, project),
                sizeof(((clingo_ground_program_observer_t *)0)->project),
-               _CFFI_OP(_CFFI_OP_NOOP, 1233) },
+               _CFFI_OP(_CFFI_OP_NOOP, 1235) },
   { "output_atom", offsetof(clingo_ground_program_observer_t, output_atom),
                    sizeof(((clingo_ground_program_observer_t *)0)->output_atom),
-                   _CFFI_OP(_CFFI_OP_NOOP, 1243) },
+                   _CFFI_OP(_CFFI_OP_NOOP, 1245) },
   { "output_term", offsetof(clingo_ground_program_observer_t, output_term),
                    sizeof(((clingo_ground_program_observer_t *)0)->output_term),
-                   _CFFI_OP(_CFFI_OP_NOOP, 1242) },
+                   _CFFI_OP(_CFFI_OP_NOOP, 1244) },
   { "external", offsetof(clingo_ground_program_observer_t, external),
                 sizeof(((clingo_ground_program_observer_t *)0)->external),
-                _CFFI_OP(_CFFI_OP_NOOP, 1238) },
+                _CFFI_OP(_CFFI_OP_NOOP, 1240) },
   { "assume", offsetof(clingo_ground_program_observer_t, assume),
               sizeof(((clingo_ground_program_observer_t *)0)->assume),
-              _CFFI_OP(_CFFI_OP_NOOP, 1231) },
+              _CFFI_OP(_CFFI_OP_NOOP, 1233) },
   { "heuristic", offsetof(clingo_ground_program_observer_t, heuristic),
                  sizeof(((clingo_ground_program_observer_t *)0)->heuristic),
-                 _CFFI_OP(_CFFI_OP_NOOP, 1236) },
+                 _CFFI_OP(_CFFI_OP_NOOP, 1238) },
   { "acyc_edge", offsetof(clingo_ground_program_observer_t, acyc_edge),
                  sizeof(((clingo_ground_program_observer_t *)0)->acyc_edge),
-                 _CFFI_OP(_CFFI_OP_NOOP, 1230) },
+                 _CFFI_OP(_CFFI_OP_NOOP, 1232) },
   { "theory_term_number", offsetof(clingo_ground_program_observer_t, theory_term_number),
                           sizeof(((clingo_ground_program_observer_t *)0)->theory_term_number),
-                          _CFFI_OP(_CFFI_OP_NOOP, 1238) },
+                          _CFFI_OP(_CFFI_OP_NOOP, 1240) },
   { "theory_term_string", offsetof(clingo_ground_program_observer_t, theory_term_string),
                           sizeof(((clingo_ground_program_observer_t *)0)->theory_term_string),
-                          _CFFI_OP(_CFFI_OP_NOOP, 1234) },
+                          _CFFI_OP(_CFFI_OP_NOOP, 1236) },
   { "theory_term_compound", offsetof(clingo_ground_program_observer_t, theory_term_compound),
                             sizeof(((clingo_ground_program_observer_t *)0)->theory_term_compound),
-                            _CFFI_OP(_CFFI_OP_NOOP, 1237) },
+                            _CFFI_OP(_CFFI_OP_NOOP, 1239) },
   { "theory_element", offsetof(clingo_ground_program_observer_t, theory_element),
                       sizeof(((clingo_ground_program_observer_t *)0)->theory_element),
-                      _CFFI_OP(_CFFI_OP_NOOP, 1239) },
+                      _CFFI_OP(_CFFI_OP_NOOP, 1241) },
   { "theory_atom", offsetof(clingo_ground_program_observer_t, theory_atom),
                    sizeof(((clingo_ground_program_observer_t *)0)->theory_atom),
-                   _CFFI_OP(_CFFI_OP_NOOP, 1241) },
+                   _CFFI_OP(_CFFI_OP_NOOP, 1243) },
   { "theory_atom_with_guard", offsetof(clingo_ground_program_observer_t, theory_atom_with_guard),
                               sizeof(((clingo_ground_program_observer_t *)0)->theory_atom_with_guard),
-                              _CFFI_OP(_CFFI_OP_NOOP, 1240) },
+                              _CFFI_OP(_CFFI_OP_NOOP, 1242) },
   { "begin_file", offsetof(clingo_location_t, begin_file),
                   sizeof(((clingo_location_t *)0)->begin_file),
                   _CFFI_OP(_CFFI_OP_NOOP, 40) },
@@ -19548,34 +19571,34 @@ static const struct _cffi_field_s _cffi_fields[] = {
             _CFFI_OP(_CFFI_OP_NOOP, 3) },
   { "init", offsetof(clingo_propagator_t, init),
             sizeof(((clingo_propagator_t *)0)->init),
-            _CFFI_OP(_CFFI_OP_NOOP, 1228) },
+            _CFFI_OP(_CFFI_OP_NOOP, 1230) },
   { "propagate", offsetof(clingo_propagator_t, propagate),
                  sizeof(((clingo_propagator_t *)0)->propagate),
-                 _CFFI_OP(_CFFI_OP_NOOP, 1226) },
+                 _CFFI_OP(_CFFI_OP_NOOP, 1228) },
   { "undo", offsetof(clingo_propagator_t, undo),
             sizeof(((clingo_propagator_t *)0)->undo),
-            _CFFI_OP(_CFFI_OP_NOOP, 1312) },
+            _CFFI_OP(_CFFI_OP_NOOP, 1314) },
   { "check", offsetof(clingo_propagator_t, check),
              sizeof(((clingo_propagator_t *)0)->check),
-             _CFFI_OP(_CFFI_OP_NOOP, 1227) },
+             _CFFI_OP(_CFFI_OP_NOOP, 1229) },
   { "decide", offsetof(clingo_propagator_t, decide),
               sizeof(((clingo_propagator_t *)0)->decide),
-              _CFFI_OP(_CFFI_OP_NOOP, 1235) },
+              _CFFI_OP(_CFFI_OP_NOOP, 1237) },
   { "execute", offsetof(clingo_script_t, execute),
                sizeof(((clingo_script_t *)0)->execute),
-               _CFFI_OP(_CFFI_OP_NOOP, 1223) },
+               _CFFI_OP(_CFFI_OP_NOOP, 1225) },
   { "call", offsetof(clingo_script_t, call),
             sizeof(((clingo_script_t *)0)->call),
-            _CFFI_OP(_CFFI_OP_NOOP, 1222) },
+            _CFFI_OP(_CFFI_OP_NOOP, 1224) },
   { "callable", offsetof(clingo_script_t, callable),
                 sizeof(((clingo_script_t *)0)->callable),
-                _CFFI_OP(_CFFI_OP_NOOP, 1216) },
+                _CFFI_OP(_CFFI_OP_NOOP, 1218) },
   { "main", offsetof(clingo_script_t, main),
             sizeof(((clingo_script_t *)0)->main),
-            _CFFI_OP(_CFFI_OP_NOOP, 1219) },
+            _CFFI_OP(_CFFI_OP_NOOP, 1221) },
   { "free", offsetof(clingo_script_t, free),
             sizeof(((clingo_script_t *)0)->free),
-            _CFFI_OP(_CFFI_OP_NOOP, 1313) },
+            _CFFI_OP(_CFFI_OP_NOOP, 1315) },
   { "version", offsetof(clingo_script_t, version),
                sizeof(((clingo_script_t *)0)->version),
                _CFFI_OP(_CFFI_OP_NOOP, 40) },
@@ -19588,144 +19611,144 @@ static const struct _cffi_field_s _cffi_fields[] = {
 };
 
 static const struct _cffi_struct_union_s _cffi_struct_unions[] = {
-  { "clingo_application", 1249, _CFFI_F_CHECK_FIELDS,
+  { "clingo_application", 1251, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_application_t), offsetof(struct _cffi_align__clingo_application_t, y), 0, 8 },
-  { "clingo_assignment", 1250, _CFFI_F_OPAQUE,
+  { "clingo_assignment", 1252, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_ast", 1257, _CFFI_F_OPAQUE,
+  { "clingo_ast", 1259, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_ast_argument", 1252, _CFFI_F_CHECK_FIELDS,
+  { "clingo_ast_argument", 1254, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_ast_argument_t), offsetof(struct _cffi_align__clingo_ast_argument_t, y), 8, 2 },
-  { "clingo_ast_attribute_names", 1253, _CFFI_F_CHECK_FIELDS,
+  { "clingo_ast_attribute_names", 1255, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_ast_attribute_names_t), offsetof(struct _cffi_align__clingo_ast_attribute_names_t, y), 10, 2 },
-  { "clingo_ast_constructor", 1255, _CFFI_F_CHECK_FIELDS,
+  { "clingo_ast_constructor", 1257, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_ast_constructor_t), offsetof(struct _cffi_align__clingo_ast_constructor_t, y), 12, 3 },
-  { "clingo_ast_constructors", 1256, _CFFI_F_CHECK_FIELDS,
+  { "clingo_ast_constructors", 1258, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_ast_constructors_t), offsetof(struct _cffi_align__clingo_ast_constructors_t, y), 15, 2 },
-  { "clingo_backend", 1258, _CFFI_F_OPAQUE,
+  { "clingo_backend", 1260, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_configuration", 1259, _CFFI_F_OPAQUE,
+  { "clingo_configuration", 1261, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_control", 1260, _CFFI_F_OPAQUE,
+  { "clingo_control", 1262, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_ground_program_observer", 1261, _CFFI_F_CHECK_FIELDS,
+  { "clingo_ground_program_observer", 1263, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_ground_program_observer_t), offsetof(struct _cffi_align__clingo_ground_program_observer_t, y), 17, 19 },
-  { "clingo_location", 1262, _CFFI_F_CHECK_FIELDS,
+  { "clingo_location", 1264, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_location_t), offsetof(struct _cffi_align__clingo_location_t, y), 36, 6 },
-  { "clingo_model", 1263, _CFFI_F_OPAQUE,
+  { "clingo_model", 1265, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_options", 1264, _CFFI_F_OPAQUE,
+  { "clingo_options", 1266, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_part", 1265, _CFFI_F_CHECK_FIELDS,
+  { "clingo_part", 1267, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_part_t), offsetof(struct _cffi_align__clingo_part_t, y), 42, 3 },
-  { "clingo_program_builder", 1266, _CFFI_F_OPAQUE,
+  { "clingo_program_builder", 1268, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_propagate_control", 1267, _CFFI_F_OPAQUE,
+  { "clingo_propagate_control", 1269, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_propagate_init", 1268, _CFFI_F_OPAQUE,
+  { "clingo_propagate_init", 1270, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_propagator", 1269, _CFFI_F_CHECK_FIELDS,
+  { "clingo_propagator", 1271, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_propagator_t), offsetof(struct _cffi_align__clingo_propagator_t, y), 45, 5 },
-  { "clingo_script", 1270, _CFFI_F_CHECK_FIELDS,
+  { "clingo_script", 1272, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_script_t), offsetof(struct _cffi_align__clingo_script_t, y), 50, 6 },
-  { "clingo_solve_control", 1271, _CFFI_F_OPAQUE,
+  { "clingo_solve_control", 1273, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_solve_handle", 1272, _CFFI_F_OPAQUE,
+  { "clingo_solve_handle", 1274, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_statistic", 1273, _CFFI_F_OPAQUE,
+  { "clingo_statistic", 1275, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_symbolic_atoms", 1274, _CFFI_F_OPAQUE,
+  { "clingo_symbolic_atoms", 1276, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_theory_atoms", 1275, _CFFI_F_OPAQUE,
+  { "clingo_theory_atoms", 1277, _CFFI_F_OPAQUE,
     (size_t)-1, -1, -1, 0 /* opaque */ },
-  { "clingo_weighted_literal", 1276, _CFFI_F_CHECK_FIELDS,
+  { "clingo_weighted_literal", 1278, _CFFI_F_CHECK_FIELDS,
     sizeof(clingo_weighted_literal_t), offsetof(struct _cffi_align__clingo_weighted_literal_t, y), 56, 2 },
 };
 
 static const struct _cffi_enum_s _cffi_enums[] = {
-  { "clingo_ast_aggregate_function_e", 1277, _cffi_prim_int(sizeof(enum clingo_ast_aggregate_function_e), ((enum clingo_ast_aggregate_function_e)-1) <= 0),
+  { "clingo_ast_aggregate_function_e", 1279, _cffi_prim_int(sizeof(enum clingo_ast_aggregate_function_e), ((enum clingo_ast_aggregate_function_e)-1) <= 0),
     "clingo_ast_aggregate_function_count,clingo_ast_aggregate_function_sum,clingo_ast_aggregate_function_sump,clingo_ast_aggregate_function_min,clingo_ast_aggregate_function_max" },
-  { "clingo_ast_attribute_e", 1278, _cffi_prim_int(sizeof(enum clingo_ast_attribute_e), ((enum clingo_ast_attribute_e)-1) <= 0),
+  { "clingo_ast_attribute_e", 1280, _cffi_prim_int(sizeof(enum clingo_ast_attribute_e), ((enum clingo_ast_attribute_e)-1) <= 0),
     "clingo_ast_attribute_argument,clingo_ast_attribute_arguments,clingo_ast_attribute_arity,clingo_ast_attribute_atom,clingo_ast_attribute_atoms,clingo_ast_attribute_atom_type,clingo_ast_attribute_bias,clingo_ast_attribute_body,clingo_ast_attribute_code,clingo_ast_attribute_coefficient,clingo_ast_attribute_comparison,clingo_ast_attribute_condition,clingo_ast_attribute_elements,clingo_ast_attribute_external,clingo_ast_attribute_external_type,clingo_ast_attribute_function,clingo_ast_attribute_guard,clingo_ast_attribute_guards,clingo_ast_attribute_head,clingo_ast_attribute_is_default,clingo_ast_attribute_left,clingo_ast_attribute_left_guard,clingo_ast_attribute_literal,clingo_ast_attribute_location,clingo_ast_attribute_modifier,clingo_ast_attribute_name,clingo_ast_attribute_node_u,clingo_ast_attribute_node_v,clingo_ast_attribute_operator_name,clingo_ast_attribute_operator_type,clingo_ast_attribute_operators,clingo_ast_attribute_parameters,clingo_ast_attribute_positive,clingo_ast_attribute_priority,clingo_ast_attribute_right,clingo_ast_attribute_right_guard,clingo_ast_attribute_sequence_type,clingo_ast_attribute_sign,clingo_ast_attribute_symbol,clingo_ast_attribute_term,clingo_ast_attribute_terms,clingo_ast_attribute_value,clingo_ast_attribute_variable,clingo_ast_attribute_weight,clingo_ast_attribute_comment_type" },
-  { "clingo_ast_attribute_type_e", 1279, _cffi_prim_int(sizeof(enum clingo_ast_attribute_type_e), ((enum clingo_ast_attribute_type_e)-1) <= 0),
+  { "clingo_ast_attribute_type_e", 1281, _cffi_prim_int(sizeof(enum clingo_ast_attribute_type_e), ((enum clingo_ast_attribute_type_e)-1) <= 0),
     "clingo_ast_attribute_type_number,clingo_ast_attribute_type_symbol,clingo_ast_attribute_type_location,clingo_ast_attribute_type_string,clingo_ast_attribute_type_ast,clingo_ast_attribute_type_optional_ast,clingo_ast_attribute_type_string_array,clingo_ast_attribute_type_ast_array" },
-  { "clingo_ast_binary_operator_e", 1280, _cffi_prim_int(sizeof(enum clingo_ast_binary_operator_e), ((enum clingo_ast_binary_operator_e)-1) <= 0),
+  { "clingo_ast_binary_operator_e", 1282, _cffi_prim_int(sizeof(enum clingo_ast_binary_operator_e), ((enum clingo_ast_binary_operator_e)-1) <= 0),
     "clingo_ast_binary_operator_xor,clingo_ast_binary_operator_or,clingo_ast_binary_operator_and,clingo_ast_binary_operator_plus,clingo_ast_binary_operator_minus,clingo_ast_binary_operator_multiplication,clingo_ast_binary_operator_division,clingo_ast_binary_operator_modulo,clingo_ast_binary_operator_power" },
-  { "clingo_ast_comparison_operator_e", 1281, _cffi_prim_int(sizeof(enum clingo_ast_comparison_operator_e), ((enum clingo_ast_comparison_operator_e)-1) <= 0),
+  { "clingo_ast_comparison_operator_e", 1283, _cffi_prim_int(sizeof(enum clingo_ast_comparison_operator_e), ((enum clingo_ast_comparison_operator_e)-1) <= 0),
     "clingo_ast_comparison_operator_greater_than,clingo_ast_comparison_operator_less_than,clingo_ast_comparison_operator_less_equal,clingo_ast_comparison_operator_greater_equal,clingo_ast_comparison_operator_not_equal,clingo_ast_comparison_operator_equal" },
-  { "clingo_ast_sign_e", 1282, _cffi_prim_int(sizeof(enum clingo_ast_sign_e), ((enum clingo_ast_sign_e)-1) <= 0),
+  { "clingo_ast_sign_e", 1284, _cffi_prim_int(sizeof(enum clingo_ast_sign_e), ((enum clingo_ast_sign_e)-1) <= 0),
     "clingo_ast_sign_no_sign,clingo_ast_sign_negation,clingo_ast_sign_double_negation" },
-  { "clingo_ast_theory_atom_definition_type_e", 1283, _cffi_prim_int(sizeof(enum clingo_ast_theory_atom_definition_type_e), ((enum clingo_ast_theory_atom_definition_type_e)-1) <= 0),
+  { "clingo_ast_theory_atom_definition_type_e", 1285, _cffi_prim_int(sizeof(enum clingo_ast_theory_atom_definition_type_e), ((enum clingo_ast_theory_atom_definition_type_e)-1) <= 0),
     "clingo_ast_theory_atom_definition_type_head,clingo_ast_theory_atom_definition_type_body,clingo_ast_theory_atom_definition_type_any,clingo_ast_theory_atom_definition_type_directive" },
-  { "clingo_ast_theory_operator_type_e", 1284, _cffi_prim_int(sizeof(enum clingo_ast_theory_operator_type_e), ((enum clingo_ast_theory_operator_type_e)-1) <= 0),
+  { "clingo_ast_theory_operator_type_e", 1286, _cffi_prim_int(sizeof(enum clingo_ast_theory_operator_type_e), ((enum clingo_ast_theory_operator_type_e)-1) <= 0),
     "clingo_ast_theory_operator_type_unary,clingo_ast_theory_operator_type_binary_left,clingo_ast_theory_operator_type_binary_right" },
-  { "clingo_ast_theory_sequence_type_e", 1285, _cffi_prim_int(sizeof(enum clingo_ast_theory_sequence_type_e), ((enum clingo_ast_theory_sequence_type_e)-1) <= 0),
+  { "clingo_ast_theory_sequence_type_e", 1287, _cffi_prim_int(sizeof(enum clingo_ast_theory_sequence_type_e), ((enum clingo_ast_theory_sequence_type_e)-1) <= 0),
     "clingo_ast_theory_sequence_type_tuple,clingo_ast_theory_sequence_type_list,clingo_ast_theory_sequence_type_set" },
-  { "clingo_ast_type_e", 1286, _cffi_prim_int(sizeof(enum clingo_ast_type_e), ((enum clingo_ast_type_e)-1) <= 0),
+  { "clingo_ast_type_e", 1288, _cffi_prim_int(sizeof(enum clingo_ast_type_e), ((enum clingo_ast_type_e)-1) <= 0),
     "clingo_ast_type_id,clingo_ast_type_variable,clingo_ast_type_symbolic_term,clingo_ast_type_unary_operation,clingo_ast_type_binary_operation,clingo_ast_type_interval,clingo_ast_type_function,clingo_ast_type_pool,clingo_ast_type_boolean_constant,clingo_ast_type_symbolic_atom,clingo_ast_type_comparison,clingo_ast_type_guard,clingo_ast_type_conditional_literal,clingo_ast_type_aggregate,clingo_ast_type_body_aggregate_element,clingo_ast_type_body_aggregate,clingo_ast_type_head_aggregate_element,clingo_ast_type_head_aggregate,clingo_ast_type_disjunction,clingo_ast_type_theory_sequence,clingo_ast_type_theory_function,clingo_ast_type_theory_unparsed_term_element,clingo_ast_type_theory_unparsed_term,clingo_ast_type_theory_guard,clingo_ast_type_theory_atom_element,clingo_ast_type_theory_atom,clingo_ast_type_literal,clingo_ast_type_theory_operator_definition,clingo_ast_type_theory_term_definition,clingo_ast_type_theory_guard_definition,clingo_ast_type_theory_atom_definition,clingo_ast_type_rule,clingo_ast_type_definition,clingo_ast_type_show_signature,clingo_ast_type_show_term,clingo_ast_type_minimize,clingo_ast_type_script,clingo_ast_type_program,clingo_ast_type_external,clingo_ast_type_edge,clingo_ast_type_heuristic,clingo_ast_type_project_atom,clingo_ast_type_project_signature,clingo_ast_type_defined,clingo_ast_type_theory_definition,clingo_ast_type_comment" },
-  { "clingo_ast_unary_operator_e", 1287, _cffi_prim_int(sizeof(enum clingo_ast_unary_operator_e), ((enum clingo_ast_unary_operator_e)-1) <= 0),
+  { "clingo_ast_unary_operator_e", 1289, _cffi_prim_int(sizeof(enum clingo_ast_unary_operator_e), ((enum clingo_ast_unary_operator_e)-1) <= 0),
     "clingo_ast_unary_operator_minus,clingo_ast_unary_operator_negation,clingo_ast_unary_operator_absolute" },
-  { "clingo_ast_unpool_type_e", 1288, _cffi_prim_int(sizeof(enum clingo_ast_unpool_type_e), ((enum clingo_ast_unpool_type_e)-1) <= 0),
+  { "clingo_ast_unpool_type_e", 1290, _cffi_prim_int(sizeof(enum clingo_ast_unpool_type_e), ((enum clingo_ast_unpool_type_e)-1) <= 0),
     "clingo_ast_unpool_type_condition,clingo_ast_unpool_type_other,clingo_ast_unpool_type_all" },
-  { "clingo_clause_type_e", 1289, _cffi_prim_int(sizeof(enum clingo_clause_type_e), ((enum clingo_clause_type_e)-1) <= 0),
+  { "clingo_clause_type_e", 1291, _cffi_prim_int(sizeof(enum clingo_clause_type_e), ((enum clingo_clause_type_e)-1) <= 0),
     "clingo_clause_type_learnt,clingo_clause_type_static,clingo_clause_type_volatile,clingo_clause_type_volatile_static" },
-  { "clingo_comment_type_e", 1290, _cffi_prim_int(sizeof(enum clingo_comment_type_e), ((enum clingo_comment_type_e)-1) <= 0),
+  { "clingo_comment_type_e", 1292, _cffi_prim_int(sizeof(enum clingo_comment_type_e), ((enum clingo_comment_type_e)-1) <= 0),
     "clingo_comment_type_line,clingo_comment_type_block" },
-  { "clingo_configuration_type_e", 1291, _cffi_prim_int(sizeof(enum clingo_configuration_type_e), ((enum clingo_configuration_type_e)-1) <= 0),
+  { "clingo_configuration_type_e", 1293, _cffi_prim_int(sizeof(enum clingo_configuration_type_e), ((enum clingo_configuration_type_e)-1) <= 0),
     "clingo_configuration_type_value,clingo_configuration_type_array,clingo_configuration_type_map" },
-  { "clingo_consequence_e", 1292, _cffi_prim_int(sizeof(enum clingo_consequence_e), ((enum clingo_consequence_e)-1) <= 0),
+  { "clingo_consequence_e", 1294, _cffi_prim_int(sizeof(enum clingo_consequence_e), ((enum clingo_consequence_e)-1) <= 0),
     "clingo_consequence_false,clingo_consequence_true,clingo_consequence_unknown" },
-  { "clingo_error_e", 1293, _cffi_prim_int(sizeof(enum clingo_error_e), ((enum clingo_error_e)-1) <= 0),
+  { "clingo_error_e", 1295, _cffi_prim_int(sizeof(enum clingo_error_e), ((enum clingo_error_e)-1) <= 0),
     "clingo_error_success,clingo_error_runtime,clingo_error_logic,clingo_error_bad_alloc,clingo_error_unknown" },
-  { "clingo_external_type_e", 1294, _cffi_prim_int(sizeof(enum clingo_external_type_e), ((enum clingo_external_type_e)-1) <= 0),
+  { "clingo_external_type_e", 1296, _cffi_prim_int(sizeof(enum clingo_external_type_e), ((enum clingo_external_type_e)-1) <= 0),
     "clingo_external_type_free,clingo_external_type_true,clingo_external_type_false,clingo_external_type_release" },
-  { "clingo_heuristic_type_e", 1295, _cffi_prim_int(sizeof(enum clingo_heuristic_type_e), ((enum clingo_heuristic_type_e)-1) <= 0),
+  { "clingo_heuristic_type_e", 1297, _cffi_prim_int(sizeof(enum clingo_heuristic_type_e), ((enum clingo_heuristic_type_e)-1) <= 0),
     "clingo_heuristic_type_level,clingo_heuristic_type_sign,clingo_heuristic_type_factor,clingo_heuristic_type_init,clingo_heuristic_type_true,clingo_heuristic_type_false" },
-  { "clingo_model_type_e", 1296, _cffi_prim_int(sizeof(enum clingo_model_type_e), ((enum clingo_model_type_e)-1) <= 0),
+  { "clingo_model_type_e", 1298, _cffi_prim_int(sizeof(enum clingo_model_type_e), ((enum clingo_model_type_e)-1) <= 0),
     "clingo_model_type_stable_model,clingo_model_type_brave_consequences,clingo_model_type_cautious_consequences" },
-  { "clingo_propagator_check_mode_e", 1297, _cffi_prim_int(sizeof(enum clingo_propagator_check_mode_e), ((enum clingo_propagator_check_mode_e)-1) <= 0),
+  { "clingo_propagator_check_mode_e", 1299, _cffi_prim_int(sizeof(enum clingo_propagator_check_mode_e), ((enum clingo_propagator_check_mode_e)-1) <= 0),
     "clingo_propagator_check_mode_none,clingo_propagator_check_mode_total,clingo_propagator_check_mode_fixpoint,clingo_propagator_check_mode_both" },
-  { "clingo_propagator_undo_mode_e", 1298, _cffi_prim_int(sizeof(enum clingo_propagator_undo_mode_e), ((enum clingo_propagator_undo_mode_e)-1) <= 0),
+  { "clingo_propagator_undo_mode_e", 1300, _cffi_prim_int(sizeof(enum clingo_propagator_undo_mode_e), ((enum clingo_propagator_undo_mode_e)-1) <= 0),
     "clingo_propagator_undo_mode_default,clingo_propagator_undo_mode_always" },
-  { "clingo_show_type_e", 1299, _cffi_prim_int(sizeof(enum clingo_show_type_e), ((enum clingo_show_type_e)-1) <= 0),
+  { "clingo_show_type_e", 1301, _cffi_prim_int(sizeof(enum clingo_show_type_e), ((enum clingo_show_type_e)-1) <= 0),
     "clingo_show_type_shown,clingo_show_type_atoms,clingo_show_type_terms,clingo_show_type_theory,clingo_show_type_all,clingo_show_type_complement" },
-  { "clingo_solve_event_type_e", 1300, _cffi_prim_int(sizeof(enum clingo_solve_event_type_e), ((enum clingo_solve_event_type_e)-1) <= 0),
+  { "clingo_solve_event_type_e", 1302, _cffi_prim_int(sizeof(enum clingo_solve_event_type_e), ((enum clingo_solve_event_type_e)-1) <= 0),
     "clingo_solve_event_type_model,clingo_solve_event_type_unsat,clingo_solve_event_type_statistics,clingo_solve_event_type_finish" },
-  { "clingo_solve_mode_e", 1301, _cffi_prim_int(sizeof(enum clingo_solve_mode_e), ((enum clingo_solve_mode_e)-1) <= 0),
+  { "clingo_solve_mode_e", 1303, _cffi_prim_int(sizeof(enum clingo_solve_mode_e), ((enum clingo_solve_mode_e)-1) <= 0),
     "clingo_solve_mode_async,clingo_solve_mode_yield" },
-  { "clingo_solve_result_e", 1302, _cffi_prim_int(sizeof(enum clingo_solve_result_e), ((enum clingo_solve_result_e)-1) <= 0),
+  { "clingo_solve_result_e", 1304, _cffi_prim_int(sizeof(enum clingo_solve_result_e), ((enum clingo_solve_result_e)-1) <= 0),
     "clingo_solve_result_satisfiable,clingo_solve_result_unsatisfiable,clingo_solve_result_exhausted,clingo_solve_result_interrupted" },
-  { "clingo_statistics_type_e", 1303, _cffi_prim_int(sizeof(enum clingo_statistics_type_e), ((enum clingo_statistics_type_e)-1) <= 0),
+  { "clingo_statistics_type_e", 1305, _cffi_prim_int(sizeof(enum clingo_statistics_type_e), ((enum clingo_statistics_type_e)-1) <= 0),
     "clingo_statistics_type_empty,clingo_statistics_type_value,clingo_statistics_type_array,clingo_statistics_type_map" },
-  { "clingo_symbol_type_e", 1304, _cffi_prim_int(sizeof(enum clingo_symbol_type_e), ((enum clingo_symbol_type_e)-1) <= 0),
+  { "clingo_symbol_type_e", 1306, _cffi_prim_int(sizeof(enum clingo_symbol_type_e), ((enum clingo_symbol_type_e)-1) <= 0),
     "clingo_symbol_type_infimum,clingo_symbol_type_number,clingo_symbol_type_string,clingo_symbol_type_function,clingo_symbol_type_supremum" },
-  { "clingo_theory_sequence_type_e", 1305, _cffi_prim_int(sizeof(enum clingo_theory_sequence_type_e), ((enum clingo_theory_sequence_type_e)-1) <= 0),
-    "clingo_theory_sequence_type_tuple,clingo_theory_sequence_type_list,clingo_theory_sequence_type_set" },
-  { "clingo_theory_term_type_e", 1306, _cffi_prim_int(sizeof(enum clingo_theory_term_type_e), ((enum clingo_theory_term_type_e)-1) <= 0),
+  { "clingo_theory_sequence_type_e", 1307, _cffi_prim_int(sizeof(enum clingo_theory_sequence_type_e), ((enum clingo_theory_sequence_type_e)-1) <= 0),
+    "clingo_theory_sequence_type_tuple,clingo_theory_sequence_type_set,clingo_theory_sequence_type_list" },
+  { "clingo_theory_term_type_e", 1308, _cffi_prim_int(sizeof(enum clingo_theory_term_type_e), ((enum clingo_theory_term_type_e)-1) <= 0),
     "clingo_theory_term_type_tuple,clingo_theory_term_type_list,clingo_theory_term_type_set,clingo_theory_term_type_function,clingo_theory_term_type_number,clingo_theory_term_type_symbol" },
-  { "clingo_truth_value_e", 1307, _cffi_prim_int(sizeof(enum clingo_truth_value_e), ((enum clingo_truth_value_e)-1) <= 0),
+  { "clingo_truth_value_e", 1309, _cffi_prim_int(sizeof(enum clingo_truth_value_e), ((enum clingo_truth_value_e)-1) <= 0),
     "clingo_truth_value_free,clingo_truth_value_true,clingo_truth_value_false" },
-  { "clingo_warning_e", 1308, _cffi_prim_int(sizeof(enum clingo_warning_e), ((enum clingo_warning_e)-1) <= 0),
+  { "clingo_warning_e", 1310, _cffi_prim_int(sizeof(enum clingo_warning_e), ((enum clingo_warning_e)-1) <= 0),
     "clingo_warning_operation_undefined,clingo_warning_runtime_error,clingo_warning_atom_undefined,clingo_warning_file_included,clingo_warning_variable_unbounded,clingo_warning_global_variable,clingo_warning_other" },
-  { "clingo_weight_constraint_type_e", 1309, _cffi_prim_int(sizeof(enum clingo_weight_constraint_type_e), ((enum clingo_weight_constraint_type_e)-1) <= 0),
+  { "clingo_weight_constraint_type_e", 1311, _cffi_prim_int(sizeof(enum clingo_weight_constraint_type_e), ((enum clingo_weight_constraint_type_e)-1) <= 0),
     "clingo_weight_constraint_type_implication_left,clingo_weight_constraint_type_implication_right,clingo_weight_constraint_type_equivalence" },
 };
 
 static const struct _cffi_typename_s _cffi_typenames[] = {
-  { "clingo_application_t", 1249 },
-  { "clingo_assignment_t", 1250 },
+  { "clingo_application_t", 1251 },
+  { "clingo_assignment_t", 1252 },
   { "clingo_ast_aggregate_function_t", 155 },
-  { "clingo_ast_argument_t", 1252 },
-  { "clingo_ast_attribute_names_t", 1253 },
+  { "clingo_ast_argument_t", 1254 },
+  { "clingo_ast_attribute_names_t", 1255 },
   { "clingo_ast_attribute_t", 155 },
   { "clingo_ast_attribute_type_t", 155 },
   { "clingo_ast_binary_operator_t", 155 },
   { "clingo_ast_callback_t", 24 },
   { "clingo_ast_comparison_operator_t", 155 },
-  { "clingo_ast_constructor_t", 1255 },
-  { "clingo_ast_constructors_t", 1256 },
+  { "clingo_ast_constructor_t", 1257 },
+  { "clingo_ast_constructors_t", 1258 },
   { "clingo_ast_sign_t", 155 },
-  { "clingo_ast_t", 1257 },
+  { "clingo_ast_t", 1259 },
   { "clingo_ast_theory_atom_definition_type_t", 155 },
   { "clingo_ast_theory_operator_type_t", 155 },
   { "clingo_ast_theory_sequence_type_t", 155 },
@@ -19733,63 +19756,63 @@ static const struct _cffi_typename_s _cffi_typenames[] = {
   { "clingo_ast_unary_operator_t", 155 },
   { "clingo_ast_unpool_type_bitset_t", 155 },
   { "clingo_atom_t", 69 },
-  { "clingo_backend_t", 1258 },
+  { "clingo_backend_t", 1260 },
   { "clingo_clause_type_t", 155 },
   { "clingo_comment_type_t", 155 },
-  { "clingo_configuration_t", 1259 },
+  { "clingo_configuration_t", 1261 },
   { "clingo_configuration_type_bitset_t", 29 },
   { "clingo_consequence_t", 155 },
-  { "clingo_control_t", 1260 },
-  { "clingo_default_model_printer_t", 588 },
+  { "clingo_control_t", 1262 },
+  { "clingo_default_model_printer_t", 590 },
   { "clingo_error_t", 155 },
   { "clingo_external_type_t", 155 },
-  { "clingo_ground_callback_t", 476 },
-  { "clingo_ground_program_observer_t", 1261 },
+  { "clingo_ground_callback_t", 478 },
+  { "clingo_ground_program_observer_t", 1263 },
   { "clingo_heuristic_type_t", 155 },
   { "clingo_id_t", 69 },
   { "clingo_literal_t", 12 },
-  { "clingo_location_t", 1262 },
+  { "clingo_location_t", 1264 },
   { "clingo_logger_t", 27 },
-  { "clingo_main_function_t", 1218 },
-  { "clingo_model_printer_t", 1224 },
-  { "clingo_model_t", 1263 },
+  { "clingo_main_function_t", 1220 },
+  { "clingo_model_printer_t", 1226 },
+  { "clingo_model_t", 1265 },
   { "clingo_model_type_t", 155 },
-  { "clingo_options_t", 1264 },
-  { "clingo_part_t", 1265 },
-  { "clingo_program_builder_t", 1266 },
-  { "clingo_propagate_control_t", 1267 },
-  { "clingo_propagate_init_t", 1268 },
-  { "clingo_propagator_check_callback_t", 1227 },
+  { "clingo_options_t", 1266 },
+  { "clingo_part_t", 1267 },
+  { "clingo_program_builder_t", 1268 },
+  { "clingo_propagate_control_t", 1269 },
+  { "clingo_propagate_init_t", 1270 },
+  { "clingo_propagator_check_callback_t", 1229 },
   { "clingo_propagator_check_mode_t", 155 },
-  { "clingo_propagator_init_callback_t", 1228 },
-  { "clingo_propagator_propagate_callback_t", 1226 },
-  { "clingo_propagator_t", 1269 },
-  { "clingo_propagator_undo_callback_t", 1312 },
+  { "clingo_propagator_init_callback_t", 1230 },
+  { "clingo_propagator_propagate_callback_t", 1228 },
+  { "clingo_propagator_t", 1271 },
+  { "clingo_propagator_undo_callback_t", 1314 },
   { "clingo_propagator_undo_mode_t", 155 },
-  { "clingo_script_t", 1270 },
+  { "clingo_script_t", 1272 },
   { "clingo_show_type_bitset_t", 29 },
   { "clingo_signature_t", 246 },
-  { "clingo_solve_control_t", 1271 },
-  { "clingo_solve_event_callback_t", 503 },
+  { "clingo_solve_control_t", 1273 },
+  { "clingo_solve_event_callback_t", 505 },
   { "clingo_solve_event_type_t", 29 },
-  { "clingo_solve_handle_t", 1272 },
+  { "clingo_solve_handle_t", 1274 },
   { "clingo_solve_mode_bitset_t", 29 },
   { "clingo_solve_result_bitset_t", 29 },
-  { "clingo_statistics_t", 1273 },
+  { "clingo_statistics_t", 1275 },
   { "clingo_statistics_type_t", 155 },
-  { "clingo_symbol_callback_t", 559 },
+  { "clingo_symbol_callback_t", 561 },
   { "clingo_symbol_t", 246 },
   { "clingo_symbol_type_t", 155 },
   { "clingo_symbolic_atom_iterator_t", 246 },
-  { "clingo_symbolic_atoms_t", 1274 },
-  { "clingo_theory_atoms_t", 1275 },
+  { "clingo_symbolic_atoms_t", 1276 },
+  { "clingo_theory_atoms_t", 1277 },
   { "clingo_theory_sequence_type_t", 155 },
   { "clingo_theory_term_type_t", 155 },
   { "clingo_truth_value_t", 155 },
   { "clingo_warning_t", 155 },
   { "clingo_weight_constraint_type_t", 155 },
   { "clingo_weight_t", 12 },
-  { "clingo_weighted_literal_t", 1276 },
+  { "clingo_weighted_literal_t", 1278 },
 };
 
 static const struct _cffi_type_context_s _cffi_type_context = {
@@ -19804,7 +19827,7 @@ static const struct _cffi_type_context_s _cffi_type_context = {
   33,  /* num_enums */
   78,  /* num_typenames */
   NULL,  /* no includes */
-  1315,  /* num_types */
+  1317,  /* num_types */
   1,  /* flags */
 };
 

--- a/libpyclingo/clingo/backend.py
+++ b/libpyclingo/clingo/backend.py
@@ -897,9 +897,7 @@ class Backend(ContextManager["Backend"]):
             handler=self._error,
         )
 
-    def add_theory_element(
-        self, terms: Sequence[int], condition: Sequence[int]
-    ) -> None:
+    def add_theory_element(self, terms: Sequence[int], condition: Sequence[int]) -> int:
         """
         Create a theory atom element.
 
@@ -926,67 +924,84 @@ class Backend(ContextManager["Backend"]):
         )
 
     def add_theory_atom(
-        self, atom_id_or_zero: int, term_id: int, elements: Sequence[int]
-    ) -> None:
+        self,
+        term_id: int,
+        elements: Sequence[int],
+        atom_id_or_zero: Optional[int] = None,
+    ) -> int:
         """
         Add a theory atom without a guard.
 
-        Note that if an equivalent theory atom already exists, the given atom
-        is ignored. To declare a defined theory atom, a rule defining the atom
-        should be added. Otherwise, the theory atom is consider an external
+        If no atom_id is given, a fresh atom id is assigned.
+
+        In case an atom id is given and an equivalent theory atom already
+        exists, the given atom id is ignored.
+
+        To declare a defined theory atom, a rule defining the program atom
+        should be added. Otherwise, the theory atom is considered an external
         body occurrence.
 
         Parameters
         ----------
-        atom_id_or_zero
-            A program atom or zero for theory directives.
         term_id
             The id of the term associated with the theory atom.
         elements
             A sequence of ids of theory atom elements.
+        atom_id_or_zero
+            An optional program atom or zero for theory directives.
         """
-        _handle_error(
-            _lib.clingo_backend_theory_atom(
-                self._rep, atom_id_or_zero, term_id, elements, len(elements)
-            )
+        if atom_id_or_zero is None:
+            atom_id_or_zero = 2**32
+        return _c_call(
+            "clingo_atom_t",
+            _lib.clingo_backend_theory_atom,
+            self._rep,
+            atom_id_or_zero,
+            term_id,
+            elements,
+            len(elements),
+            handler=self._error,
         )
 
     def add_theory_atom_with_guard(
         self,
-        atom_id_or_zero: int,
         term_id: int,
         elements: Sequence[int],
         operator: str,
         right_hand_side_id: int,
+        atom_id_or_zero: Optional[int] = None,
     ) -> None:
         """
         Add a theory atom with a guard.
 
         Parameters
         ----------
-        atom_id_or_zero
-            A program atom or zero for theory directives.
         term_id
             The id of the term associated with the theory atom.
         elements
             A sequence of ids of theory atom elements.
-        operator:
+        operator
             String representing a theory operator.
-        right_hand_side_id:
+        right_hand_side_id
             Term id for the term on the right hand side.
+        atom_id_or_zero
+            A optional program atom or zero for theory directives.
 
         See Also
         --------
         Backend.add_theory_atom
         """
-        _handle_error(
-            _lib.clingo_backend_theory_atom_with_guard(
-                self._rep,
-                atom_id_or_zero,
-                term_id,
-                elements,
-                len(elements),
-                operator.encode(),
-                right_hand_side_id,
-            )
+        if atom_id_or_zero is None:
+            atom_id_or_zero = 2**32
+        return _c_call(
+            "clingo_atom_t",
+            _lib.clingo_backend_theory_atom_with_guard,
+            self._rep,
+            atom_id_or_zero,
+            term_id,
+            elements,
+            len(elements),
+            operator.encode(),
+            right_hand_side_id,
+            handler=self._error,
         )

--- a/libpyclingo/clingo/backend.py
+++ b/libpyclingo/clingo/backend.py
@@ -951,7 +951,7 @@ class Backend(ContextManager["Backend"]):
             An optional program atom or zero for theory directives.
         """
         if atom_id_or_zero is None:
-            atom_id_or_zero = 2**32
+            atom_id_or_zero = 0xffffffff
         return _c_call(
             "clingo_atom_t",
             _lib.clingo_backend_theory_atom,
@@ -970,7 +970,7 @@ class Backend(ContextManager["Backend"]):
         operator: str,
         right_hand_side_id: int,
         atom_id_or_zero: Optional[int] = None,
-    ) -> None:
+    ) -> int:
         """
         Add a theory atom with a guard.
 
@@ -992,7 +992,7 @@ class Backend(ContextManager["Backend"]):
         Backend.add_theory_atom
         """
         if atom_id_or_zero is None:
-            atom_id_or_zero = 2**32
+            atom_id_or_zero = 0xffffffff
         return _c_call(
             "clingo_atom_t",
             _lib.clingo_backend_theory_atom_with_guard,

--- a/libpyclingo/clingo/tests/test_backend.py
+++ b/libpyclingo/clingo/tests/test_backend.py
@@ -260,12 +260,12 @@ class TestBackend(TestCase):
             elem = backend.add_theory_element([num_one, num_two, seq, fun, lst, tup], [1, -2, 3])
 
             # Tests with guards and elements
-            backend.add_theory_atom(0, fun, [])
-            backend.add_theory_atom_with_guard(0, fun, [], "=", num_one)
+            backend.add_theory_atom(fun, [], 0)
+            backend.add_theory_atom_with_guard(fun, [], "=", num_one, 0)
             backend.add_theory_atom(
-                0, backend.add_theory_term_symbol(parse_term("g(1,2)")), []
+                backend.add_theory_term_symbol(parse_term("g(1,2)")), [], 0
             )
-            backend.add_theory_atom(0, fseq, [elem])
+            backend.add_theory_atom(fseq, [elem], 0)
 
         atoms = list(ctl.theory_atoms)
         self.assertListEqual(


### PR DESCRIPTION
Note that this breaks backwards-compatibility because the `atom_id_or_zero` parameter is optional and moved to the end. More complicated overloading would be possible but this is most likely not a widely used interface to justify this.