### PR TITLE
Replace distutils with setuptools/sysconfig

### DIFF
--- a/cmake/python-site.py
+++ b/cmake/python-site.py
@@ -7,10 +7,7 @@ if sys.version_info >= (3, 11):
 else:
     NEW_STYLE = False
     from site import USER_SITE
-    try:
-        from setuptools.sysconfig import get_python_lib, get_config_vars
-    except ImportError:
-        from distutils.sysconfig import get_python_lib, get_config_vars
+    from distutils.sysconfig import get_python_lib, get_config_vars
 
 parser = ArgumentParser()
 if sys.version_info >= (3, 7):

--- a/scratch/setup.py
+++ b/scratch/setup.py
@@ -1,4 +1,4 @@
-from distutils.core import setup, Extension
+from setuptools import setup, Extension
 import os
 
 path = os.path.normpath(os.path.abspath(os.path.join(os.getcwd(), "build", "release", "bin")))


### PR DESCRIPTION
Distutils was deprecated in Python 3.10 and removed in Python 3.12.[^1] This PR removes all uses of distutils to fix Python 3.12 support.[^2]

@haampie 

[^1]: https://peps.python.org/pep-0632/
[^2]: https://setuptools.pypa.io/en/latest/deprecated/distutils-legacy.html