### PR TITLE
handle overflows in the IESolver

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -13,6 +13,7 @@
   * fix parsing of hexadecimal numbers (#421)
   * fix assignment aggregates (#436)
   * fix build scripts for Python 3.12 (#452)
+  * fix overflows in IESolver (#462)
   * make sure `clingo_control_ground` is re-entrant (#418)
   * update clasp and dependencies
 

--- a/libgringo/gringo/term.hh
+++ b/libgringo/gringo/term.hh
@@ -259,14 +259,10 @@ public:
     void compute();
 
 private:
+    enum class UpdateResult { changed, unchanged, overflow };
     using SubSolvers = std::forward_list<IESolver>;
-    template<typename I>
-    static I floordiv_(I n, I m);
-    template<typename I>
-    static I ceildiv_(I n, I m);
-    static int div_(bool positive, int a, int b);
-    bool update_bound_(IETerm const &term, int slack, int num_unbounded);
-    void update_slack_(IETerm const &term, int &slack, int &num_unbounded);
+    UpdateResult update_bound_(IETerm const &term, int64_t slack, int num_unbounded);
+    bool update_slack_(IETerm const &term, int64_t &slack, int &num_unbounded);
 
     IESolver *parent_;
     IEContext &ctx_;

--- a/libgringo/src/ground/literals.cc
+++ b/libgringo/src/ground/literals.cc
@@ -294,7 +294,7 @@ private:
 
 } // namespace
 
-// {{{1 definition of PredicateLiteral
+// {{{1 definition of RangeLiteral
 
 RangeLiteral::RangeLiteral(UTerm assign, UTerm left, UTerm right)
 : assign_(std::move(assign))
@@ -333,7 +333,7 @@ Literal::Score RangeLiteral::score(Term::VarSet const &bound, Logger &log) {
         bool undefined = false;
         Symbol l(range_.first->eval(undefined, log));
         Symbol r(range_.second->eval(undefined, log));
-        return (l.type() == SymbolType::Num && r.type() == SymbolType::Num) ? r.num() - l.num() : -1;
+        return (l.type() == SymbolType::Num && r.type() == SymbolType::Num) ? static_cast<double>(r.num()) - l.num() : -1.0;
     }
     return 0;
 }

--- a/libgringo/tests/output/lparse.cc
+++ b/libgringo/tests/output/lparse.cc
@@ -1132,7 +1132,25 @@ TEST_CASE("output-lparse", "[output]") {
                 "a(6) :- not not { }.\n"
                 , {"a("})));
     }
+    SECTION("IESolver") {
+        // clean
+        REQUIRE(
+            "([[p(1),p(a),q]],[])" ==
+            IO::to_string(solve(
+                "p(1).\n"
+                "p(a).\n"
+                "q :- p(X), -0x7FFFFFFF-1 <= X <= 0x7FFFFFFF.\n"
+                , {"p", "q"})));
+        // relies on two's complemenet
+        REQUIRE(
+            "([[p(1),p(a),q]],[])" ==
+            IO::to_string(solve(
+                "p(1).\n"
+                "p(a).\n"
+                "q :- p(X), 0x80000000 <= X <= 0x7FFFFFFF.\n"
+                , {"p", "q"})));
+    }
+
 }
 
 } } } // namespace Test Output Gringo
-


### PR DESCRIPTION
Variables with large domains could lead to overflows in the IESolver. To prevent this, a 64bit type is used to sum up values. In case there are still overflows, computed bounds are simply ignored. 