### PR TITLE
Issue #28: Unify PropagateControl and PropagateInit

### DIFF
--- a/examples/python-api/dl/app.py
+++ b/examples/python-api/dl/app.py
@@ -155,9 +155,7 @@ def rewrite(lib: Library, files: Sequence[str]) -> ast.Program:
 
     prg = ast.Program(lib)
     prg.add(ast.parse_statement(lib, THEORY))
-    with ast.Scanner(lib, list(files)) as scn:
-        for stm in scn:
-            prg.add(accept(stm) or stm)
+    ast.parse_files(lib, files, lambda stm: prg.add(accept(stm) or stm))
     return prg
 
 
@@ -361,11 +359,12 @@ class DLPropagator(Propagator):
         self._e2l.setdefault(edge, []).append(lit)
         init.add_watch(lit)
 
-    def init(self, init: PropagateInit):
+    def init(self, assignment: Assignment, init: PropagateInit):
         """
         Initialize the propagator extracting difference constraints from the
         theory data.
         """
+        assert assignment
         for atom in init.base.theory:
             term = atom.name
             if (term.name in ("__diff_h", "__diff_b")) and len(term.arguments) == 0:
@@ -378,27 +377,29 @@ class DLPropagator(Propagator):
                 if term.name == "__diff_b":
                     self._add_edge(init, -lit, v, u, -w - 1)
 
-    def propagate(self, control: PropagateControl, changes: Sequence[int]):
+    def propagate(
+        self, assignment: Assignment, control: PropagateControl, changes: Sequence[int]
+    ):
         """
         Add edges that became true to the graph to check for negative cycles.
         """
-        state = self._state(control.thread_id)
-        level = control.assignment.decision_level
+        state = self._state(assignment.thread_id)
+        level = assignment.decision_level
         for lit in changes:
             for edge in self._l2e[lit]:
                 cycle = state.add_edge(level, edge)
                 if cycle is not None:
-                    c = [self._literal(control, e) for e in cycle]
+                    c = [self._literal(assignment, e) for e in cycle]
                     if control.add_nogood(c):
                         control.propagate()
                     return
 
-    def undo(self, thread_id: int, assignment: Assignment, changes: Sequence[int]):
+    def undo(self, assignment: Assignment, changes: Sequence[int]):
         """
         Backtrack the last decision level propagated.
         """
         assert changes
-        self._state(thread_id).backtrack(assignment.decision_level)
+        self._state(assignment.thread_id).backtrack(assignment.decision_level)
 
     def on_model(self, model: Model):
         """
@@ -418,9 +419,9 @@ class DLPropagator(Propagator):
             self._states.append(Graph(self._lib))
         return self._states[thread_id]
 
-    def _literal(self, control, edge):
+    def _literal(self, assignment: Assignment, edge: WeightedEdge):
         for lit in self._e2l[edge]:
-            if control.assignment.is_true(lit):
+            if assignment.is_true(lit):
                 return lit
         assert False
 

--- a/lib/c-api/include/clingo/app.h
+++ b/lib/c-api/include/clingo/app.h
@@ -51,14 +51,14 @@ typedef struct clingo_options clingo_options_t;
 //! @param[in] files files passed via command line arguments
 //! @param[in] size number of files
 //! @param[in] data user data for the callback
-//! @return wether the call was successful
+//! @return whether the call was successful
 typedef bool (*clingo_main_function_t)(clingo_control_t *control, clingo_string_t const *files, size_t size,
                                        void *data);
 
 //! Callback to print a model in default format.
 //!
 //! @param[in] data user data for the callback
-//! @return wether the call was successful
+//! @return whether the call was successful
 typedef bool (*clingo_default_model_printer_t)(void *data);
 
 //! Callback to customize model printing.
@@ -67,7 +67,7 @@ typedef bool (*clingo_default_model_printer_t)(void *data);
 //! @param[in] printer the default model printer
 //! @param[in] printer_data user data for the printer
 //! @param[in] data user data for the callback
-//! @return wether the call was successful
+//! @return whether the call was successful
 typedef bool (*clingo_model_printer_t)(clingo_model_t const *model, clingo_default_model_printer_t printer,
                                        void *printer_data, void *data);
 
@@ -87,7 +87,7 @@ typedef struct clingo_application {
 //! @param[in] size the size of the value
 //! @param[in] data the user data of the callback
 //! @param[in] result
-//! @return wether the call was successful
+//! @return whether the call was successful
 typedef bool (*clingo_option_parser_t)(char const *value, size_t size, void *data, bool *result);
 
 //! Add an option that is processed with a custom parser.
@@ -113,7 +113,7 @@ typedef bool (*clingo_option_parser_t)(char const *value, size_t size, void *dat
 //! @param[in] multi whether the option can appear multiple times on the command-line
 //! @param[in] argument optional string (NULL) to change the value name in the generated help output
 //! @param[in] argument_size the size of the argument
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_options_add(clingo_options_t *options, char const *group, size_t group_size,
                                                   char const *option, size_t option_size, char const *description,
                                                   size_t description_size, clingo_option_parser_t parser, void *data,
@@ -131,7 +131,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_options_add(clingo_options_t *options, cha
 //! @param[in] description the description of the option
 //! @param[in] description_size the size of the description
 //! @param[in] target boolean set to true if the flag is given on the command-line
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_options_add_flag(clingo_options_t *options, char const *group, size_t group_size,
                                                        char const *option, size_t option_size, char const *description,
                                                        size_t description_size, bool *target);
@@ -148,7 +148,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_options_add_flag(clingo_options_t *options
 //! @param[in] app struct with callbacks to override default clingo functionality
 //! @param[in] data user data for callbacks in app
 //! @param[out] code the exit code
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_main(clingo_lib_t *lib, clingo_string_t const *arguments, size_t size,
                                            clingo_application_t const *app, void *data, int *code);
 

--- a/lib/c-api/include/clingo/ast.h
+++ b/lib/c-api/include/clingo/ast.h
@@ -164,14 +164,14 @@ typedef struct clingo_ast clingo_ast_t;
 //! @param[in] lib the library object to store symbols
 //! @param[in] type the type of AST to construct
 //! @param[out] ast the resulting AST
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_ast_construct(clingo_lib_t *lib, clingo_ast_type_t type, clingo_ast_t **ast, ...);
 
 //! Copy the given AST node.
 //!
 //! @param[in] ast the AST to copy
 //! @param[out] copy the resulting AST
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_ast_copy(clingo_ast_t *ast, clingo_ast_t **copy);
 
 //! Enumeration of expressions that can be parsed.
@@ -195,7 +195,7 @@ typedef int clingo_ast_parse_type_t;
 //! @param[in] string the expression to parse
 //! @param[in] size the size of the string
 //! @param[in] ast the resulting ast
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_ast_parse_expression(clingo_lib_t *lib, clingo_ast_parse_type_t type,
                                                            char const *string, size_t size, clingo_ast_t **ast);
 
@@ -221,7 +221,7 @@ CLINGO_VISIBILITY_DEFAULT void clingo_ast_array_free(clingo_ast_t **ast, size_t 
 //!
 //! @param[in] ast the target AST
 //! @param[in] builder the string builder
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_ast_to_string(clingo_ast_t *ast, clingo_string_builder_t *builder);
 
 //! @}
@@ -258,7 +258,7 @@ CLINGO_VISIBILITY_DEFAULT size_t clingo_ast_hash(clingo_ast_t *ast);
 //!
 //! @param[in] ast the target AST
 //! @param[out] type the resulting type
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_ast_get_type(clingo_ast_t *ast, clingo_ast_type_t *type);
 
 //! Get the value of numeric attribute.
@@ -266,7 +266,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_ast_get_type(clingo_ast_t *ast, clingo_ast
 //! @param[in] ast the target AST
 //! @param[in] attribute the target attribute
 //! @param[out] value the resulting value
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_ast_attribute_get_number(clingo_ast_t *ast, clingo_ast_attribute_t attribute,
                                                                int *value);
 
@@ -275,7 +275,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_ast_attribute_get_number(clingo_ast_t *ast
 //! @param[in] ast the target AST
 //! @param[in] attribute the target attribute
 //! @param[out] value the resulting value
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_ast_attribute_get_symbol(clingo_ast_t *ast, clingo_ast_attribute_t attribute,
                                                                clingo_symbol_t *value);
 
@@ -284,7 +284,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_ast_attribute_get_symbol(clingo_ast_t *ast
 //! @param[in] ast the target AST
 //! @param[in] attribute the target attribute
 //! @param[out] value the resulting value
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_ast_attribute_get_location(clingo_ast_t *ast, clingo_ast_attribute_t attribute,
                                                                  clingo_location_t const **value);
 
@@ -293,7 +293,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_ast_attribute_get_location(clingo_ast_t *a
 //! @param[in] ast the target AST
 //! @param[in] attribute the target attribute
 //! @param[out] value the resulting value
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_ast_attribute_get_string(clingo_ast_t *ast, clingo_ast_attribute_t attribute,
                                                                clingo_string_t *value);
 
@@ -305,7 +305,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_ast_attribute_get_string(clingo_ast_t *ast
 //! @param[in] attribute the target attribute
 //! @param[out] value the resulting value
 //! @param[out] size the size of the array
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_ast_attribute_get_string_array(clingo_ast_t *ast,
                                                                      clingo_ast_attribute_t attribute,
                                                                      clingo_string_t const **value, size_t *size);
@@ -318,7 +318,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_ast_attribute_get_string_array(clingo_ast_
 //! @param[in] attribute the target attribute
 //! @param[out] value the resulting value
 //! @param[out] size the size of the array
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_ast_attribute_get_symbol_array(clingo_ast_t *ast,
                                                                      clingo_ast_attribute_t attribute,
                                                                      clingo_symbol_t const **value, size_t *size);
@@ -332,7 +332,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_ast_attribute_get_symbol_array(clingo_ast_
 //! @param[in] ast the target AST
 //! @param[in] attribute the target attribute
 //! @param[out] value the resulting value
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_ast_attribute_get_ast(clingo_ast_t *ast, clingo_ast_attribute_t attribute,
                                                             clingo_ast_t **value);
 
@@ -344,7 +344,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_ast_attribute_get_ast(clingo_ast_t *ast, c
 //! @param[in] attribute the target attribute
 //! @param[out] value the resulting value
 //! @param[out] size the size of the array
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_ast_attribute_get_ast_array(clingo_ast_t *ast, clingo_ast_attribute_t attribute,
                                                                   clingo_ast_t ***value, size_t *size);
 
@@ -409,7 +409,7 @@ typedef struct clingo_ast_rewrite_context clingo_ast_rewrite_context_t;
 //!
 //! @param[in] lib the library object to store symbols
 //! @param[out] context the resulting context object
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_ast_rewrite_context_create(clingo_lib_t *lib,
                                                                  clingo_ast_rewrite_context_t **context);
 
@@ -425,7 +425,7 @@ CLINGO_VISIBILITY_DEFAULT void clingo_ast_rewrite_context_free(clingo_ast_rewrit
 //! @param[in] context the context object
 //! @param[in] param the parameter to protect
 //! @param[in] size the size of the string
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_ast_rewrite_context_add_param(clingo_ast_rewrite_context_t *context,
                                                                     char const *param, size_t size);
 
@@ -440,7 +440,7 @@ CLINGO_VISIBILITY_DEFAULT void clingo_ast_rewrite_context_clear_params(clingo_as
 //!
 //! @param[in] context the context object
 //! @param[in] theory the theory definition
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_ast_rewrite_context_add_theory(clingo_ast_rewrite_context_t *context,
                                                                      clingo_ast_t const *theory);
 
@@ -485,7 +485,7 @@ CLINGO_VISIBILITY_DEFAULT clingo_lib_t *clingo_ast_rewrite_context_get_lib(cling
 //! @param[in] statement the statement object
 //! @param[out] result the resulting rewritten statements
 //! @param[out] result_size the number of resulting statements
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_ast_rewrite(clingo_ast_rewrite_context_t *context, clingo_ast_t *statement,
                                                   clingo_ast_t ***result, size_t *result_size);
 
@@ -499,7 +499,7 @@ typedef struct clingo_program clingo_program_t;
 //!
 //! @param[in] lib the library object
 //! @param[out] program the program builder object
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_program_new(clingo_lib_t *lib, clingo_program_t **program);
 //! Destroy the given program object.
 //!

--- a/lib/c-api/include/clingo/backend.h
+++ b/lib/c-api/include/clingo/backend.h
@@ -52,13 +52,13 @@ typedef struct clingo_backend clingo_backend_t;
 //!
 //! @param[in] control the control object
 //! @param[out] backend the resulting backend
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_control_backend(clingo_control_t *control, clingo_backend_t **backend);
 
 //! Finalize the backend after using it.
 //!
 //! @param[in] backend the target backend
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_backend_close(clingo_backend_t *backend);
 
 //! Add a rule to the program.
@@ -69,7 +69,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_backend_close(clingo_backend_t *backend);
 //! @param[in] head_size the number of atoms in the head
 //! @param[in] body the body literals
 //! @param[in] body_size the number of literals in the body
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_backend_rule(clingo_backend_t *backend, bool choice, clingo_atom_t const *head,
                                                    size_t head_size, clingo_literal_t const *body, size_t body_size);
 //! Add a weight rule to the program.
@@ -82,7 +82,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_backend_rule(clingo_backend_t *backend, bo
 //! @param[in] lower_bound the lower bound of the weight rule
 //! @param[in] body the weighted body literals
 //! @param[in] body_size the number of weighted literals in the body
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_backend_weight_rule(clingo_backend_t *backend, bool choice,
                                                           clingo_atom_t const *head, size_t head_size,
                                                           clingo_weight_t lower_bound,
@@ -93,7 +93,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_backend_weight_rule(clingo_backend_t *back
 //! @param[in] priority the priority of the constraint
 //! @param[in] literals the weighted literals whose sum to minimize
 //! @param[in] size the number of weighted literals
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_backend_minimize(clingo_backend_t *backend, clingo_weight_t priority,
                                                        clingo_weighted_literal_t const *literals, size_t size);
 //! Add a projection directive.
@@ -101,7 +101,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_backend_minimize(clingo_backend_t *backend
 //! @param[in] backend the target backend
 //! @param[in] atoms the atoms to project on
 //! @param[in] size the number of atoms
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_backend_project(clingo_backend_t *backend, clingo_atom_t const *atoms,
                                                       size_t size);
 //! Add an external statement.
@@ -109,7 +109,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_backend_project(clingo_backend_t *backend,
 //! @param[in] backend the target backend
 //! @param[in] atom the external atom
 //! @param[in] type the type of the external statement
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_backend_external(clingo_backend_t *backend, clingo_atom_t atom,
                                                        clingo_external_type_t type);
 //! Add an assumption directive.
@@ -118,7 +118,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_backend_external(clingo_backend_t *backend
 //! @param[in] literals the literals to assume (positive literals are true and negative literals false for the next
 //! solve call)
 //! @param[in] size the number of atoms
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_backend_assume(clingo_backend_t *backend, clingo_literal_t const *literals,
                                                      size_t size);
 //! Add a heuristic directive.
@@ -130,7 +130,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_backend_assume(clingo_backend_t *backend, 
 //! @param[in] priority the heuristic priority
 //! @param[in] condition the condition under which to apply the heuristic modification
 //! @param[in] size the number of atoms in the condition
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_backend_heuristic(clingo_backend_t *backend, clingo_atom_t atom,
                                                         clingo_heuristic_type_t type, int bias, unsigned priority,
                                                         clingo_literal_t const *condition, size_t size);
@@ -141,7 +141,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_backend_heuristic(clingo_backend_t *backen
 //! @param[in] node_v the end vertex of the edge
 //! @param[in] condition the condition under which the edge is part of the graph
 //! @param[in] size the number of atoms in the condition
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_backend_acyc_edge(clingo_backend_t *backend, int node_u, int node_v,
                                                         clingo_literal_t const *condition, size_t size);
 //! Get a fresh atom to be used in aspif directives.
@@ -149,7 +149,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_backend_acyc_edge(clingo_backend_t *backen
 //! @param[in] backend the target backend
 //! @param[in] symbol optional symbol to associate the atom with
 //! @param[out] atom the resulting atom
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_backend_add_atom(clingo_backend_t *backend, clingo_symbol_t const *symbol,
                                                        clingo_atom_t *atom);
 //! Add a numeric theory term.
@@ -157,7 +157,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_backend_add_atom(clingo_backend_t *backend
 //! @param[in] backend the target backend
 //! @param[in] number the value of the term
 //! @param[out] term_id the resulting term id
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_backend_theory_term_number(clingo_backend_t *backend, int number,
                                                                  clingo_id_t *term_id);
 //! Add a theory term representing a string.
@@ -166,7 +166,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_backend_theory_term_number(clingo_backend_
 //! @param[in] string the value of the term
 //! @param[in] size the size of the string
 //! @param[out] term_id the resulting term id
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_backend_theory_term_string(clingo_backend_t *backend, char const *string,
                                                                  size_t size, clingo_id_t *term_id);
 //! Add a theory term representing a sequence of theory terms.
@@ -176,7 +176,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_backend_theory_term_string(clingo_backend_
 //! @param[in] arguments the term ids of the terms in the sequence
 //! @param[in] size the number of elements of the sequence
 //! @param[out] term_id the resulting term id
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_backend_theory_term_sequence(clingo_backend_t *backend,
                                                                    clingo_theory_sequence_type_t type,
                                                                    clingo_id_t const *arguments, size_t size,
@@ -189,7 +189,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_backend_theory_term_sequence(clingo_backen
 //! @param[in] arguments an array of term ids for the theory terms in the arguments
 //! @param[in] arguments_size the number of arguments
 //! @param[out] term_id the resulting term id
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_backend_theory_term_function(clingo_backend_t *backend, char const *name,
                                                                    size_t name_size, clingo_id_t const *arguments,
                                                                    size_t arguments_size, clingo_id_t *term_id);
@@ -198,7 +198,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_backend_theory_term_function(clingo_backen
 //! @param[in] backend the target backend
 //! @param[in] symbol the symbol to convert
 //! @param[out] term_id the resulting term id
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_backend_theory_term_symbol(clingo_backend_t *backend, clingo_symbol_t symbol,
                                                                  clingo_id_t *term_id);
 //! Add a theory atom element.
@@ -209,7 +209,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_backend_theory_term_symbol(clingo_backend_
 //! @param[in] condition an array of program literals representing the condition
 //! @param[in] condition_size the size of the condition
 //! @param[out] element_id the resulting element id
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_backend_theory_element(clingo_backend_t *backend, clingo_id_t const *tuple,
                                                              size_t tuple_size, clingo_literal_t const *condition,
                                                              size_t condition_size, clingo_id_t *element_id);
@@ -229,7 +229,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_backend_theory_element(clingo_backend_t *b
 //! @param[in] right_hand_side_id the term id of the right-hand-side
 //! @param[in] atom_in the atom as described above
 //! @param[out] atom_out the final program atom of the theory atom
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_backend_theory_atom(clingo_backend_t *backend, clingo_symbol_t name,
                                                           clingo_id_t const *elements, size_t size,
                                                           clingo_string_t *operator_name,

--- a/lib/c-api/include/clingo/base.h
+++ b/lib/c-api/include/clingo/base.h
@@ -101,7 +101,7 @@ typedef struct clingo_theory_base clingo_theory_base_t;
 //! @param[in] atoms the atom base
 //! @param[in] literal the index of the literal
 //! @param[out] is_fact whether the literal is a fact
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_base_is_fact(clingo_base_t const *atoms, clingo_literal_t literal, bool *is_fact);
 
 //! Check whether an literal is external.
@@ -112,7 +112,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_base_is_fact(clingo_base_t const *atoms, c
 //! @param[in] atoms the target
 //! @param[in] literal the index of the literal
 //! @param[out] is_external whether the literal is an external
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_base_is_external(clingo_base_t const *atoms, clingo_literal_t literal,
                                                        bool *is_external);
 
@@ -123,7 +123,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_base_is_external(clingo_base_t const *atom
 //! @param[in] atoms the target
 //! @param[in] literal the index of the tom
 //! @param[out] is_shown whether the tom is shown
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_base_is_shown(clingo_base_t const *atoms, clingo_literal_t literal,
                                                     bool *is_shown);
 
@@ -134,7 +134,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_base_is_shown(clingo_base_t const *atoms, 
 //! @param[in] atoms the target
 //! @param[in] literal the index of the literal
 //! @param[out] is_projected whether the literal is subject to projection
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_base_is_projected(clingo_base_t const *atoms, clingo_literal_t literal,
                                                         bool *is_projected);
 
@@ -146,7 +146,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_base_is_projected(clingo_base_t const *ato
 //! @param[in] atoms the target
 //! @param[in] literal the index of the literal
 //! @param[out] is_current whether the literal was introduced in the current step
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_base_is_current(clingo_base_t const *atoms, clingo_literal_t literal,
                                                       bool *is_current);
 
@@ -156,7 +156,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_base_is_current(clingo_base_t const *atoms
 //!
 //! @param[in] base the target
 //! @param[out] size the number of atoms
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_base_atoms_size(clingo_base_t const *base, size_t *size);
 
 //! Get the signature and atom base at the given index.
@@ -168,7 +168,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_base_atoms_size(clingo_base_t const *base,
 //! @param[in] index the index of the atom base
 //! @param[out] signature the target signature
 //! @param[out] atoms the target atom base
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_base_atoms_at(clingo_base_t const *base, size_t index,
                                                     clingo_signature_t *signature, clingo_atom_base_t const **atoms);
 
@@ -178,7 +178,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_base_atoms_at(clingo_base_t const *base, s
 //! @param[in] signature the signature to lookup
 //! @param[out] atoms the target atom base
 //! @param[out] found whether a base has been found
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_base_atoms_find(clingo_base_t const *base, clingo_signature_t const *signature,
                                                       clingo_atom_base_t const **atoms, bool *found);
 
@@ -186,7 +186,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_base_atoms_find(clingo_base_t const *base,
 //!
 //! @param[in] atoms the atom base
 //! @param[out] size the target size
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_atom_base_size(clingo_atom_base_t const *atoms, size_t *size);
 
 //! Find the index of the atom with the given symbol in the atom base.
@@ -196,7 +196,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_atom_base_size(clingo_atom_base_t const *a
 //! @param atoms the atom base
 //! @param symbol the symbol to lookup
 //! @param index the target index
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_atom_base_find(clingo_atom_base_t const *atoms, clingo_symbol_t symbol,
                                                      size_t *index);
 
@@ -205,7 +205,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_atom_base_find(clingo_atom_base_t const *a
 //! @param[in] atoms the atom base
 //! @param[in] index the index of the atom
 //! @param[out] symbol the resulting symbol
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_atom_base_symbol(clingo_atom_base_t const *atoms, size_t index,
                                                        clingo_symbol_t *symbol);
 
@@ -217,7 +217,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_atom_base_symbol(clingo_atom_base_t const 
 //! @param[in] atoms the atom base
 //! @param[in] index the index of the atom
 //! @param[out] literal the resulting literal
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_atom_base_literal(clingo_atom_base_t const *atoms, size_t index,
                                                         clingo_literal_t *literal);
 
@@ -225,7 +225,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_atom_base_literal(clingo_atom_base_t const
 //!
 //! @param base the base
 //! @param terms the term base
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_base_terms(clingo_base_t const *base, clingo_term_base_t const **terms);
 
 //! Get the theory base capturing theory terms, elements, and atoms.
@@ -242,7 +242,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_base_terms(clingo_base_t const *base, clin
 //!
 //! @param base the base
 //! @param theory the theory base
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_base_theory(clingo_base_t const *base, clingo_theory_base_t const **theory);
 
 //! During grounding, theory atoms get consecutive numbers starting with zero.
@@ -259,7 +259,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_base_theory(clingo_base_t const *base, cli
 //!
 //! @param[in] terms the term base
 //! @param[out] size the number of terms in the base
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_term_base_size(clingo_term_base_t const *terms, size_t *size);
 
 //! Get the symbol of the show directive with the given index.
@@ -267,7 +267,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_term_base_size(clingo_term_base_t const *t
 //! @param[in] terms the term base
 //! @param[in] index the index of the show directive
 //! @param[out] term the resulting term
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_term_base_symbol(clingo_term_base_t const *terms, size_t index,
                                                        clingo_symbol_t *term);
 
@@ -281,7 +281,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_term_base_symbol(clingo_term_base_t const 
 //! @param[out] sizes the sizes of the conjunctions
 //! @param[out] literals the target literals
 //! @param[out] size the size of the disjunction
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_term_base_condition(clingo_term_base_t const *terms, size_t index,
                                                           size_t const **sizes,
                                                           clingo_literal_t const *const **literals, size_t *size);
@@ -293,7 +293,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_term_base_condition(clingo_term_base_t con
 //! @param[in] terms the term base
 //! @param[in] symbol the symbol to lookup
 //! @param[out] index the target index
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_term_base_find(clingo_term_base_t const *terms, clingo_symbol_t symbol,
                                                      size_t *index);
 
@@ -305,7 +305,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_term_base_find(clingo_term_base_t const *t
 //! @param[in] theory container where the term is stored
 //! @param[in] term id of the term
 //! @param[out] type the resulting type
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_term_type(clingo_theory_base_t const *theory, clingo_id_t term,
                                                             clingo_theory_term_type_t *type);
 
@@ -315,7 +315,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_term_type(clingo_theory_base_t
 //! @param[in] theory container where the term is stored
 //! @param[in] term id of the term
 //! @param[out] number the resulting number
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_term_number(clingo_theory_base_t const *theory, clingo_id_t term,
                                                               int *number);
 //! Get the name of the given constant or function theory term.
@@ -324,7 +324,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_term_number(clingo_theory_base
 //! @param[in] theory container where the term is stored
 //! @param[in] term id of the term
 //! @param[out] name the resulting name
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_term_name(clingo_theory_base_t const *theory, clingo_id_t term,
                                                             clingo_string_t *name);
 //! Get the arguments of the given function theory term.
@@ -334,7 +334,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_term_name(clingo_theory_base_t
 //! @param[in] term id of the term
 //! @param[out] arguments the resulting arguments in form of an array of term ids
 //! @param[out] size the number of arguments
-//! @return wether the call was successful
+//! @return whether the call was successful
 
 CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_term_arguments(clingo_theory_base_t const *theory, clingo_id_t term,
                                                                  clingo_id_t const **arguments, size_t *size);
@@ -344,7 +344,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_term_arguments(clingo_theory_b
 //! @param[in] theory container where the term is stored
 //! @param[in] term id of the term
 //! @param[in] builder the string builder
-//! @return wether the call was successful
+//! @return whether the call was successful
 //! @see clingo_theory_base_term_to_string_size()
 CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_term_to_string(clingo_theory_base_t const *theory, clingo_id_t term,
                                                                  clingo_string_builder_t *builder);
@@ -360,7 +360,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_term_to_string(clingo_theory_b
 //! @param[in] element id of the element
 //! @param[out] tuple the resulting array of term ids
 //! @param[out] size the number of term ids
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_element_tuple(clingo_theory_base_t const *theory, clingo_id_t element,
                                                                 clingo_id_t const **tuple, size_t *size);
 
@@ -370,7 +370,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_element_tuple(clingo_theory_ba
 //! @param[in] element id of the element
 //! @param[out] condition the resulting array of aspif literals
 //! @param[out] size the number of term literals
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_element_condition(clingo_theory_base_t const *theory,
                                                                     clingo_id_t element,
                                                                     clingo_literal_t const **condition, size_t *size);
@@ -385,7 +385,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_element_condition(clingo_theor
 //! @param[in] theory container where the element is stored
 //! @param[in] element id of the element
 //! @param[out] condition the resulting condition id
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_element_condition_id(clingo_theory_base_t const *theory,
                                                                        clingo_id_t element,
                                                                        clingo_literal_t *condition);
@@ -395,7 +395,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_element_condition_id(clingo_th
 //! @param[in] theory container where the element is stored
 //! @param[in] element id of the element
 //! @param[in] builder the builder
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_element_to_string(clingo_theory_base_t const *theory,
                                                                     clingo_id_t element,
                                                                     clingo_string_builder_t *builder);
@@ -409,7 +409,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_element_to_string(clingo_theor
 //!
 //! @param[in] theory the target
 //! @param[out] size the resulting number
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_size(clingo_theory_base_t const *theory, size_t *size);
 
 //! Get the theory term associated with the theory atom.
@@ -417,7 +417,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_size(clingo_theory_base_t cons
 //! @param[in] theory container where the atom is stored
 //! @param[in] atom id of the atom
 //! @param[out] term the resulting term id
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_atom_term(clingo_theory_base_t const *theory, clingo_id_t atom,
                                                             clingo_id_t *term);
 
@@ -427,7 +427,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_atom_term(clingo_theory_base_t
 //! @param[in] atom id of the atom
 //! @param[out] elements the resulting array of elements
 //! @param[out] size the number of elements
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_atom_elements(clingo_theory_base_t const *theory, clingo_id_t atom,
                                                                 clingo_id_t const **elements, size_t *size);
 
@@ -436,7 +436,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_atom_elements(clingo_theory_ba
 //! @param[in] theory container where the atom is stored
 //! @param[in] atom id of the atom
 //! @param[out] has_guard whether the theory atom has a guard
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_atom_has_guard(clingo_theory_base_t const *theory, clingo_id_t atom,
                                                                  bool *has_guard);
 
@@ -446,7 +446,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_atom_has_guard(clingo_theory_b
 //! @param[in] atom id of the atom
 //! @param[out] connective the resulting theory operator
 //! @param[out] term the resulting term
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_atom_guard(clingo_theory_base_t const *theory, clingo_id_t atom,
                                                              clingo_string_t *connective, clingo_id_t *term);
 
@@ -455,7 +455,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_atom_guard(clingo_theory_base_
 //! @param[in] theory container where the atom is stored
 //! @param[in] atom id of the atom
 //! @param[out] literal the resulting literal
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_atom_literal(clingo_theory_base_t const *theory, clingo_id_t atom,
                                                                clingo_literal_t *literal);
 
@@ -464,7 +464,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_atom_literal(clingo_theory_bas
 //! @param[in] theory container where the atom is stored
 //! @param[in] atom id of the element
 //! @param[in] builder the builder
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_atom_to_string(clingo_theory_base_t const *theory, clingo_id_t atom,
                                                                  clingo_string_builder_t *builder);
 //! @}
@@ -477,7 +477,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_theory_base_atom_to_string(clingo_theory_b
 //!
 //! @param[in] control the target
 //! @param[in] base the base to obtain
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_control_base(clingo_control_t const *control, clingo_base_t const **base);
 
 //! @}

--- a/lib/c-api/include/clingo/config.h
+++ b/lib/c-api/include/clingo/config.h
@@ -49,7 +49,7 @@ typedef struct clingo_config clingo_config_t;
 //!
 //! @param[in] config the target configuration
 //! @param[out] key the root key
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_config_root(clingo_config_t const *config, clingo_id_t *key);
 
 //! Get the type of a key.
@@ -59,7 +59,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_config_root(clingo_config_t const *config,
 //! @param[in] config the target configuration
 //! @param[in] key the key
 //! @param[out] type the resulting type
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_config_type(clingo_config_t const *config, clingo_id_t key,
                                                   clingo_config_type_bitset_t *type);
 //! Get the description of an entry.
@@ -67,7 +67,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_config_type(clingo_config_t const *config,
 //! @param[in] config the target configuration
 //! @param[in] key the key
 //! @param[out] description the description
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_config_description(clingo_config_t const *config, clingo_id_t key,
                                                          clingo_string_t *description);
 
@@ -80,7 +80,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_config_description(clingo_config_t const *
 //! @param[in] config the target configuration
 //! @param[in] key the key
 //! @param[out] size the resulting size
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_config_array_size(clingo_config_t const *config, clingo_id_t key, size_t *size);
 //! Get the subkey at the given offset of an array entry.
 //!
@@ -91,7 +91,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_config_array_size(clingo_config_t const *c
 //! @param[in] key the key
 //! @param[in] offset the offset in the array
 //! @param[out] subkey the resulting subkey
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_config_array_at(clingo_config_t const *config, clingo_id_t key, size_t offset,
                                                       clingo_id_t *subkey);
 //! @}
@@ -105,7 +105,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_config_array_at(clingo_config_t const *con
 //! @param[in] config the target configuration
 //! @param[in] key the key
 //! @param[out] size the resulting number
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_config_map_size(clingo_config_t const *config, clingo_id_t key, size_t *size);
 //! Query whether the map has a key.
 //!
@@ -116,7 +116,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_config_map_size(clingo_config_t const *con
 //! @param[in] name the name to look up the subkey
 //! @param[in] size the size of the name
 //! @param[out] result whether the key is in the map
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_config_map_has_subkey(clingo_config_t const *config, clingo_id_t key,
                                                             char const *name, size_t size, bool *result);
 //! Get the name associated with the offset-th subkey.
@@ -126,7 +126,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_config_map_has_subkey(clingo_config_t cons
 //! @param[in] key the key
 //! @param[in] offset the offset of the name
 //! @param[out] name the resulting name
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_config_map_subkey_name(clingo_config_t const *config, clingo_id_t key,
                                                              size_t offset, clingo_string_t *name);
 //! Lookup a subkey under the given name.
@@ -138,7 +138,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_config_map_subkey_name(clingo_config_t con
 //! @param[in] name the name to look up the subkey
 //! @param[in] size the size of the name
 //! @param[out] subkey the resulting subkey
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_config_map_at(clingo_config_t const *config, clingo_id_t key, char const *name,
                                                     size_t size, clingo_id_t *subkey);
 //! @}
@@ -153,7 +153,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_config_map_at(clingo_config_t const *confi
 //! @param[in] key the key
 //! @param[out] value the resulting string value
 //! @param[out] has_value whether the config entry has a value
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_config_value_get(clingo_config_t const *config, clingo_id_t key,
                                                        clingo_string_t *value, bool *has_value);
 //! Set the value of an entry.
@@ -163,7 +163,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_config_value_get(clingo_config_t const *co
 //! @param[in] key the key
 //! @param[in] value the value to set
 //! @param[in] size the size of the value
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_config_value_set(clingo_config_t *config, clingo_id_t key, char const *value,
                                                        size_t size);
 
@@ -172,7 +172,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_config_value_set(clingo_config_t *config, 
 //! @param[in] config the target configuration
 //! @param[in] key the key
 //! @param[in] builder the builder
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_config_to_string(clingo_config_t const *config, clingo_id_t key,
                                                        clingo_string_builder_t *builder);
 
@@ -182,7 +182,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_config_to_string(clingo_config_t const *co
 //!
 //! @param[in] control the target
 //! @param[out] config the configuration
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_control_config(clingo_control_t *control, clingo_config_t **config);
 
 //! @}

--- a/lib/c-api/include/clingo/control.h
+++ b/lib/c-api/include/clingo/control.h
@@ -117,7 +117,7 @@ typedef struct clingo_const_map clingo_const_map_t;
 //! @param[in] name_size the size of the name
 //! @param[out] symbol the value of the constant
 //! @param[out] found whether the constant was found
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_const_map_find(clingo_const_map_t const *map, char const *name, size_t name_size,
                                                      clingo_symbol_t *symbol, bool *found);
 
@@ -127,7 +127,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_const_map_find(clingo_const_map_t const *m
 //! @param[in] index the index of the elemnt
 //! @param[out] name the name of the constant
 //! @param[out] symbol the value of the constant
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_const_map_at(clingo_const_map_t const *map, size_t index, clingo_string_t *name,
                                                    clingo_symbol_t *symbol);
 
@@ -135,7 +135,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_const_map_at(clingo_const_map_t const *map
 //!
 //! @param[in] map the target
 //! @param[out] size the size of the map
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_const_map_size(clingo_const_map_t const *map, size_t *size);
 
 //! Create a new control object.
@@ -151,7 +151,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_const_map_size(clingo_const_map_t const *m
 //! @param[in] arguments string array of command line arguments
 //! @param[in] size size of the arguments array
 //! @param[out] control resulting control object
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_control_new(clingo_lib_t *lib, clingo_string_t const *arguments, size_t size,
                                                   clingo_control_t **control);
 
@@ -169,7 +169,7 @@ CLINGO_VISIBILITY_DEFAULT void clingo_control_release(clingo_control_t *control)
 //!
 //! @param[in] control the target
 //! @param[in] mode the mode
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_control_mode(clingo_control_t *control, clingo_mode_t *mode);
 
 //! Extend the logic program with a program in a file.
@@ -177,7 +177,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_control_mode(clingo_control_t *control, cl
 //! @param[in] control the target
 //! @param[in] files the files to parse
 //! @param[in] size the number of files to parse
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_control_parse_files(clingo_control_t *control, clingo_string_t const *files,
                                                           size_t size);
 
@@ -189,7 +189,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_control_parse_files(clingo_control_t *cont
 //! @param[in] control the target
 //! @param[in] program string representation of the program
 //! @param[in] size the size of the program
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_control_parse_string(clingo_control_t *control, char const *program, size_t size);
 
 //! Ground the selected parts of the current (non-ground) logic program.
@@ -205,21 +205,21 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_control_parse_string(clingo_control_t *con
 //! @param[in] size size of the parts array
 //! @param[in] ground_callback callback to implement external functions
 //! @param[in] data user data for ground_callback
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_control_ground(clingo_control_t *control, clingo_part_t const *parts, size_t size,
                                                      clingo_ground_callback_t ground_callback, void *data);
 
 //! Execute the default ground and solve flow after parsing.
 //!
 //! @param[in] control the target
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_control_main(clingo_control_t *control);
 
 //! Get the map of constants.
 //!
 //! @param[in] control the target
 //! @param[out] map the map of constants
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_control_const_map(clingo_control_t *control, clingo_const_map_t const **map);
 
 //! Get the output of the text output.
@@ -228,7 +228,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_control_const_map(clingo_control_t *contro
 //!
 //! @param[in] control the target
 //! @param[out] result the resulting string
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_control_buffer(clingo_control_t *control, clingo_string_t *result);
 
 //! Get the program parts to ground.
@@ -237,7 +237,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_control_buffer(clingo_control_t *control, 
 //! @param[out] parts the resulting parts
 //! @param[out] size the resulting parts
 //! @param[out] has_value the resulting parts
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_control_get_parts(clingo_control_t *control, clingo_part_t const **parts,
                                                         size_t *size, bool *has_value);
 
@@ -247,7 +247,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_control_get_parts(clingo_control_t *contro
 //! @param[in] parts the parts to set
 //! @param[in] size the size of the parts
 //! @param[in] has_value whether parts are available
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_control_set_parts(clingo_control_t *control, clingo_part_t const *parts,
                                                         size_t size, bool has_value);
 

--- a/lib/c-api/include/clingo/core.h
+++ b/lib/c-api/include/clingo/core.h
@@ -214,7 +214,7 @@ CLINGO_VISIBILITY_DEFAULT void clingo_message_string(clingo_message_t code, clin
 //! @param[in] data user data for the logger callback
 //! @param[in] limit the message limit
 //! @param[out] lib the resulting library object
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_lib_new(clingo_lib_flags_t flags, clingo_log_level_t level,
                                               clingo_logger_t const *logger, void *data, size_t limit,
                                               clingo_lib_t **lib);
@@ -254,13 +254,13 @@ typedef struct clingo_string_builder clingo_string_builder_t;
 //! Create a new string builder.
 //!
 //! @param[out] bld the resulting builder
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_string_builder_new(clingo_string_builder_t **bld);
 //! Copy the string builder.
 //!
 //! @param[in] src the builder to copy
 //! @param[out] dst the resulting builder
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_string_builder_copy(clingo_string_builder_t const *src,
                                                           clingo_string_builder_t **dst);
 //! Free the string builder.
@@ -272,7 +272,7 @@ CLINGO_VISIBILITY_DEFAULT void clingo_string_builder_free(clingo_string_builder_
 //!
 //! @param[in] bld the builder
 //! @param[out] value the resulting string
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_string_builder_string(clingo_string_builder_t const *bld, clingo_string_t *value);
 //! Clear the string in the builder.
 //!
@@ -293,14 +293,14 @@ typedef struct clingo_position clingo_position_t;
 //! @param[in] line the line number of the position
 //! @param[in] column the column number of the position
 //! @param[out] pos the resulting position
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_position_new(clingo_lib_t *lib, char const *file, size_t size, size_t line,
                                                    size_t column, clingo_position_t const **pos);
 //! Copy the given position.
 //!
 //! @param[in] src the position to copy
 //! @param[out] dst the resulting position
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_position_copy(clingo_position_t const *src, clingo_position_t const **dst);
 //! Free the given position.
 //!
@@ -347,7 +347,7 @@ CLINGO_VISIBILITY_DEFAULT int clingo_position_compare(clingo_position_t const *a
 //!
 //! @param[in] pos the position
 //! @param[in] str the string builder
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_position_to_string(clingo_position_t const *pos, clingo_string_builder_t *str);
 
 //! Represents a source code location marking its beginning and end.
@@ -358,14 +358,14 @@ typedef struct clingo_location clingo_location_t;
 //! @param[in] begin the position marking the beginning
 //! @param[in] end the position marking the end
 //! @param[out] loc the resulting location
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_location_new(clingo_position_t const *begin, clingo_position_t const *end,
                                                    clingo_location_t const **loc);
 //! Copy the given location.
 //!
 //! @param[in] src the location to copy
 //! @param[out] dst the resulting location
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_location_copy(clingo_location_t const *src, clingo_location_t const **dst);
 //! Free the given location.
 //!
@@ -411,7 +411,7 @@ CLINGO_VISIBILITY_DEFAULT int clingo_location_compare(clingo_location_t const *a
 //!
 //! @param[in] loc the location
 //! @param[in] str the string builder
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_location_to_string(clingo_location_t const *loc, clingo_string_builder_t *str);
 
 //! @}

--- a/lib/c-api/include/clingo/model.h
+++ b/lib/c-api/include/clingo/model.h
@@ -78,13 +78,13 @@ typedef int clingo_consequence_t;
 //!
 //! @param[in] model the target
 //! @param[out] type the type of the model
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_model_type(clingo_model_t const *model, clingo_model_type_t *type);
 //! Get the running number of the model.
 //!
 //! @param[in] model the target
 //! @param[out] number the number of the model
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_model_number(clingo_model_t const *model, uint64_t *number);
 
 //! Get the symbols of the selected types in the model.
@@ -93,7 +93,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_model_number(clingo_model_t const *model, 
 //! @param[in] show which symbols to select
 //! @param[out] callback callback to copy symbols
 //! @param[in] data userdata for the callback
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_model_symbols(clingo_model_t const *model, clingo_show_type_bitset_t show,
                                                     clingo_symbol_callback_t callback, void *data);
 //! Constant time lookup to test whether an atom is in a model.
@@ -101,7 +101,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_model_symbols(clingo_model_t const *model,
 //! @param[in] model the target
 //! @param[in] atom the atom to lookup
 //! @param[out] contained whether the atom is contained
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_model_contains(clingo_model_t const *model, clingo_symbol_t atom,
                                                      bool *contained);
 //! Check if a program literal is true in a model.
@@ -109,7 +109,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_model_contains(clingo_model_t const *model
 //! @param[in] model the target
 //! @param[in] literal the literal to lookup
 //! @param[out] result whether the literal is true
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_model_is_true(clingo_model_t const *model, clingo_literal_t literal,
                                                     bool *result);
 //! Check if the given literal is a consequence.
@@ -123,7 +123,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_model_is_true(clingo_model_t const *model,
 //! @param[in] model the target
 //! @param[in] literal the literal to lookup
 //! @param[out] result whether the literal is a consequence
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_model_is_consequence(clingo_model_t const *model, clingo_literal_t literal,
                                                            clingo_consequence_t *result);
 //! Get the costs of a model.
@@ -133,7 +133,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_model_is_consequence(clingo_model_t const 
 //! @param[in] model the target
 //! @param[out] costs the resulting costs
 //! @param[out] size the size of the costs array
-//! @return wether the call was successful
+//! @return whether the call was successful
 //! @see clingo_model_optimality_proven()
 CLINGO_VISIBILITY_DEFAULT bool clingo_model_cost(clingo_model_t const *model, int64_t const **costs, size_t *size);
 //! Get the priorities of the costs.
@@ -143,21 +143,21 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_model_cost(clingo_model_t const *model, in
 //! @param[in] model the target
 //! @param[out] priorities the resulting priorities
 //! @param[out] size the size of the priorities array
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_model_priority(clingo_model_t const *model, clingo_weight_t const **priorities,
                                                      size_t *size);
 //! Whether the optimality of a model has been proven.
 //!
 //! @param[in] model the target
 //! @param[out] proven whether the optimality has been proven
-//! @return wether the call was successful
+//! @return whether the call was successful
 //! @see clingo_model_cost()
 CLINGO_VISIBILITY_DEFAULT bool clingo_model_optimality_proven(clingo_model_t const *model, bool *proven);
 //! Get the id of the solver thread that found the model.
 //!
 //! @param[in] model the target
 //! @param[out] id the resulting thread id
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_model_thread_id(clingo_model_t const *model, clingo_id_t *id);
 //! Add symbols to the model.
 //!
@@ -168,7 +168,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_model_thread_id(clingo_model_t const *mode
 //! @param[in] model the target
 //! @param[in] symbols the symbols to add
 //! @param[in] size the number of symbols to add
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_model_extend(clingo_model_t *model, clingo_symbol_t const *symbols, size_t size);
 //! @}
 
@@ -180,13 +180,13 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_model_extend(clingo_model_t *model, clingo
 //! This object allows for adding clauses during model enumeration.
 //! @param[in] model the target
 //! @param[out] control the resulting solve control object
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_model_control(clingo_model_t *model, clingo_solve_control_t **control);
 //! Get an object to inspect the symbolic atoms.
 //!
 //! @param[in] control the target
 //! @param[out] base the resulting object
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_solve_control_base(clingo_solve_control_t const *control,
                                                          clingo_base_t const **base);
 //! Add a clause that applies to the current solving step during model
@@ -198,7 +198,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_solve_control_base(clingo_solve_control_t 
 //! @param[in] control the target
 //! @param[in] clause array of literals representing the clause
 //! @param[in] size the size of the literal array
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_solve_control_add_clause(clingo_solve_control_t *control,
                                                                clingo_literal_t const *clause, size_t size);
 //! @}

--- a/lib/c-api/include/clingo/propagate.h
+++ b/lib/c-api/include/clingo/propagate.h
@@ -56,6 +56,14 @@ typedef int clingo_truth_value_t;
 
 //! @name Assignment Functions
 //! @{
+//! Get the id of the thread to which the assignment belongs.
+//!
+//! @note Thread ids are consecutive numbers starting with zero.
+//!
+//! @param[in] assignment the target assignment
+//! @param[out] id the thread id
+//! @return whether the call was successful
+CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_thread_id(clingo_assignment_t const *assignment, clingo_id_t *id);
 
 //! Get the current decision level.
 //!
@@ -229,6 +237,9 @@ enum clingo_weight_constraint_type_e {
 //! Corresponding type to ::clingo_weight_constraint_type_e.
 typedef int clingo_weight_constraint_type_t;
 
+//! This object can be used to add clauses and propagate literals while solving.
+typedef struct clingo_propagate_control clingo_propagate_control_t;
+
 //! Object to initialize a user-defined propagator before each solving step.
 //!
 //! Each @link c_base symbolic or theory atom@endlink is uniquely associated with an
@@ -254,38 +265,7 @@ typedef struct clingo_propagate_init clingo_propagate_init_t;
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_solver_literal(clingo_propagate_init_t const *init,
                                                                     clingo_literal_t aspif_literal,
                                                                     clingo_literal_t *solver_literal);
-//! Add a watch for the solver literal in the given phase.
-//!
-//! @param[in] init the target
-//! @param[in] solver_literal the solver literal
-//! @return whether the call was successful
-CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_add_watch(clingo_propagate_init_t *init,
-                                                               clingo_literal_t solver_literal);
-//! Add a watch for the solver literal in the given phase to the given solver thread.
-//!
-//! @param[in] init the target
-//! @param[in] solver_literal the solver literal
-//! @param[in] thread_id the id of the solver thread
-//! @return whether the call was successful
-CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_add_watch_to_thread(clingo_propagate_init_t *init,
-                                                                         clingo_literal_t solver_literal,
-                                                                         clingo_id_t thread_id);
-//! Remove the watch for the solver literal in the given phase.
-//!
-//! @param[in] init the target
-//! @param[in] solver_literal the solver literal
-//! @return whether the call was successful
-CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_remove_watch(clingo_propagate_init_t *init,
-                                                                  clingo_literal_t solver_literal);
-//! Remove the watch for the solver literal in the given phase from the given solver thread.
-//!
-//! @param[in] init the target
-//! @param[in] solver_literal the solver literal
-//! @param[in] thread_id the id of the solver thread
-//! @return whether the call was successful
-CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_remove_watch_from_thread(clingo_propagate_init_t *init,
-                                                                              clingo_literal_t solver_literal,
-                                                                              uint32_t thread_id);
+
 //! Freeze the given solver literal.
 //!
 //! Any solver literal that is not frozen is subject to simplification and might be removed in a preprocessing step
@@ -316,7 +296,6 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_base(clingo_propagate_init_
 //! @param[in] init the target
 //! @param[out] threads the number of threads
 //! @return whether the call was successful
-//! @see clingo_propagate_control_thread_id()
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_number_of_threads(clingo_propagate_init_t const *init,
                                                                        clingo_id_t *threads);
 //! Configure when to call the check method of the propagator.
@@ -330,7 +309,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_set_check_mode(clingo_propa
 //! Get the current check mode of the propagator.
 //!
 //! @param[in] init the target
-//! @param[out] mode the rersulting mode
+//! @param[out] mode the resulting mode
 //! @return whether the call was successful
 //! @see clingo_propagate_init_set_check_mode()
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_get_check_mode(clingo_propagate_init_t const *init,
@@ -351,61 +330,18 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_set_undo_mode(clingo_propag
 //! @see clingo_propagate_init_set_undo_mode()
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_get_undo_mode(clingo_propagate_init_t const *init,
                                                                    clingo_propagator_undo_mode_t *mode);
-//! Get the top level assignment solver.
+
+//! Get the underlying propagate control object.
 //!
+//! This function can be used to get a @ref clingo_propagate_control_t object that can be used to add clauses,
+//! variables, and watches. Control functions called on the returned object affect all current and future solver
+//! threads. Furthermore, all watched literals are automatically frozen.
 //! @param[in] init the target
-//! @param[out] assignment the resulting assignment
+//! @param[out] control the resulting object
 //! @return whether the call was successful
-CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_assignment(clingo_propagate_init_t const *init,
-                                                                clingo_assignment_t const **assignment);
-//! Add a literal to the solver.
-//!
-//! To be able to use the variable in clauses during propagation or add watches to it, it has to be frozen.
-//! Otherwise, it might be removed during preprocessing.
-//!
-//! @attention If variables were added, subsequent calls to functions adding constraints or
-//! ::clingo_propagate_init_propagate() are expensive. It is best to add variables in batches.
-//!
-//! @param[in] init the target
-//! @param[in] freeze whether to freeze the literal
-//! @param[out] solver_literal the added literal
-//! @return whether the call was successful
-CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_add_literal(clingo_propagate_init_t *init, bool freeze,
-                                                                 clingo_literal_t *solver_literal);
-//! Add the given clause to the solver.
-//!
-//! @attention No further calls on the init object or functions on the assignment should be called when the result of
-//! this method is false.
-//!
-//! @param[in] init the target
-//! @param[in] literals the clause to add
-//! @param[in] size the size of the clause
-//! @param[out] result result indicating whether the problem became unsatisfiable
-//! @return whether the call was successful
-CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_add_clause(clingo_propagate_init_t *init,
-                                                                clingo_literal_t const *literals, size_t size,
-                                                                bool *result);
-//! Add the given weight constraint to the solver.
-//!
-//! This function adds a constraint of form `literal <=> { lit=weight | (lit, weight) in literals } >= bound` to the
-//! solver. Depending on the type, the `<=>` connective can be either a left implication, right implication, or
-//! equivalence.
-//!
-//! @attention No further calls on the init object or functions on the assignment should be called when the result of
-//! this method is false.
-//!
-//! @param[in] init the target
-//! @param[in] solver_literal the literal of the constraint
-//! @param[in] literals the weighted literals
-//! @param[in] size the number of weighted literals
-//! @param[in] bound the bound of the constraint
-//! @param[in] type the type of the weight constraint
-//! @param[in] compare_equal if true compare equal instead of less than equal
-//! @param[out] result result indicating whether the problem became unsatisfiable
-//! @return whether the call was successful
-CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_add_weight_constraint(
-    clingo_propagate_init_t *init, clingo_literal_t solver_literal, clingo_weighted_literal_t const *literals,
-    size_t size, clingo_weight_t bound, clingo_weight_constraint_type_t type, bool compare_equal, bool *result);
+CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_control(clingo_propagate_init_t const *init,
+                                                             clingo_propagate_control_t **control);
+
 //! Add the given literal to minimize to the solver.
 //!
 //! This corresponds to a weak constraint of form `:~ literal. [weight@priority]`.
@@ -418,16 +354,6 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_add_weight_constraint(
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_add_minimize(clingo_propagate_init_t *init,
                                                                   clingo_literal_t solver_literal,
                                                                   clingo_weight_t weight, clingo_weight_t priority);
-//! Propagates consequences of the underlying problem excluding registered propagators.
-//!
-//! @note The function has no effect if SAT-preprocessing is enabled.
-//! @attention No further calls on the init object or functions on the assignment should be called when the result of
-//! this method is false.
-//!
-//! @param[in] init the target
-//! @param[out] result result indicating whether the problem became unsatisfiable
-//! @return whether the call was successful
-CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_propagate(clingo_propagate_init_t *init, bool *result);
 
 //! @}
 
@@ -446,42 +372,26 @@ enum clingo_clause_type_e {
 //! Corresponding type to ::clingo_clause_type_e.
 typedef int clingo_clause_type_t;
 
-//! This object can be used to add clauses and propagate literals while solving.
-typedef struct clingo_propagate_control clingo_propagate_control_t;
-
-//! @name Propagation Functions
+//! @name Control Functions
 //! @{
 
-//! Get the id of the underlying solver thread.
+//! Adds a new literal to the problem or the active solver thread.
 //!
-//! Thread ids are consecutive numbers starting with zero.
-//!
-//! @param[in] control the target
-//! @param[out] thread_id the thread id
-//! @return whether the call was successful
-CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_thread_id(clingo_propagate_control_t const *control,
-                                                                  clingo_id_t *thread_id);
-//! Get the assignment associated with the underlying solver.
+//! @attention If the function is called in the context of a particular solver thread, the literal is volatile and
+//! only valid within that thread and the current solving step. Volatile literals and clauses involving a volatile
+//! literal are deleted after the current search.
 //!
 //! @param[in] control the target
-//! @param[out] assignment the resulting assignment
-//! @return whether the call was successful
-CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_assignment(clingo_propagate_control_t const *control,
-                                                                   clingo_assignment_t const **assignment);
-//! Adds a new volatile literal to the underlying solver thread.
-//!
-//! @attention The literal is only valid within the current solving step and solver thread.
-//! All volatile literals and clauses involving a volatile literal are deleted after the current search.
-//!
-//! @param[in] control the target
+//! @param[in] freeze whether to freeze the literal
 //! @param[out] result the (positive) solver literal
 //! @return whether the call was successful
-CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_add_literal(clingo_propagate_control_t *control,
+CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_add_literal(clingo_propagate_control_t *control, bool freeze,
                                                                     clingo_literal_t *result);
+
 //! Add a watch for the solver literal in the given phase.
 //!
-//! @note Unlike @ref clingo_propagate_init_add_watch() this does not add a watch to all solver threads but just the
-//! current one.
+//! @note If called in the context of initialization, the watch is added to all current and future solving threads.
+//! Otherwise, the watch is only added to the active solving thread.
 //!
 //! @param[in] control the target
 //! @param[in] literal the literal to watch
@@ -489,7 +399,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_add_literal(clingo_propa
 //! @see clingo_propagate_control_remove_watch()
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_add_watch(clingo_propagate_control_t *control,
                                                                   clingo_literal_t literal);
-//! Check whether a literal is watched in the current solver thread.
+//! Check whether a literal is watched in the current context.
 //!
 //! @param[in] control the target
 //! @param[in] literal the literal to check
@@ -499,7 +409,8 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_has_watch(clingo_propaga
                                                                   clingo_literal_t literal, bool *has_watch);
 //! Removes the watch (if any) for the given solver literal.
 //!
-//! @note Similar to @ref clingo_propagate_init_add_watch() this just removes the watch in the current solver thread.
+//! @note If called in the context of initialization, the watch is removed from all current and future solver threads.
+//! Otherwise, the watch is only removed from the active solving thread.
 //!
 //! @param[in] control the target
 //! @param[in] literal the literal to remove
@@ -517,11 +428,32 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_remove_watch(clingo_prop
 //! @param[in] literals the literals of the clause
 //! @param[in] size the size of the clause
 //! @param[in] type the clause type determining its lifetime
-//! @param[out] result result indicating whether propagation has to be stopped
+//! @param[out] result result indicating whether propagation or initialization has to be stopped
 //! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_add_clause(clingo_propagate_control_t *control,
                                                                    clingo_literal_t const *literals, size_t size,
                                                                    clingo_clause_type_t type, bool *result);
+//! Add the given weight constraint to the solver.
+//!
+//! This function adds a constraint of form `literal <=> { lit=weight | (lit, weight) in literals } >= bound` to the
+//! solver. Depending on the type, the `<=>` connective can be either a left implication, right implication, or
+//! equivalence.
+//!
+//! @attention No further calls on the control object or functions on the assignment should be called when the result of
+//! this method is false.
+//!
+//! @param[in] control the target
+//! @param[in] solver_literal the literal of the constraint
+//! @param[in] literals the weighted literals
+//! @param[in] size the number of weighted literals
+//! @param[in] bound the bound of the constraint
+//! @param[in] type the type of the weight constraint
+//! @param[out] result result indicating whether propagation or initialization has to be stopped
+//! @return whether the call was successful
+CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_add_weight_constraint(
+    clingo_propagate_control_t *control, clingo_literal_t solver_literal, clingo_weighted_literal_t const *literals,
+    size_t size, clingo_weight_t bound, clingo_weight_constraint_type_t type, bool *result);
+
 //! Propagate implied literals (resulting from added clauses).
 //!
 //! This method sets its result to false if the current propagation must be stopped for the solver to backtrack.
@@ -530,25 +462,28 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_add_clause(clingo_propag
 //! this method is false.
 //!
 //! @param[in] control the target
-//! @param[out] result result indicating whether propagation has to be stopped
+//! @param[out] result result indicating whether propagation or initialization has to be stopped
 //! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_propagate(clingo_propagate_control_t *control, bool *result);
 
 //! @}
 
 //! Typedef for @ref ::clingo_propagator::init().
-typedef bool (*clingo_propagator_init_callback_t)(clingo_propagate_init_t *, void *);
+typedef bool (*clingo_propagator_init_callback_t)(clingo_assignment_t const *, clingo_propagate_init_t *, void *);
+
+//! Typedef for @ref ::clingo_propagator::attach().
+typedef bool (*clingo_propagator_attach_callback_t)(clingo_assignment_t const *, clingo_propagate_control_t *, void *);
 
 //! Typedef for @ref ::clingo_propagator::propagate().
-typedef bool (*clingo_propagator_propagate_callback_t)(clingo_propagate_control_t *, clingo_literal_t const *, size_t,
-                                                       void *);
+typedef bool (*clingo_propagator_propagate_callback_t)(clingo_assignment_t const *, clingo_propagate_control_t *,
+                                                       clingo_literal_t const *, size_t, void *);
 
 //! Typedef for @ref ::clingo_propagator::undo().
-typedef void (*clingo_propagator_undo_callback_t)(clingo_propagate_control_t const *, clingo_literal_t const *, size_t,
+typedef void (*clingo_propagator_undo_callback_t)(clingo_assignment_t const *, clingo_literal_t const *, size_t,
                                                   void *);
 
 //! Typedef for @ref ::clingo_propagator::check().
-typedef bool (*clingo_propagator_check_callback_t)(clingo_propagate_control_t *, void *);
+typedef bool (*clingo_propagator_check_callback_t)(clingo_assignment_t const *, clingo_propagate_control_t *, void *);
 
 //! An instance of this struct has to be registered with a solver to implement a custom propagator.
 //!
@@ -562,14 +497,28 @@ typedef struct clingo_propagator {
     //! @note This is the last point to access symbolic and theory atoms.
     //! Once the search has started, they are no longer accessible.
     //!
+    //! @param[in] assignment the current assignment
     //! @param[in] init initialization object
     //! @param[in] data user data for the callback
     //! @return whether the call was successful
     //! @see ::clingo_propagator_init_callback_t
-    bool (*init)(clingo_propagate_init_t *init, void *data);
+    bool (*init)(clingo_assignment_t const *assignment, clingo_propagate_init_t *init, void *data);
+    //! This function is called once for each solving thread before solving of the current step is started.
+    //! It can be used to add thread-specific watches and literals, or initialize thread-specific data structures.
+    //!
+    //! @attention Literals and watches added in this function are only valid within the current solving thread.
+    //! Furthermore, added literals and clauses involving such literals are deleted after the current search.
+    //!
+    //! @param[in] assignment the current assignment of the target solver
+    //! @param[in] control control object for the target solver
+    //! @param[in] data user data for the callback
+    //! @return whether the call was successful
+    //! @see ::clingo_propagator_init_callback_t
+    bool (*attach)(clingo_assignment_t const *assignment, clingo_propagate_control_t *control, void *data);
+
     //! Can be used to propagate solver literals given a @link clingo_assignment_t partial assignment@endlink.
     //!
-    //! Called during propagation with a non-empty array of @link clingo_propagate_init_add_watch() watched solver
+    //! Called during propagation with a non-empty array of @link clingo_propagate_control_add_watch() watched solver
     //! literals@endlink that have been assigned to true since the last call to either propagate, undo, (or the start of
     //! the search) - the change set. Only watched solver literals are contained in the change set. Each literal in the
     //! change set is true w.r.t. the current @link clingo_assignment_t assignment@endlink.
@@ -599,29 +548,29 @@ typedef struct clingo_propagator {
     //!
     //! @note
     //! This function can be called from different solving threads.
-    //! Each thread has its own assignment and id, which can be obtained using @ref
-    //! clingo_propagate_control_thread_id().
+    //! Each thread has its own assignment and id, where thread ids are consecutive numbers starting with zero.
     //!
+    //! @param[in] assignment current assignment of the target solver
     //! @param[in] control control object for the target solver
     //! @param[in] changes the change set
     //! @param[in] size the size of the change set
     //! @param[in] data user data for the callback
     //! @return whether the call was successful
     //! @see ::clingo_propagator_propagate_callback_t
-    bool (*propagate)(clingo_propagate_control_t *control, clingo_literal_t const *changes, size_t size, void *data);
+    bool (*propagate)(clingo_assignment_t const *assignment, clingo_propagate_control_t *control,
+                      clingo_literal_t const *changes, size_t size, void *data);
     //! Called whenever a solver undoes assignments to watched solver literals.
     //!
     //! This callback is meant to update assignment dependent state in the propagator.
     //!
-    //! @note No clauses must be propagated in this callback and no errors should be set.
     //!
-    //! @param[in] control control object for the target solver
+    //! @param[in] assignment current assignment of the target solver
     //! @param[in] changes the change set
     //! @param[in] size the size of the change set
     //! @param[in] data user data for the callback
     //! @return whether the call was successful
     //! @see ::clingo_propagator_undo_callback_t
-    void (*undo)(clingo_propagate_control_t const *control, clingo_literal_t const *changes, size_t size, void *data);
+    void (*undo)(clingo_assignment_t const *assignment, clingo_literal_t const *changes, size_t size, void *data);
     //! This function is similar to @ref clingo_propagate_control_propagate() but is called without a change set on
     //! propagation fixpoints.
     //!
@@ -630,26 +579,26 @@ typedef struct clingo_propagator {
     //!
     //! @note This function is called even if no watches have been added.
     //!
+    //! @param[in] assignment current assignment of the target solver
     //! @param[in] control control object for the target solver
     //! @param[in] data user data for the callback
     //! @return whether the call was successful
     //! @see ::clingo_propagator_check_callback_t
-    bool (*check)(clingo_propagate_control_t *control, void *data);
+    bool (*check)(clingo_assignment_t const *assignment, clingo_propagate_control_t *control, void *data);
     //! This function allows a propagator to implement domain-specific heuristics.
     //!
     //! It is called whenever propagation reaches a fixed point and
     //! should return a free solver literal that is to be assigned true.
     //! In case multiple propagators are registered,
     //! this function can return 0 to let a propagator registered later make a decision.
-    //! If all propagators return 0, then the fallback literal is
+    //! If all propagators return 0, then the fallback literal is used.
     //!
-    //! @param[in] thread_id the solver's thread id
     //! @param[in] assignment the assignment of the solver
     //! @param[in] fallback the literal chosen by the solver's heuristic
     //! @param[in] data user data for the callback
     //! @param[out] decision the literal to make true
     //! @return whether the call was successful
-    bool (*decide)(clingo_id_t thread_id, clingo_assignment_t const *assignment, clingo_literal_t fallback, void *data,
+    bool (*decide)(clingo_assignment_t const *assignment, clingo_literal_t fallback, void *data,
                    clingo_literal_t *decision);
     //! Free the propagator.
     //! @param[in] data user data for the callback

--- a/lib/c-api/include/clingo/propagate.h
+++ b/lib/c-api/include/clingo/propagate.h
@@ -61,7 +61,7 @@ typedef int clingo_truth_value_t;
 //!
 //! @param[in] assignment the target assignment
 //! @param[out] level the decision level
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_decision_level(clingo_assignment_t const *assignment, uint32_t *level);
 //! Get the current root level.
 //!
@@ -69,13 +69,13 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_decision_level(clingo_assignmen
 //!
 //! @param[in] assignment the target assignment
 //! @param[out] level the decision level
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_root_level(clingo_assignment_t const *assignment, uint32_t *level);
 //! Check if the given assignment is conflicting.
 //!
 //! @param[in] assignment the target assignment
 //! @param[out] is_conflicting whether the assignment is conflicting
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_has_conflict(clingo_assignment_t const *assignment,
                                                               bool *is_conflicting);
 //! Check if the given literal is part of a (partial) assignment.
@@ -83,7 +83,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_has_conflict(clingo_assignment_
 //! @param[in] assignment the target assignment
 //! @param[in] literal the literal
 //! @param[out] is_valid whether the literal is valid
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_has_literal(clingo_assignment_t const *assignment,
                                                              clingo_literal_t literal, bool *is_valid);
 //! Determine the decision level of a given literal.
@@ -91,7 +91,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_has_literal(clingo_assignment_t
 //! @param[in] assignment the target assignment
 //! @param[in] literal the literal
 //! @param[out] level the resulting level
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_level(clingo_assignment_t const *assignment, clingo_literal_t literal,
                                                        uint32_t *level);
 //! Determine the decision literal given a decision level.
@@ -99,7 +99,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_level(clingo_assignment_t const
 //! @param[in] assignment the target assignment
 //! @param[in] level the level
 //! @param[out] literal the resulting literal
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_decision(clingo_assignment_t const *assignment, uint32_t level,
                                                           clingo_literal_t *literal);
 //! Check if a literal has a fixed truth value.
@@ -107,7 +107,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_decision(clingo_assignment_t co
 //! @param[in] assignment the target assignment
 //! @param[in] literal the literal
 //! @param[out] is_fixed whether the literal is fixed
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_is_fixed(clingo_assignment_t const *assignment,
                                                           clingo_literal_t literal, bool *is_fixed);
 //! Check if a literal is true.
@@ -115,7 +115,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_is_fixed(clingo_assignment_t co
 //! @param[in] assignment the target assignment
 //! @param[in] literal the literal
 //! @param[out] is_true whether the literal is true
-//! @return wether the call was successful
+//! @return whether the call was successful
 //! @see clingo_assignment_truth_value()
 CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_is_true(clingo_assignment_t const *assignment,
                                                          clingo_literal_t literal, bool *is_true);
@@ -124,7 +124,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_is_true(clingo_assignment_t con
 //! @param[in] assignment the target assignment
 //! @param[in] literal the literal
 //! @param[out] is_false whether the literal is false
-//! @return wether the call was successful
+//! @return whether the call was successful
 //! @see clingo_assignment_truth_value()
 CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_is_false(clingo_assignment_t const *assignment,
                                                           clingo_literal_t literal, bool *is_false);
@@ -133,48 +133,48 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_is_false(clingo_assignment_t co
 //! @param[in] assignment the target assignment
 //! @param[in] literal the literal
 //! @param[out] value the resulting truth value
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_truth_value(clingo_assignment_t const *assignment,
                                                              clingo_literal_t literal, clingo_truth_value_t *value);
 //! The number of (positive) literals in the assignment.
 //!
 //! @param[in] assignment the target
 //! @param[out] size the number of literals
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_size(clingo_assignment_t const *assignment, size_t *size);
 //! The (positive) literal at the given offset in the assignment.
 //!
 //! @param[in] assignment the target
 //! @param[in] offset the offset of the literal
 //! @param[out] literal the literal
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_at(clingo_assignment_t const *assignment, size_t offset,
                                                     clingo_literal_t *literal);
-//! Check if the assignment is total, i.e. there are no free literal.
+//! Check if the assignment is total, i.e. there are no free literals.
 //!
 //! @param[in] assignment the target
 //! @param[out] is_total whether the assignment is total
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_is_total(clingo_assignment_t const *assignment, bool *is_total);
 //! Returns the number of literals in the trail, i.e., the number of assigned literals.
 //!
 //! @param[in] assignment the target
 //! @param[out] size the number of literals in the trail
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_trail_size(clingo_assignment_t const *assignment, uint32_t *size);
 //! Returns the offset of the decision literal with the given decision level in
 //! the trail.
 //!
 //! @note Literals in the trail are ordered by decision levels, where the first
 //! literal with a larger level than the previous literals is a decision; the
-//! following literals with same level are implied by this decision literal.
+//! following literals with the same level are implied by this decision literal.
 //! Each decision level up to and including the current decision level has a
 //! valid offset in the trail.
 //!
 //! @param[in] assignment the target
 //! @param[in] level the decision level
 //! @param[out] offset the offset of the decision literal
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_trail_begin(clingo_assignment_t const *assignment, uint32_t level,
                                                              uint32_t *offset);
 //! Returns the offset following the last literal with the given decision level.
@@ -184,7 +184,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_trail_begin(clingo_assignment_t
 //! @param[in] assignment the target
 //! @param[in] level the decision level
 //! @param[out] offset the offset
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_trail_end(clingo_assignment_t const *assignment, uint32_t level,
                                                            uint32_t *offset);
 //! Returns the literal at the given position in the trail.
@@ -192,7 +192,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_trail_end(clingo_assignment_t c
 //! @param[in] assignment the target
 //! @param[in] offset the offset of the literal
 //! @param[out] literal the literal
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_assignment_trail_at(clingo_assignment_t const *assignment, uint32_t offset,
                                                           clingo_literal_t *literal);
 
@@ -236,7 +236,7 @@ typedef int clingo_weight_constraint_type_t;
 //! represent default negation. Furthermore, there are non-zero integer solver literals (also represented using @ref
 //! ::clingo_literal_t). There is a surjective mapping from program atoms to solver literals.
 //!
-//! All methods called during propagation use solver literals whereas clingo_symbolic_atoms_literal() and
+//! All methods called during propagation use solver literals, whereas clingo_symbolic_atoms_literal() and
 //! clingo_theory_atoms_atom_literal() return program literals. The function clingo_propagate_init_solver_literal() can
 //! be used to map program literals or @link clingo_theory_base_element_condition_id() condition ids@endlink to solver
 //! literals.
@@ -250,7 +250,7 @@ typedef struct clingo_propagate_init clingo_propagate_init_t;
 //! @param[in] init the target
 //! @param[in] aspif_literal the aspif literal to map
 //! @param[out] solver_literal the resulting solver literal
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_solver_literal(clingo_propagate_init_t const *init,
                                                                     clingo_literal_t aspif_literal,
                                                                     clingo_literal_t *solver_literal);
@@ -258,7 +258,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_solver_literal(clingo_propa
 //!
 //! @param[in] init the target
 //! @param[in] solver_literal the solver literal
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_add_watch(clingo_propagate_init_t *init,
                                                                clingo_literal_t solver_literal);
 //! Add a watch for the solver literal in the given phase to the given solver thread.
@@ -266,7 +266,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_add_watch(clingo_propagate_
 //! @param[in] init the target
 //! @param[in] solver_literal the solver literal
 //! @param[in] thread_id the id of the solver thread
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_add_watch_to_thread(clingo_propagate_init_t *init,
                                                                          clingo_literal_t solver_literal,
                                                                          clingo_id_t thread_id);
@@ -274,7 +274,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_add_watch_to_thread(clingo_
 //!
 //! @param[in] init the target
 //! @param[in] solver_literal the solver literal
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_remove_watch(clingo_propagate_init_t *init,
                                                                   clingo_literal_t solver_literal);
 //! Remove the watch for the solver literal in the given phase from the given solver thread.
@@ -282,7 +282,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_remove_watch(clingo_propaga
 //! @param[in] init the target
 //! @param[in] solver_literal the solver literal
 //! @param[in] thread_id the id of the solver thread
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_remove_watch_from_thread(clingo_propagate_init_t *init,
                                                                               clingo_literal_t solver_literal,
                                                                               uint32_t thread_id);
@@ -295,27 +295,27 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_remove_watch_from_thread(cl
 //!
 //! @param[in] init the target
 //! @param[in] solver_literal the solver literal
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_freeze_literal(clingo_propagate_init_t *init,
                                                                     clingo_literal_t solver_literal);
 //! Get the underlying library object.
 //!
 //! @param[in] init the target
 //! @param[out] lib the resulting object
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_library(clingo_propagate_init_t const *init, clingo_lib_t **lib);
 //! Get an object to inspect the base.
 //!
 //! @param[in] init the target
 //! @param[out] base the resulting object
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_base(clingo_propagate_init_t const *init,
                                                           clingo_base_t const **base);
 //! Get the number of threads used in subsequent solving.
 //!
 //! @param[in] init the target
 //! @param[out] threads the number of threads
-//! @return wether the call was successful
+//! @return whether the call was successful
 //! @see clingo_propagate_control_thread_id()
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_number_of_threads(clingo_propagate_init_t const *init,
                                                                        clingo_id_t *threads);
@@ -323,7 +323,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_number_of_threads(clingo_pr
 //!
 //! @param[in] init the target
 //! @param[in] mode bitmask when to call the propagator
-//! @return wether the call was successful
+//! @return whether the call was successful
 //! @see @ref ::clingo_propagator::check()
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_set_check_mode(clingo_propagate_init_t *init,
                                                                     clingo_propagator_check_mode_t mode);
@@ -331,7 +331,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_set_check_mode(clingo_propa
 //!
 //! @param[in] init the target
 //! @param[out] mode the rersulting mode
-//! @return wether the call was successful
+//! @return whether the call was successful
 //! @see clingo_propagate_init_set_check_mode()
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_get_check_mode(clingo_propagate_init_t const *init,
                                                                     clingo_propagator_check_mode_t *mode);
@@ -339,7 +339,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_get_check_mode(clingo_propa
 //!
 //! @param[in] init the target
 //! @param[in] mode when to call the propagator
-//! @return wether the call was successful
+//! @return whether the call was successful
 //! @see @ref ::clingo_propagator::check()
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_set_undo_mode(clingo_propagate_init_t *init,
                                                                    clingo_propagator_undo_mode_t mode);
@@ -347,7 +347,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_set_undo_mode(clingo_propag
 //!
 //! @param[in] init the target
 //! @param[out] mode the resulting mode
-//! @return wether the call was successful
+//! @return whether the call was successful
 //! @see clingo_propagate_init_set_undo_mode()
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_get_undo_mode(clingo_propagate_init_t const *init,
                                                                    clingo_propagator_undo_mode_t *mode);
@@ -355,7 +355,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_get_undo_mode(clingo_propag
 //!
 //! @param[in] init the target
 //! @param[out] assignment the resulting assignment
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_assignment(clingo_propagate_init_t const *init,
                                                                 clingo_assignment_t const **assignment);
 //! Add a literal to the solver.
@@ -369,7 +369,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_assignment(clingo_propagate
 //! @param[in] init the target
 //! @param[in] freeze whether to freeze the literal
 //! @param[out] solver_literal the added literal
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_add_literal(clingo_propagate_init_t *init, bool freeze,
                                                                  clingo_literal_t *solver_literal);
 //! Add the given clause to the solver.
@@ -381,14 +381,14 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_add_literal(clingo_propagat
 //! @param[in] literals the clause to add
 //! @param[in] size the size of the clause
 //! @param[out] result result indicating whether the problem became unsatisfiable
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_add_clause(clingo_propagate_init_t *init,
                                                                 clingo_literal_t const *literals, size_t size,
                                                                 bool *result);
 //! Add the given weight constraint to the solver.
 //!
 //! This function adds a constraint of form `literal <=> { lit=weight | (lit, weight) in literals } >= bound` to the
-//! solver. Depending on the type the `<=>` connective can be either a left implication, right implication, or
+//! solver. Depending on the type, the `<=>` connective can be either a left implication, right implication, or
 //! equivalence.
 //!
 //! @attention No further calls on the init object or functions on the assignment should be called when the result of
@@ -402,7 +402,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_add_clause(clingo_propagate
 //! @param[in] type the type of the weight constraint
 //! @param[in] compare_equal if true compare equal instead of less than equal
 //! @param[out] result result indicating whether the problem became unsatisfiable
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_add_weight_constraint(
     clingo_propagate_init_t *init, clingo_literal_t solver_literal, clingo_weighted_literal_t const *literals,
     size_t size, clingo_weight_t bound, clingo_weight_constraint_type_t type, bool compare_equal, bool *result);
@@ -414,7 +414,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_add_weight_constraint(
 //! @param[in] solver_literal the literal to minimize
 //! @param[in] weight the weight of the literal
 //! @param[in] priority the priority of the literal
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_add_minimize(clingo_propagate_init_t *init,
                                                                   clingo_literal_t solver_literal,
                                                                   clingo_weight_t weight, clingo_weight_t priority);
@@ -426,7 +426,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_add_minimize(clingo_propaga
 //!
 //! @param[in] init the target
 //! @param[out] result result indicating whether the problem became unsatisfiable
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_init_propagate(clingo_propagate_init_t *init, bool *result);
 
 //! @}
@@ -458,14 +458,14 @@ typedef struct clingo_propagate_control clingo_propagate_control_t;
 //!
 //! @param[in] control the target
 //! @param[out] thread_id the thread id
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_thread_id(clingo_propagate_control_t const *control,
                                                                   clingo_id_t *thread_id);
 //! Get the assignment associated with the underlying solver.
 //!
 //! @param[in] control the target
 //! @param[out] assignment the resulting assignment
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_assignment(clingo_propagate_control_t const *control,
                                                                    clingo_assignment_t const **assignment);
 //! Adds a new volatile literal to the underlying solver thread.
@@ -475,7 +475,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_assignment(clingo_propag
 //!
 //! @param[in] control the target
 //! @param[out] result the (positive) solver literal
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_add_literal(clingo_propagate_control_t *control,
                                                                     clingo_literal_t *result);
 //! Add a watch for the solver literal in the given phase.
@@ -485,7 +485,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_add_literal(clingo_propa
 //!
 //! @param[in] control the target
 //! @param[in] literal the literal to watch
-//! @return wether the call was successful
+//! @return whether the call was successful
 //! @see clingo_propagate_control_remove_watch()
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_add_watch(clingo_propagate_control_t *control,
                                                                   clingo_literal_t literal);
@@ -494,7 +494,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_add_watch(clingo_propaga
 //! @param[in] control the target
 //! @param[in] literal the literal to check
 //! @param[out] has_watch whether the literal is watched
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_has_watch(clingo_propagate_control_t const *control,
                                                                   clingo_literal_t literal, bool *has_watch);
 //! Removes the watch (if any) for the given solver literal.
@@ -503,7 +503,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_has_watch(clingo_propaga
 //!
 //! @param[in] control the target
 //! @param[in] literal the literal to remove
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_remove_watch(clingo_propagate_control_t *control,
                                                                      clingo_literal_t literal);
 //! Add the given clause to the solver.
@@ -518,7 +518,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_remove_watch(clingo_prop
 //! @param[in] size the size of the clause
 //! @param[in] type the clause type determining its lifetime
 //! @param[out] result result indicating whether propagation has to be stopped
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_add_clause(clingo_propagate_control_t *control,
                                                                    clingo_literal_t const *literals, size_t size,
                                                                    clingo_clause_type_t type, bool *result);
@@ -531,7 +531,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_add_clause(clingo_propag
 //!
 //! @param[in] control the target
 //! @param[out] result result indicating whether propagation has to be stopped
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_propagate_control_propagate(clingo_propagate_control_t *control, bool *result);
 
 //! @}
@@ -564,7 +564,7 @@ typedef struct clingo_propagator {
     //!
     //! @param[in] init initialization object
     //! @param[in] data user data for the callback
-    //! @return wether the call was successful
+    //! @return whether the call was successful
     //! @see ::clingo_propagator_init_callback_t
     bool (*init)(clingo_propagate_init_t *init, void *data);
     //! Can be used to propagate solver literals given a @link clingo_assignment_t partial assignment@endlink.
@@ -606,7 +606,7 @@ typedef struct clingo_propagator {
     //! @param[in] changes the change set
     //! @param[in] size the size of the change set
     //! @param[in] data user data for the callback
-    //! @return wether the call was successful
+    //! @return whether the call was successful
     //! @see ::clingo_propagator_propagate_callback_t
     bool (*propagate)(clingo_propagate_control_t *control, clingo_literal_t const *changes, size_t size, void *data);
     //! Called whenever a solver undoes assignments to watched solver literals.
@@ -619,7 +619,7 @@ typedef struct clingo_propagator {
     //! @param[in] changes the change set
     //! @param[in] size the size of the change set
     //! @param[in] data user data for the callback
-    //! @return wether the call was successful
+    //! @return whether the call was successful
     //! @see ::clingo_propagator_undo_callback_t
     void (*undo)(clingo_propagate_control_t const *control, clingo_literal_t const *changes, size_t size, void *data);
     //! This function is similar to @ref clingo_propagate_control_propagate() but is called without a change set on
@@ -632,7 +632,7 @@ typedef struct clingo_propagator {
     //!
     //! @param[in] control control object for the target solver
     //! @param[in] data user data for the callback
-    //! @return wether the call was successful
+    //! @return whether the call was successful
     //! @see ::clingo_propagator_check_callback_t
     bool (*check)(clingo_propagate_control_t *control, void *data);
     //! This function allows a propagator to implement domain-specific heuristics.
@@ -648,7 +648,7 @@ typedef struct clingo_propagator {
     //! @param[in] fallback the literal chosen by the solver's heuristic
     //! @param[in] data user data for the callback
     //! @param[out] decision the literal to make true
-    //! @return wether the call was successful
+    //! @return whether the call was successful
     bool (*decide)(clingo_id_t thread_id, clingo_assignment_t const *assignment, clingo_literal_t fallback, void *data,
                    clingo_literal_t *decision);
     //! Free the propagator.
@@ -661,7 +661,7 @@ typedef struct clingo_propagator {
 //! @param[in] control the target
 //! @param[in] propagator the propagator
 //! @param[in] data user data passed to the propagator functions
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_control_register_propagator(clingo_control_t *control,
                                                                   clingo_propagator_t const *propagator, void *data);
 //! @}

--- a/lib/c-api/include/clingo/propagate.h
+++ b/lib/c-api/include/clingo/propagate.h
@@ -56,6 +56,7 @@ typedef int clingo_truth_value_t;
 
 //! @name Assignment Functions
 //! @{
+
 //! Get the id of the thread to which the assignment belongs.
 //!
 //! @note Thread ids are consecutive numbers starting with zero.

--- a/lib/c-api/include/clingo/solve.h
+++ b/lib/c-api/include/clingo/solve.h
@@ -119,7 +119,7 @@ typedef struct clingo_solve_handle clingo_solve_handle_t;
 //!
 //! @param[in] handle the target
 //! @param[out] result the solve result
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_solve_handle_get(clingo_solve_handle_t *handle,
                                                        clingo_solve_result_bitset_t *result);
 //! Wait for the specified amount of time to check if the next result is ready.
@@ -130,13 +130,13 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_solve_handle_get(clingo_solve_handle_t *ha
 //! @param[in] handle the target
 //! @param[in] timeout the maximum time to wait
 //! @param[out] result whether the search has finished
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_solve_handle_wait(clingo_solve_handle_t *handle, double timeout, bool *result);
 //! Get the next model (or zero if there are no more models).
 //!
 //! @param[in] handle the target
 //! @param[out] model the model (it is NULL if there are no more models)
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_solve_handle_model(clingo_solve_handle_t *handle, clingo_model_t const **model);
 //! When a problem is unsatisfiable, get a subset of the assumptions that made the problem unsatisfiable.
 //!
@@ -145,7 +145,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_solve_handle_model(clingo_solve_handle_t *
 //! @param[in] handle the target
 //! @param[out] literals array of literals in the core
 //! @param[out] size the size of the core
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_solve_handle_core(clingo_solve_handle_t *handle,
                                                         clingo_literal_t const **literals, size_t *size);
 //! When a problem is satisfiable and the search is finished, get the last
@@ -155,7 +155,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_solve_handle_core(clingo_solve_handle_t *h
 //!
 //! @param[in] handle the target
 //! @param[out] model the last computed model (or NULL if the program is unsatisfiable or the search is still ongoing)
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_solve_handle_last(clingo_solve_handle_t *handle, clingo_model_t const **model);
 //! Discards the last model and starts the search for the next one.
 //!
@@ -165,19 +165,19 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_solve_handle_last(clingo_solve_handle_t *h
 //! @note This function does not block.
 //!
 //! @param[in] handle the target
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_solve_handle_resume(clingo_solve_handle_t *handle);
 //! Stop the running search and block until done.
 //!
 //! @param[in] handle the target
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_solve_handle_cancel(clingo_solve_handle_t *handle);
 //! Stops the running search and releases the handle.
 //!
 //! Blocks until the search is stopped (as if an implicit cancel was called before the handle is released).
 //!
 //! @param[in] handle the target
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_solve_handle_close(clingo_solve_handle_t *handle);
 
 //! Solve the currently grounded logic program enumerating its models.
@@ -191,7 +191,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_solve_handle_close(clingo_solve_handle_t *
 //! @param[in] handler the event handler to register
 //! @param[in] data the user data for the event handler
 //! @param[out] handle handle to the current search to enumerate models
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_control_solve(clingo_control_t *control, clingo_solve_mode_bitset_t mode,
                                                     clingo_literal_t const *assumptions, size_t assumptions_size,
                                                     clingo_solve_event_handler_t const *handler, void *data,

--- a/lib/c-api/include/clingo/stats.h
+++ b/lib/c-api/include/clingo/stats.h
@@ -62,7 +62,7 @@ typedef struct clingo_statistic clingo_stats_t;
 //!
 //! @param[in] stats the target stats
 //! @param[out] key the root key
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_stats_root(clingo_stats_t const *stats, uint64_t *key);
 
 //! Get the type of a key.
@@ -70,7 +70,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_stats_root(clingo_stats_t const *stats, ui
 //! @param[in] stats the target stats
 //! @param[in] key the key
 //! @param[out] type the resulting type
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_stats_type(clingo_stats_t const *stats, uint64_t key, clingo_stats_type_t *type);
 
 //! Get a string representation of the statistics.
@@ -93,7 +93,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_stats_to_string(clingo_stats_t const *stat
 //! @param[in] stats the target stats
 //! @param[in] key the key
 //! @param[out] size the resulting size
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_stats_array_size(clingo_stats_t const *stats, uint64_t key, size_t *size);
 //! Get the subkey at the given offset of an array entry.
 //!
@@ -102,7 +102,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_stats_array_size(clingo_stats_t const *sta
 //! @param[in] key the key
 //! @param[in] offset the offset in the array
 //! @param[out] subkey the resulting subkey
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_stats_array_at(clingo_stats_t const *stats, uint64_t key, size_t offset,
                                                      uint64_t *subkey);
 //! Create the subkey at the end of an array entry.
@@ -112,7 +112,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_stats_array_at(clingo_stats_t const *stats
 //! @param[in] key the key
 //! @param[in] type the type of the new subkey
 //! @param[out] subkey the resulting subkey
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_stats_array_push(clingo_stats_t *stats, uint64_t key, clingo_stats_type_t type,
                                                        uint64_t *subkey);
 //! @}
@@ -126,7 +126,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_stats_array_push(clingo_stats_t *stats, ui
 //! @param[in] stats the target stats
 //! @param[in] key the key
 //! @param[out] size the resulting number
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_stats_map_size(clingo_stats_t const *stats, uint64_t key, size_t *size);
 //! Test if the given map contains a specific subkey.
 //!
@@ -136,7 +136,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_stats_map_size(clingo_stats_t const *stats
 //! @param[in] name name of the subkey
 //! @param[in] size the size of the name
 //! @param[out] result true if the map has a subkey with the given name
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_stats_map_has_subkey(clingo_stats_t const *stats, uint64_t key, char const *name,
                                                            size_t size, bool *result);
 //! Get the name associated with the offset-th subkey.
@@ -146,7 +146,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_stats_map_has_subkey(clingo_stats_t const 
 //! @param[in] key the key
 //! @param[in] offset the offset of the name
 //! @param[out] name the resulting name
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_stats_map_subkey_name(clingo_stats_t const *stats, uint64_t key, size_t offset,
                                                             clingo_string_t *name);
 //! Lookup a subkey under the given name.
@@ -158,7 +158,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_stats_map_subkey_name(clingo_stats_t const
 //! @param[in] name the name to look up the subkey
 //! @param[in] size the size of the name
 //! @param[out] subkey the resulting subkey
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_stats_map_at(clingo_stats_t const *stats, uint64_t key, char const *name,
                                                    size_t size, uint64_t *subkey);
 //! Add a subkey with the given name.
@@ -170,7 +170,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_stats_map_at(clingo_stats_t const *stats, 
 //! @param[in] size the size of the name
 //! @param[in] type the type of the new subkey
 //! @param[out] subkey the index of the resulting subkey
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_stats_map_add_subkey(clingo_stats_t *stats, uint64_t key, char const *name,
                                                            size_t size, clingo_stats_type_t type, uint64_t *subkey);
 //! @}
@@ -184,7 +184,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_stats_map_add_subkey(clingo_stats_t *stats
 //! @param[in] stats the target stats
 //! @param[in] key the key
 //! @param[out] value the resulting value
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_stats_value_get(clingo_stats_t const *stats, uint64_t key, double *value);
 //! Set the value of the given entry.
 //!
@@ -192,7 +192,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_stats_value_get(clingo_stats_t const *stat
 //! @param[in] stats the target stats
 //! @param[in] key the key
 //! @param[out] value the new value
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_stats_value_set(clingo_stats_t *stats, uint64_t key, double value);
 //! @}
 
@@ -200,7 +200,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_stats_value_set(clingo_stats_t *stats, uin
 //!
 //! @param[in] control the target control object
 //! @param[out] stats the resulting stats object
-//! @return wether the call was successful
+//! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_control_stats(clingo_control_t *control, clingo_stats_t const **stats);
 
 //! @}

--- a/lib/c-api/include/clingo/theory.h
+++ b/lib/c-api/include/clingo/theory.h
@@ -69,7 +69,7 @@ typedef struct clingo_theory {
     //! @param[out] major the major version component (optional)
     //! @param[out] minor the minor version component (optional)
     //! @param[out] revision the revision version component (optional)
-    //! @return wether the call was successful
+    //! @return whether the call was successful
     bool (*info)(void *self, clingo_string_t *name, int *major, int *minor, int *revision);
     //! Destroy the theory.
     //!
@@ -81,7 +81,7 @@ typedef struct clingo_theory {
     //!
     //! @param[in] self the self pointer
     //! @param[in] control the control object
-    //! @return wether the call was successful
+    //! @return whether the call was successful
     bool (*register_theory)(void *self, clingo_control_t *control);
     //! Rewrite the given ast for the theory.
     //!
@@ -91,7 +91,7 @@ typedef struct clingo_theory {
     //! @param[in] statement the statement to rewrite
     //! @param[in] callback the callback to pass rewritten statements to
     //! @param[in] data the user data for the callback
-    //! @return wether the call was successful
+    //! @return whether the call was successful
     bool (*rewrite_ast)(void *self, clingo_ast_t *statement, clingo_theory_ast_callback_t callback, void *data);
     //! Prepare the theory.
     //!
@@ -99,18 +99,18 @@ typedef struct clingo_theory {
     //!
     //! @param[in] self the self pointer
     //! @param[in] control the control object
-    //! @return wether the call was successful
+    //! @return whether the call was successful
     bool (*prepare)(void *self, clingo_control_t *control);
     //! Register the theory's options with the given application options object.
     //!
     //! @param[in] self the self pointer
     //! @param[in] control the options object
-    //! @return wether the call was successful
+    //! @return whether the call was successful
     bool (*register_options)(void *self, clingo_options_t *options);
     //! Validate the options of the theory.
     //!
     //! @param[in] self the self pointer
-    //! @return wether the call was successful
+    //! @return whether the call was successful
     bool (*validate_options)(void *self);
     //! Configure the theory passing key value pairs.
     //!
@@ -119,19 +119,19 @@ typedef struct clingo_theory {
     //! @param[in] key_size the size of the name
     //! @param[in] value the value to set
     //! @param[in] value_size the size of the value
-    //! @return wether the call was successful
+    //! @return whether the call was successful
     bool (*configure)(void *self, char const *key, size_t key_size, char const *value, size_t value_size);
     //! Inform the theory that a model has been found.
     //!
     //! @param[in] self the self pointer
     //! @param[in] model the current model
-    //! @return wether the call was successful
+    //! @return whether the call was successful
     bool (*on_model)(void *self, clingo_model_t *model);
     //! Add the theory's statistics to the given maps.
     //!
     //! @param[in] self the self pointer
     //! @param[in] stats the statistics object
-    //! @return wether the call was successful
+    //! @return whether the call was successful
     bool (*on_stats)(void *self, clingo_stats_t *stats);
     //! Get the integer index of a symbol assigned by the theory when a model is found.
     //!
@@ -141,7 +141,7 @@ typedef struct clingo_theory {
     //! @param[in] symbol the symbol to lookup
     //! @param[out] index the resulting index (optional)
     //! @param[out] found whether the symbol has been found (optional)
-    //! @return wether the call was successful
+    //! @return whether the call was successful
     bool (*lookup_symbol)(void *self, clingo_symbol_t symbol, size_t *index, bool *found);
     //! Get the next index that has a value.
     //!
@@ -156,7 +156,7 @@ typedef struct clingo_theory {
     //! @param[inout] init whether to advance or initialize the index
     //! @param[out] index the resulting index
     //! @param[out] has_value whether the index has a value
-    //! @return wether the call was successful
+    //! @return whether the call was successful
     bool (*assignment_next)(void *self, uint32_t thread_id, bool *init, size_t *index, bool *has_value);
     //! Get the value assigned to the given index.
     //!
@@ -168,7 +168,7 @@ typedef struct clingo_theory {
     //! @param[out] symbol the resulting symbol (optional)
     //! @param[out] value the resulting value (optional)
     //! @param[out] has_value whether the index has a value (optional)
-    //! @return wether the call was successful
+    //! @return whether the call was successful
     bool (*assignment_get_value)(void *self, uint32_t thread_id, size_t index, clingo_symbol_t *symbol,
                                  clingo_theory_value_t *value, bool *has_value);
 

--- a/lib/c-api/src/propagate.cc
+++ b/lib/c-api/src/propagate.cc
@@ -44,24 +44,19 @@ auto c_cast(Potassco::AbstractAssignment const *assignment) -> clingo_assignment
     return reinterpret_cast<clingo_assignment_t const *>(assignment);
 }
 
-auto cpp_cast(clingo_propagate_control_t const *control) -> Potassco::AbstractSolver const * {
+auto cpp_cast(clingo_propagate_control_t const *control) -> Potassco::AbstractPropagator::Control const * {
     // NOLINTNEXTLINE
-    return reinterpret_cast<Potassco::AbstractSolver const *>(control);
+    return reinterpret_cast<Potassco::AbstractPropagator::Control const *>(control);
 }
 
-auto cpp_cast(clingo_propagate_control_t *control) -> Potassco::AbstractSolver * {
+auto cpp_cast(clingo_propagate_control_t *control) -> Potassco::AbstractPropagator::Control * {
     // NOLINTNEXTLINE
-    return reinterpret_cast<Potassco::AbstractSolver *>(control);
+    return reinterpret_cast<Potassco::AbstractPropagator::Control *>(control);
 }
 
-auto c_cast(Potassco::AbstractSolver const *init) -> clingo_propagate_control_t const * {
+auto c_cast(Potassco::AbstractPropagator::Control *control) -> clingo_propagate_control_t * {
     // NOLINTNEXTLINE
-    return reinterpret_cast<clingo_propagate_control_t const *>(init);
-}
-
-auto c_cast(Potassco::AbstractSolver *init) -> clingo_propagate_control_t * {
-    // NOLINTNEXTLINE
-    return reinterpret_cast<clingo_propagate_control_t *>(init);
+    return reinterpret_cast<clingo_propagate_control_t *>(control);
 }
 
 auto map(Potassco::TruthValue value) -> clingo_truth_value_t {
@@ -81,38 +76,44 @@ class ClingoPropagator : public CppClingo::Control::Propagator {
         }
     }
 
-    void init(Init &init) override {
+    void init(const Potassco::AbstractAssignment &assignment, Init &init) override {
         if (prop_.init != nullptr) {
             auto cinit = clingo_propagate_init{ctl_, &init};
-            handle_error(prop_.init(&cinit, data_));
+            handle_error(prop_.init(c_cast(&assignment), &cinit, data_));
         }
     }
 
-    void propagate(Potassco::AbstractSolver &solver, Potassco::LitSpan changes) override {
+    void attach(const Potassco::AbstractAssignment &assignment, Control &solver) override {
+        if (prop_.attach != nullptr) {
+            handle_error(prop_.attach(c_cast(&assignment), c_cast(&solver), data_));
+        }
+    }
+
+    void propagate(const Potassco::AbstractAssignment &assignment, Control &solver,
+                   Potassco::LitSpan changes) override {
         if (prop_.propagate != nullptr) {
-            handle_error(prop_.propagate(c_cast(&solver), changes.data(), changes.size(), data_));
+            handle_error(prop_.propagate(c_cast(&assignment), c_cast(&solver), changes.data(), changes.size(), data_));
         }
     }
 
-    void undo(Potassco::AbstractSolver const &solver, Potassco::LitSpan undo) override {
+    void undo(const Potassco::AbstractAssignment &assignment, Potassco::LitSpan undo) override {
         if (prop_.undo != nullptr) {
-            prop_.undo(c_cast(&solver), undo.data(), undo.size(), data_);
+            prop_.undo(c_cast(&assignment), undo.data(), undo.size(), data_);
         }
     }
 
-    void check(Potassco::AbstractSolver &solver) override {
+    void check(const Potassco::AbstractAssignment &assignment, Control &solver) override {
         if (prop_.check != nullptr) {
-            handle_error(prop_.check(c_cast(&solver), data_));
+            handle_error(prop_.check(c_cast(&assignment), c_cast(&solver), data_));
         }
     }
 
     [[nodiscard]] auto hasHeuristic() const -> bool override { return prop_.decide != nullptr; }
 
-    auto decide(Potassco::Id_t solverId, const Potassco::AbstractAssignment &assignment, Potassco::Lit_t fallback)
-        -> Potassco::Lit_t override {
+    auto decide(const Potassco::AbstractAssignment &assignment, Potassco::Lit_t fallback) -> Potassco::Lit_t override {
         clingo_literal_t decision = 0;
         if (prop_.decide != nullptr) {
-            handle_error(prop_.decide(solverId, c_cast(&assignment), fallback, data_, &decision));
+            handle_error(prop_.decide(c_cast(&assignment), fallback, data_, &decision));
         }
         return decision;
     }
@@ -125,6 +126,16 @@ class ClingoPropagator : public CppClingo::Control::Propagator {
 
 } // namespace
 } // namespace CppClingo::CAPI
+
+extern "C" auto clingo_assignment_thread_id(clingo_assignment_t const *assignment, clingo_id_t *id) -> bool {
+    CLINGO_TRY {
+        if (assignment == nullptr || id == nullptr) {
+            return fail_arguments();
+        }
+        *id = cpp_cast(assignment)->solverId();
+    }
+    CLINGO_CATCH;
+}
 
 extern "C" auto clingo_assignment_decision_level(clingo_assignment_t const *assignment, uint32_t *level) -> bool {
     CLINGO_TRY {
@@ -243,8 +254,8 @@ extern "C" auto clingo_assignment_size(clingo_assignment_t const *assignment, si
     CLINGO_CATCH;
 }
 
-extern "C" auto clingo_assignment_at(clingo_assignment_t const *assignment, size_t offset, clingo_literal_t *literal)
-    -> bool {
+extern "C" auto clingo_assignment_at(clingo_assignment_t const *assignment, size_t offset,
+                                     clingo_literal_t *literal) -> bool {
     CLINGO_TRY {
         if (offset >= cpp_cast(assignment)->size()) {
             return fail_with(clingo_result_range, "index out of range");
@@ -274,8 +285,8 @@ extern "C" auto clingo_assignment_trail_size(clingo_assignment_t const *assignme
     CLINGO_CATCH;
 }
 
-extern "C" auto clingo_assignment_trail_begin(clingo_assignment_t const *assignment, uint32_t level, uint32_t *offset)
-    -> bool {
+extern "C" auto clingo_assignment_trail_begin(clingo_assignment_t const *assignment, uint32_t level,
+                                              uint32_t *offset) -> bool {
     CLINGO_TRY {
         if (assignment == nullptr || offset == nullptr) {
             return fail_arguments();
@@ -285,8 +296,8 @@ extern "C" auto clingo_assignment_trail_begin(clingo_assignment_t const *assignm
     CLINGO_CATCH;
 }
 
-extern "C" auto clingo_assignment_trail_end(clingo_assignment_t const *assignment, uint32_t level, uint32_t *offset)
-    -> bool {
+extern "C" auto clingo_assignment_trail_end(clingo_assignment_t const *assignment, uint32_t level,
+                                            uint32_t *offset) -> bool {
     CLINGO_TRY {
         if (assignment == nullptr || offset == nullptr) {
             return fail_arguments();
@@ -308,8 +319,8 @@ extern "C" auto clingo_assignment_trail_at(clingo_assignment_t const *assignment
 }
 
 extern "C" auto clingo_propagate_init_solver_literal(clingo_propagate_init_t const *init,
-                                                     clingo_literal_t aspif_literal, clingo_literal_t *solver_literal)
-    -> bool {
+                                                     clingo_literal_t aspif_literal,
+                                                     clingo_literal_t *solver_literal) -> bool {
     CLINGO_TRY {
         if (init == nullptr || solver_literal == nullptr) {
             return fail_arguments();
@@ -319,59 +330,13 @@ extern "C" auto clingo_propagate_init_solver_literal(clingo_propagate_init_t con
     CLINGO_CATCH;
 }
 
-extern "C" auto clingo_propagate_init_add_watch(clingo_propagate_init_t *init, clingo_literal_t solver_literal)
-    -> bool {
+extern "C" auto clingo_propagate_init_freeze_literal(clingo_propagate_init_t *init,
+                                                     clingo_literal_t solver_literal) -> bool {
     CLINGO_TRY {
         if (init == nullptr) {
             return fail_arguments();
         }
-        init->init->addWatch(solver_literal);
-    }
-    CLINGO_CATCH;
-}
-
-extern "C" auto clingo_propagate_init_add_watch_to_thread(clingo_propagate_init_t *init,
-                                                          clingo_literal_t solver_literal, clingo_id_t thread_id)
-    -> bool {
-    CLINGO_TRY {
-        if (init == nullptr) {
-            return fail_arguments();
-        }
-        init->init->addWatch(solver_literal, thread_id);
-    }
-    CLINGO_CATCH;
-}
-
-extern "C" auto clingo_propagate_init_remove_watch(clingo_propagate_init_t *init, clingo_literal_t solver_literal)
-    -> bool {
-    CLINGO_TRY {
-        if (init == nullptr) {
-            return fail_arguments();
-        }
-        init->init->removeWatch(solver_literal);
-    }
-    CLINGO_CATCH;
-}
-
-extern "C" auto clingo_propagate_init_remove_watch_from_thread(clingo_propagate_init_t *init,
-                                                               clingo_literal_t solver_literal, uint32_t thread_id)
-    -> bool {
-    CLINGO_TRY {
-        if (init == nullptr) {
-            return fail_arguments();
-        }
-        init->init->removeWatch(solver_literal, thread_id);
-    }
-    CLINGO_CATCH;
-}
-
-extern "C" auto clingo_propagate_init_freeze_literal(clingo_propagate_init_t *init, clingo_literal_t solver_literal)
-    -> bool {
-    CLINGO_TRY {
-        if (init == nullptr) {
-            return fail_arguments();
-        }
-        init->init->freezeLiteral(solver_literal);
+        init->init->freezeVariable(solver_literal);
     }
     CLINGO_CATCH;
 }
@@ -397,8 +362,19 @@ extern "C" auto clingo_propagate_init_base(clingo_propagate_init_t const *init, 
     CLINGO_CATCH;
 }
 
-extern "C" auto clingo_propagate_init_number_of_threads(clingo_propagate_init_t const *init, clingo_id_t *threads)
-    -> bool {
+extern "C" auto clingo_propagate_init_control(clingo_propagate_init_t const *init,
+                                              clingo_propagate_control_t **control) -> bool {
+    CLINGO_TRY {
+        if (init == nullptr || control == nullptr) {
+            return fail_arguments();
+        }
+        *control = c_cast(init->init);
+    }
+    CLINGO_CATCH;
+}
+
+extern "C" auto clingo_propagate_init_number_of_threads(clingo_propagate_init_t const *init,
+                                                        clingo_id_t *threads) -> bool {
     CLINGO_TRY {
         if (init == nullptr || threads == nullptr) {
             return fail_arguments();
@@ -408,8 +384,8 @@ extern "C" auto clingo_propagate_init_number_of_threads(clingo_propagate_init_t 
     CLINGO_CATCH;
 }
 
-extern "C" auto clingo_propagate_init_set_check_mode(clingo_propagate_init_t *init, clingo_propagator_check_mode_t mode)
-    -> bool {
+extern "C" auto clingo_propagate_init_set_check_mode(clingo_propagate_init_t *init,
+                                                     clingo_propagator_check_mode_t mode) -> bool {
     CLINGO_TRY {
         if (init == nullptr) {
             return fail_arguments();
@@ -430,8 +406,8 @@ extern "C" auto clingo_propagate_init_get_check_mode(clingo_propagate_init_t con
     CLINGO_CATCH;
 }
 
-extern "C" auto clingo_propagate_init_set_undo_mode(clingo_propagate_init_t *init, clingo_propagator_undo_mode_t mode)
-    -> bool {
+extern "C" auto clingo_propagate_init_set_undo_mode(clingo_propagate_init_t *init,
+                                                    clingo_propagator_undo_mode_t mode) -> bool {
     CLINGO_TRY {
         if (init == nullptr) {
             return fail_arguments();
@@ -452,53 +428,6 @@ extern "C" auto clingo_propagate_init_get_undo_mode(clingo_propagate_init_t cons
     CLINGO_CATCH;
 }
 
-extern "C" auto clingo_propagate_init_assignment(clingo_propagate_init_t const *init,
-                                                 clingo_assignment_t const **assignment) -> bool {
-    CLINGO_TRY {
-        if (init == nullptr) {
-            return fail_arguments();
-        }
-        *assignment = c_cast(&init->init->assignment());
-    }
-    CLINGO_CATCH;
-}
-
-extern "C" auto clingo_propagate_init_add_literal(clingo_propagate_init_t *init, bool freeze,
-                                                  clingo_literal_t *solver_literal) -> bool {
-    CLINGO_TRY {
-        if (init == nullptr || solver_literal == nullptr) {
-            return fail_arguments();
-        }
-        *solver_literal = init->init->addLiteral(freeze);
-    }
-    CLINGO_CATCH;
-}
-
-extern "C" auto clingo_propagate_init_add_clause(clingo_propagate_init_t *init, clingo_literal_t const *literals,
-                                                 size_t size, bool *result) -> bool {
-    CLINGO_TRY {
-        if (init == nullptr || (literals == nullptr && size > 0) || result == nullptr) {
-            return fail_arguments();
-        }
-        *result = init->init->addClause(std::span{literals, size});
-    }
-    CLINGO_CATCH;
-}
-
-extern "C" auto clingo_propagate_init_add_weight_constraint(clingo_propagate_init_t *init,
-                                                            clingo_literal_t solver_literal,
-                                                            clingo_weighted_literal_t const *literals, size_t size,
-                                                            clingo_weight_t bound, clingo_weight_constraint_type_t type,
-                                                            bool compare_equal, bool *result) -> bool {
-    CLINGO_TRY {
-        if (init == nullptr || (literals == nullptr && size > 0) || result == nullptr) {
-            return fail_arguments();
-        }
-        *result = init->init->addWeightConstraint(solver_literal, map(literals, size), bound, type, compare_equal);
-    }
-    CLINGO_CATCH;
-}
-
 extern "C" auto clingo_propagate_init_add_minimize(clingo_propagate_init_t *init, clingo_literal_t solver_literal,
                                                    clingo_weight_t weight, clingo_weight_t priority) -> bool {
     CLINGO_TRY {
@@ -510,51 +439,19 @@ extern "C" auto clingo_propagate_init_add_minimize(clingo_propagate_init_t *init
     CLINGO_CATCH;
 }
 
-extern "C" auto clingo_propagate_init_propagate(clingo_propagate_init_t *init, bool *result) -> bool {
-    CLINGO_TRY {
-        if (init == nullptr || result == nullptr) {
-            return fail_arguments();
-        }
-        *result = init->init->propagate();
-    }
-    CLINGO_CATCH;
-}
-
-extern "C" auto clingo_propagate_control_thread_id(clingo_propagate_control_t const *control, clingo_id_t *thread_id)
-    -> bool {
-    CLINGO_TRY {
-        if (control == nullptr || thread_id == nullptr) {
-            return fail_arguments();
-        }
-        *thread_id = cpp_cast(control)->id();
-    }
-    CLINGO_CATCH;
-}
-
-extern "C" auto clingo_propagate_control_assignment(clingo_propagate_control_t const *control,
-                                                    clingo_assignment_t const **assignment) -> bool {
-    CLINGO_TRY {
-        if (control == nullptr || assignment == nullptr) {
-            return fail_arguments();
-        }
-        *assignment = c_cast(&cpp_cast(control)->assignment());
-    }
-    CLINGO_CATCH;
-}
-
-extern "C" auto clingo_propagate_control_add_literal(clingo_propagate_control_t *control, clingo_literal_t *result)
-    -> bool {
+extern "C" auto clingo_propagate_control_add_literal(clingo_propagate_control_t *control, bool freeze,
+                                                     clingo_literal_t *result) -> bool {
     CLINGO_TRY {
         if (control == nullptr || result == nullptr) {
             return fail_arguments();
         }
-        *result = cpp_cast(control)->addVariable();
+        *result = cpp_cast(control)->addVariable(freeze);
     }
     CLINGO_CATCH;
 }
 
-extern "C" auto clingo_propagate_control_add_watch(clingo_propagate_control_t *control, clingo_literal_t literal)
-    -> bool {
+extern "C" auto clingo_propagate_control_add_watch(clingo_propagate_control_t *control,
+                                                   clingo_literal_t literal) -> bool {
     CLINGO_TRY {
         if (control == nullptr) {
             return fail_arguments();
@@ -575,8 +472,8 @@ extern "C" auto clingo_propagate_control_has_watch(clingo_propagate_control_t co
     CLINGO_CATCH;
 }
 
-extern "C" auto clingo_propagate_control_remove_watch(clingo_propagate_control_t *control, clingo_literal_t literal)
-    -> bool {
+extern "C" auto clingo_propagate_control_remove_watch(clingo_propagate_control_t *control,
+                                                      clingo_literal_t literal) -> bool {
     CLINGO_TRY {
         if (control == nullptr) {
             return fail_arguments();
@@ -600,6 +497,18 @@ extern "C" auto clingo_propagate_control_add_clause(clingo_propagate_control_t *
         static_assert(static_cast<clingo_clause_type_t>(Potassco::ClauseType::transient_locked) ==
                       clingo_clause_type_volatile_static);
         *result = cpp_cast(control)->addClause(std::span{literals, size}, static_cast<Potassco::ClauseType>(type));
+    }
+    CLINGO_CATCH;
+}
+
+extern "C" auto clingo_propagate_control_add_weight_constraint(
+    clingo_propagate_control_t *control, clingo_literal_t solver_literal, clingo_weighted_literal_t const *literals,
+    size_t size, clingo_weight_t bound, clingo_weight_constraint_type_t type, bool *result) -> bool {
+    CLINGO_TRY {
+        if (control == nullptr || (literals == nullptr && size > 0) || result == nullptr) {
+            return fail_arguments();
+        }
+        *result = cpp_cast(control)->addWeightConstraint(solver_literal, map(literals, size), bound, type);
     }
     CLINGO_CATCH;
 }

--- a/lib/cxx-api/include/clingo/propagate.hh
+++ b/lib/cxx-api/include/clingo/propagate.hh
@@ -46,7 +46,7 @@ CLINGO_ENABLE_BITSET_ENUM(ClauseFlags);
 //!
 //! Literals in the trail are ordered by decision levels, where the first
 //! literal with a larger level than the previous literals is a decision; the
-//! following literals with same level are implied by this decision literal.
+//! following literals with the same level are implied by this decision literal.
 //! Each decision level up to and including the current decision level has a
 //! valid offset in the trail.
 class Trail {
@@ -154,10 +154,13 @@ class Assignment {
 
     //! Construct an assignment from the underlying C representation.
     explicit Assignment(clingo_assignment_t const *assignment) : assignment_(assignment) {}
+    //! Get the id of the thread to which the assignment belongs.
+    //! @return the id of the solving thread owning this assignment
+    [[nodiscard]] auto thread_id() const -> ProgramId { return Detail::call<clingo_assignment_thread_id>(assignment_); }
 
     //! Get the size of the assignment.
     //!
-    //! This is the number af all positive problem literals including
+    //! This is the number of all positive problem literals including
     //! unassigned literals.
     //!
     //! @return the size of the assignment
@@ -301,6 +304,114 @@ class Assignment {
     clingo_assignment_t const *assignment_;
 };
 
+//! Class to control a user-defined propagator.
+//!
+//! This class provides methods for adding clauses, literals, and nogoods, as
+//! well as managing watches and performing propagation.
+class PropagateControl {
+  public:
+    //! Constructor from the underlying C representation.
+    //!
+    //! @param ctl the C representation of the control object
+    explicit PropagateControl(clingo_propagate_control_t *ctl) : ctl_{ctl} {}
+    //! Constructor from the underlying C representation.
+    //!
+    //! @param init the C representation of the init object
+    explicit PropagateControl(clingo_propagate_init_t *init)
+        : PropagateControl(Detail::call<clingo_propagate_init_control>(init)) {}
+
+    //! Adds a literal to the problem or the active solver thread.
+    //!
+    //! @note If the function is called in the context of a particular solver thread, the literal is solver local:
+    //! solver local literals are not shared between solvers and are removed at the end of the current solving step.
+    //! @param freeze whether to freeze the literal
+    //! @return the added literal
+    [[nodiscard]] auto add_literal(bool freeze = true) const -> SolverLiteral {
+        return Detail::call<clingo_propagate_control_add_literal>(ctl_, freeze);
+    }
+
+    //! Add a clause to the solver.
+    //!
+    //! If adding the clause results in a conflict or requires backtracking, the function returns false
+    //! and the calling propagator must not add further clauses from the current callback.
+    //!
+    //! @param literals the literals of the clause to add
+    //! @param flags the flags for the clause
+    //! @return whether the clause was added without conflict
+    [[nodiscard]] auto add_clause(SolverLiteralSpan literals, ClauseFlags flags = ClauseFlags::none) const -> bool {
+        return Detail::call<clingo_propagate_control_add_clause>(ctl_, literals.data(), literals.size(),
+                                                                 static_cast<clingo_clause_type_t>(flags));
+    }
+
+    //! Add a clause to the solver.
+    //!
+    //! @overload add_clause(SolverLiteralSpan literals, ClauseFlags flags = ClauseFlags::none)
+    [[nodiscard]] auto add_clause(SolverLiteralList literals, ClauseFlags flags = ClauseFlags::none) const -> bool {
+        return add_clause(SolverLiteralSpan{literals}, flags);
+    }
+
+    //! Add a weight constraint to the solver.
+    //!
+    //! @param literal the literal associated with the constraint
+    //! @param literals the weighted literals of the constraint
+    //! @param bound the bound of the constraint
+    //! @param type the type of the weight constraint
+    //! @return whether the constraint was added without a conflict
+    [[nodiscard]] auto add_weight_constraint(SolverLiteral literal, WeightedLiteralSpan literals, Weight bound,
+                                             WeightConstraintType type) const -> bool {
+        return Detail::call<clingo_propagate_control_add_weight_constraint>(ctl_, literal, literals.data(),
+                                                                            literals.size(), bound, type);
+    }
+
+    //! Add a nogood to the solver.
+    //!
+    //! This is the same as calling add_clause() with the negated literals.
+    //!
+    //! @param literals the literals of the nogood to add
+    //! @param flags the flags for the nogood
+    //! @return whether the nogood was added without conflict
+    [[nodiscard]] auto add_nogood(SolverLiteralSpan literals, ClauseFlags flags = ClauseFlags::none) const -> bool {
+        return add_clause(Detail::transform(literals, [](auto const &lit) { return -lit; }), flags);
+    }
+
+    //! Add a watch for the given solver literal.
+    //!
+    //! @note If called in the context of initialization, the watch is added to all current and future solving threads.
+    //! Otherwise, the watch is only added to the active solving thread.
+    //!
+    //! @param literal the literal to watch
+    void add_watch(SolverLiteral literal) const {
+        Detail::handle_error(clingo_propagate_control_add_watch(ctl_, literal));
+    }
+
+    //! Check whether the given solver literal is watched in the current context.
+    //!
+    //! @param literal the literal to check
+    //! @return whether the literal is watched
+    [[nodiscard]] auto has_watch(SolverLiteral literal) const -> bool {
+        return Detail::call<clingo_propagate_control_has_watch>(ctl_, literal);
+    }
+
+    //! Remove a watch for the given solver literal.
+    //!
+    //! @param lit the literal to remove the watch for
+    void remove_watch(SolverLiteral lit) const {
+        Detail::handle_error(clingo_propagate_control_remove_watch(ctl_, lit));
+    }
+
+    //! Propagate consequences of previously added clauses.
+    //!
+    //! If a conflict is detected during propagation, the function returns
+    //! false and the calling propagator must not add further clauses from the
+    //! current callback.
+    //!
+    //! @return whether propagation succeeded without conflict
+    [[nodiscard]] auto propagate() const -> bool { return Detail::call<clingo_propagate_control_propagate>(ctl_); }
+
+  private:
+    clingo_propagate_control_t *ctl_;
+};
+
 //! Object to initialize a user-defined propagator before each solving step.
 //!
 //! Each @link cpp_base symbolic or theory atom@endlink is uniquely associated
@@ -310,24 +421,17 @@ class Assignment {
 //! literals (@ref ::SolverLiteral). There is a surjective mapping from program
 //! atoms to solver literals.
 //!
-//! All methods called during propagation use solver literals whereas
+//! All methods called during propagation use solver literals, whereas
 //! Clingo::Atom::literal() and Clingo::TheoryAtom::literal() return program
 //! literals. The function Clingo::PropagateInit::solver_literal() can be used to map
 //! program literals or @link Clingo::TheoryElement::condition_id() condition
 //! ids@endlink to solver literals.
-class PropagateInit {
+class PropagateInit : public PropagateControl {
   public:
     //! Constructor from the underlying C representation.
     //!
     //! @param init the C representation of the initialization object
-    explicit PropagateInit(clingo_propagate_init_t *init) : init_{init} {}
-
-    //! Get the assignment of the current solver.
-    //!
-    //! @return the assignment of the current solver
-    [[nodiscard]] auto assignment() const -> Assignment {
-        return Assignment{Detail::call<clingo_propagate_init_assignment>(init_)};
-    }
+    explicit PropagateInit(clingo_propagate_init_t *init) : PropagateControl(init), init_{init} {}
 
     //! Get the library object associated with the propagator.
     //!
@@ -378,39 +482,12 @@ class PropagateInit {
             clingo_propagate_init_set_undo_mode(init_, static_cast<clingo_propagator_undo_mode_t>(mode)));
     }
 
-    //! Add a clause to the solver.
+    //! Map a program literal to a solver literal.
     //!
-    //! If the clause could not be added to the solver, there is a top-level
-    //! conflict and the underlying problem is unsatisfiable. The function
-    //! returns false in this case.
-    //!
-    //! @param literals the literals of the clause to add
-    //! @return whether the clause was added without conflict
-    [[nodiscard]] auto add_clause(SolverLiteralSpan literals) const -> bool {
-        return Detail::call<clingo_propagate_init_add_clause>(init_, literals.data(), literals.size());
-    }
-
-    //! Add a clause to the solver.
-    //!
-    //! If the clause could not be added to the solver, there is a top-level
-    //! conflict and the underlying problem is unsatisfiable. The function
-    //! returns false in this case.
-    //!
-    //! @param literals the literals of the clause to add
-    //! @return whether the clause was added without conflict
-    [[nodiscard]] auto add_clause(SolverLiteralList literals) const -> bool {
-        return add_clause(SolverLiteralSpan{literals});
-    }
-
-    //! Add a literal to the solver.
-    //!
-    //! The literal can be frozen to exempt it from being eliminated during
-    //! preprocessing.
-    //!
-    //! @param freeze whether to freeze the literal
-    //! @return the added literal
-    [[nodiscard]] auto add_literal(bool freeze = true) const -> SolverLiteral {
-        return Detail::call<clingo_propagate_init_add_literal>(init_, freeze);
+    //! @param literal the program literal to map
+    //! @return the corresponding solver literal
+    [[nodiscard]] auto solver_literal(ProgramLiteral literal) const -> SolverLiteral {
+        return Detail::call<clingo_propagate_init_solver_literal>(init_, literal);
     }
 
     //! Add a weighted literal to minimize to the solver.
@@ -422,185 +499,17 @@ class PropagateInit {
         Detail::handle_error(clingo_propagate_init_add_minimize(init_, literal, weight, priority));
     }
 
-    //! Add a watch for the given solver literal.
-    //!
-    //! The Clingo::Propagator::propagate() is called whenever the watched
-    //! literal is assigned a truth value.
-    //!
-    //! Literals can be added to the given thread or all threads if no thread
-    //! id is given.
-    //!
-    //! @param literal the literal to watch
-    //! @param thread_id the id of the thread to add the watch to
-    void add_watch(SolverLiteral literal, std::optional<ProgramId> thread_id = std::nullopt) const {
-        if (thread_id) {
-            Detail::handle_error(clingo_propagate_init_add_watch_to_thread(init_, literal, *thread_id));
-        } else {
-            Detail::handle_error(clingo_propagate_init_add_watch(init_, literal));
-        }
-    }
-
-    //! Add a weight constraint to the solver.
-    //!
-    //! @param literal the literal associated with the constraint
-    //! @param literals the weighted literals of the constraint
-    //! @param bound the bound of the constraint
-    //! @param type the type of the weight constraint
-    //! @param compare_equal if true compare equal instead of less than equal
-    //! @return whether the constraint was added without conflict
-    [[nodiscard]] auto add_weight_constraint(SolverLiteral literal, WeightedLiteralSpan literals, Weight bound,
-                                             WeightConstraintType type, bool compare_equal) const -> bool {
-        return Detail::call<clingo_propagate_init_add_weight_constraint>(init_, literal, literals.data(),
-                                                                         literals.size(), bound, type, compare_equal);
-    }
-
     //! Freeze the given literal in the solver.
     //!
-    //! Frozen literals are not eliminated during preprocessing.
+    //! Frozen literals are exempt from elimination during preprocessing.
     //!
     //! @param literal the literal to freeze
     void freeze_literal(SolverLiteral literal) const {
         Detail::handle_error(clingo_propagate_init_freeze_literal(init_, literal));
     }
 
-    //! Propagate consequences of the underlying problem.
-    //!
-    //! This function can be called to propagte consequences of previously
-    //! added clauses and weight constraints.
-    //!
-    //! @return whether propagation succeeded without conflict
-    [[nodiscard]] auto propagate() const -> bool { return Detail::call<clingo_propagate_init_propagate>(init_); }
-
-    //! Remove a watch for the given solver literal.
-    //!
-    //! If no thread id is given, the watch is removed from all threads.
-    //!
-    //! @param literal the literal to remove the watch for
-    //! @param thread_id the id of the thread to remove the watch from
-    void remove_watch(SolverLiteral literal, std::optional<ProgramId> thread_id) const {
-        if (thread_id) {
-            Detail::handle_error(clingo_propagate_init_remove_watch_from_thread(init_, literal, *thread_id));
-        } else {
-            Detail::handle_error(clingo_propagate_init_remove_watch(init_, literal));
-        }
-    }
-
-    //! Map a program literal to a solver literal.
-    //!
-    //! @param literal the program literal to map
-    //! @return the corresponding solver literal
-    [[nodiscard]] auto solver_literal(ProgramLiteral literal) const -> SolverLiteral {
-        return Detail::call<clingo_propagate_init_solver_literal>(init_, literal);
-    }
-
   private:
     clingo_propagate_init_t *init_;
-};
-
-//! Class to control propagation of a user-defined propagator.
-//!
-//! This class provides methods for adding clauses, literals, and nogoods, as
-//! well as managing watches and performing propagation.
-class PropagateControl {
-  public:
-    //! Constructor from the underlying C representation.
-    //!
-    //! @param ctl the C representation of the control object
-    explicit PropagateControl(clingo_propagate_control_t *ctl) : ctl_{ctl} {}
-
-    //! Add solver local literal to the solver.
-    //!
-    //! Solver local literals are not shared between solvers and are removed at
-    //! the end of the current solving step.
-    //!
-    //! @return the added literal
-    [[nodiscard]] auto add_literal() const -> SolverLiteral {
-        return Detail::call<clingo_propagate_control_add_literal>(ctl_);
-    }
-
-    //! Add a clause to the solver.
-    //!
-    //! If adding the clause results in a conflict, the function returns false
-    //! and the calling propagator must not add further clauses from the
-    //! current callback.
-    //!
-    //! @param literals the literals of the clause to add
-    //! @param flags the flags for the clause
-    //! @return whether the clause was added without conflict
-    [[nodiscard]] auto add_clause(SolverLiteralSpan literals, ClauseFlags flags = ClauseFlags::none) const -> bool {
-        return Detail::call<clingo_propagate_control_add_clause>(ctl_, literals.data(), literals.size(),
-                                                                 static_cast<clingo_clause_type_t>(flags));
-    }
-
-    //! Add a clause to the solver.
-    //!
-    //! If adding the clause results in a conflict, the function returns false
-    //! and the calling propagator must not add further clauses from the
-    //! current callback.
-    //!
-    //! @param literals the literals of the clause to add
-    //! @param flags the flags for the clause
-    //! @return whether the clause was added without conflict
-    [[nodiscard]] auto add_clause(SolverLiteralList literals, ClauseFlags flags = ClauseFlags::none) const -> bool {
-        return add_clause(SolverLiteralSpan{literals}, flags);
-    }
-
-    //! Add a nogood to the solver.
-    //!
-    //! This is the same as calling add clause with the negated literals.
-    //!
-    //! @param literals the literals of the nogood to add
-    //! @param flags the flags for the nogood
-    //! @return whether the nogood was added without conflict
-    [[nodiscard]] auto add_nogood(SolverLiteralSpan literals, ClauseFlags flags = ClauseFlags::none) const -> bool {
-        return add_clause(Detail::transform(literals, [](auto const &lit) { return -lit; }), flags);
-    }
-
-    //! Add a watch for the given solver literal.
-    //!
-    //! @param literal the literal to watch
-    void add_watch(SolverLiteral literal) const {
-        Detail::handle_error(clingo_propagate_control_add_watch(ctl_, literal));
-    }
-
-    //! Check whether the given solver literal is watched.
-    //!
-    //! @param literal the literal to check
-    //! @return whether the literal is watched
-    [[nodiscard]] auto has_watch(SolverLiteral literal) const -> bool {
-        return Detail::call<clingo_propagate_control_has_watch>(ctl_, literal);
-    }
-
-    //! Propagate consequences of previously added clauses.
-    //!
-    //! If a confilct is detected during propagation, the function returns
-    //! false and the calling propagator must not add further clauses from the
-    //! current callback.
-    //!
-    //! @return whether propagation succeeded without conflict
-    [[nodiscard]] auto propagate() const -> bool { return Detail::call<clingo_propagate_control_propagate>(ctl_); }
-
-    //! Remove a watch for the given solver literal.
-    //!
-    //! @param lit the literal to remove the watch for
-    void remove_watch(SolverLiteral lit) const {
-        Detail::handle_error(clingo_propagate_control_remove_watch(ctl_, lit));
-    }
-
-    //! Get the assignment of the current solver.
-    //!
-    //! @return the assignment of the current solver
-    [[nodiscard]] auto assignment() const -> Assignment {
-        return Assignment{Detail::call<clingo_propagate_control_assignment>(ctl_)};
-    }
-
-    //! Get the thread id of the current solver.
-    //!
-    //! @return the thread id of the current solver
-    [[nodiscard]] auto thread_id() const -> ProgramId { return Detail::call<clingo_propagate_control_thread_id>(ctl_); }
-
-  private:
-    clingo_propagate_control_t *ctl_;
 };
 
 //! Interface for user-defined propagators.
@@ -612,25 +521,35 @@ class Propagator {
     Propagator(Propagator &&other) = delete;
     //! Disable copy and move operations.
     auto operator=(Propagator &&other) -> Propagator & = delete;
-    //! The default destructor.
+    //! The destructor.
     virtual ~Propagator() = default;
 
     //! Callback to initialize the propagator before each solving step.
     //!
     //! @param init the initialization object
-    void init(PropagateInit init) { do_init(init); }
+    void init(Assignment assignment, PropagateInit init) { do_init(assignment, init); }
+    //! Callback to initialize/setup thread-specific data for the propagator.
+    //!
+    //! This function is called once for each solving thread before solving of the current step is started.
+    //!
+    //! @param assignment the current assignment of the solver
+    //! @param ctl the propagate control object
+    void attach(Assignment assignment, PropagateControl ctl) { do_attach(assignment, ctl); }
 
     //! Callback to propagate consequences of the given literals.
     //!
-    //! The function is only called for watched literals that were assigned on
+    //! The function is only called for watched literals assigned on
     //! the current decision level.
     //!
     //! A propagator can add clauses here to propagate consequences of the
     //! underlying theory.
     //!
+    //! @param assignment the current assignment of the solver
     //! @param ctl the propagate control object
     //! @param changes the literals that were assigned on the current decision level
-    void propagate(PropagateControl ctl, ProgramLiteralSpan changes) { do_propagate(ctl, changes); }
+    void propagate(Assignment assignment, PropagateControl ctl, ProgramLiteralSpan changes) {
+        do_propagate(assignment, ctl, changes);
+    }
 
     //! Called when the solver backtracks to a previous decision level.
     //!
@@ -640,12 +559,9 @@ class Propagator {
     //! Clingo::PropagateInit::undo_mode() can be used to control when this
     //! function is called.
     //!
-    //! @param thread_id the id of the current solver thread
     //! @param assignment the current assignment of the solver
     //! @param changes the literals that were assigned on the current decision level
-    void undo(ProgramId thread_id, Assignment assignment, ProgramLiteralSpan changes) {
-        do_undo(thread_id, assignment, changes);
-    }
+    void undo(Assignment assignment, ProgramLiteralSpan changes) { do_undo(assignment, changes); }
 
     //! Callback that is called on propagation fixpoints or total assignments.
     //!
@@ -655,15 +571,17 @@ class Propagator {
     //! Like in Clingo::Propagator::Propagate(), a propagator can add clauses
     //! here to propagate consequences or discard the current assignment.
     //!
+    //! @param assignment the current assignment of the solver
     //! @param ctl the propagate control object
-    void check(PropagateControl ctl) { do_check(ctl); }
+    void check(Assignment assignment, PropagateControl ctl) { do_check(assignment, ctl); }
 
   private:
-    virtual void do_init([[maybe_unused]] PropagateInit init) {}
-    virtual void do_propagate([[maybe_unused]] PropagateControl ctl, [[maybe_unused]] ProgramLiteralSpan changes) {}
-    virtual void do_undo([[maybe_unused]] uint32_t thread_id, [[maybe_unused]] Assignment assignment,
-                         [[maybe_unused]] ProgramLiteralSpan changes) {}
-    virtual void do_check([[maybe_unused]] PropagateControl ctl) {}
+    virtual void do_init([[maybe_unused]] Assignment assignment, [[maybe_unused]] PropagateInit init) {}
+    virtual void do_attach([[maybe_unused]] Assignment assignment, [[maybe_unused]] PropagateControl ctl) {}
+    virtual void do_propagate([[maybe_unused]] Assignment assignment, [[maybe_unused]] PropagateControl ctl,
+                              [[maybe_unused]] ProgramLiteralSpan changes) {}
+    virtual void do_undo([[maybe_unused]] Assignment assignment, [[maybe_unused]] ProgramLiteralSpan changes) {}
+    virtual void do_check([[maybe_unused]] Assignment assignment, [[maybe_unused]] PropagateControl ctl) {}
 };
 
 //! Interface for user-defined propagators with a decision heuristic.
@@ -678,16 +596,14 @@ class Heuristic : public Propagator {
     //! assigned. This choice can be overridden by returning a different
     //! literal.
     //!
-    //! @param thread_id the id of the current solver thread
     //! @param assignment the current assignment of the solver
     //! @param literal the fallback literal
-    auto decide(ProgramId thread_id, Assignment assignment, SolverLiteral literal) -> SolverLiteral {
-        return do_decide(thread_id, assignment, literal);
+    auto decide(Assignment assignment, SolverLiteral literal) -> SolverLiteral {
+        return do_decide(assignment, literal);
     }
 
   private:
-    virtual auto do_decide([[maybe_unused]] uint32_t thread_id, [[maybe_unused]] Assignment assignment,
-                           clingo_literal_t literal) -> clingo_literal_t {
+    virtual auto do_decide([[maybe_unused]] Assignment assignment, clingo_literal_t literal) -> clingo_literal_t {
         return literal;
     }
 };
@@ -697,35 +613,41 @@ class Heuristic : public Propagator {
 namespace Detail {
 
 inline static constexpr auto c_propagator = clingo_propagator_t{
-    [](clingo_propagate_init_t *init, void *data) -> bool {
+    [](clingo_assignment_t const *assignment, clingo_propagate_init_t *init, void *data) -> bool {
         auto &self = *static_cast<Propagator *>(data);
         CLINGO_TRY {
-            self.init(PropagateInit{init});
+            self.init(Assignment{assignment}, PropagateInit{init});
         }
         CLINGO_CATCH;
     },
-    [](clingo_propagate_control_t *control, clingo_literal_t const *changes, size_t size, void *data) -> bool {
+    [](clingo_assignment_t const *assignment, clingo_propagate_control_t *control, void *data) {
         auto &self = *static_cast<Propagator *>(data);
         CLINGO_TRY {
-            self.propagate(PropagateControl{control}, SolverLiteralSpan{changes, size});
+            self.attach(Assignment{assignment}, PropagateControl{control});
         }
         CLINGO_CATCH;
     },
-    [](clingo_propagate_control_t const *control, clingo_literal_t const *changes, size_t size, void *data) {
+    [](clingo_assignment_t const *assignment, clingo_propagate_control_t *control, clingo_literal_t const *changes,
+       size_t size, void *data) -> bool {
+        auto &self = *static_cast<Propagator *>(data);
+        CLINGO_TRY {
+            self.propagate(Assignment{assignment}, PropagateControl{control}, SolverLiteralSpan{changes, size});
+        }
+        CLINGO_CATCH;
+    },
+    [](clingo_assignment_t const *assignment, clingo_literal_t const *changes, size_t size, void *data) {
         auto &self = *static_cast<Propagator *>(data);
         try {
-            uint32_t thread_id = Detail::call<clingo_propagate_control_thread_id>(control);
-            clingo_assignment_t const *assignment = Detail::call<clingo_propagate_control_assignment>(control);
-            self.undo(thread_id, Assignment{assignment}, SolverLiteralSpan{changes, size});
+            self.undo(Assignment{assignment}, SolverLiteralSpan{changes, size});
         } catch (std::exception const &e) {
             printf("panic: %s\n", e.what());
             std::abort();
         }
     },
-    [](clingo_propagate_control_t *control, void *data) -> bool {
+    [](clingo_assignment_t const *assignment, clingo_propagate_control_t *control, void *data) -> bool {
         auto &self = *static_cast<Propagator *>(data);
         CLINGO_TRY {
-            self.check(PropagateControl{control});
+            self.check(Assignment{assignment}, PropagateControl{control});
         }
         CLINGO_CATCH;
     },
@@ -735,15 +657,16 @@ inline static constexpr auto c_propagator = clingo_propagator_t{
 
 inline static constexpr auto c_heuristic = clingo_propagator_t{
     c_propagator.init,
+    c_propagator.attach,
     c_propagator.propagate,
     c_propagator.undo,
     c_propagator.check,
-    [](clingo_id_t thread_id, clingo_assignment_t const *assignment, clingo_literal_t fallback, void *data,
+    [](clingo_assignment_t const *assignment, clingo_literal_t fallback, void *data,
        clingo_literal_t *decision) -> bool {
         auto &self = *static_cast<Propagator *>(data);
         CLINGO_TRY {
             // NOLINTBEGIN
-            *decision = static_cast<Heuristic &>(self).decide(thread_id, Assignment{assignment}, fallback);
+            *decision = static_cast<Heuristic &>(self).decide(Assignment{assignment}, fallback);
             // NOLINTEND
         }
         CLINGO_CATCH;

--- a/lib/cxx-api/include/clingo/propagate.hh
+++ b/lib/cxx-api/include/clingo/propagate.hh
@@ -345,7 +345,12 @@ class PropagateControl {
 
     //! Add a clause to the solver.
     //!
-    //! @overload add_clause(SolverLiteralSpan literals, ClauseFlags flags = ClauseFlags::none)
+    //! If adding the clause results in a conflict or requires backtracking, the function returns false
+    //! and the calling propagator must not add further clauses from the current callback.
+    //!
+    //! @param literals the literals of the clause to add
+    //! @param flags the flags for the clause
+    //! @return whether the clause was added without conflict
     [[nodiscard]] auto add_clause(SolverLiteralList literals, ClauseFlags flags = ClauseFlags::none) const -> bool {
         return add_clause(SolverLiteralSpan{literals}, flags);
     }
@@ -526,6 +531,7 @@ class Propagator {
 
     //! Callback to initialize the propagator before each solving step.
     //!
+    //! @param assignment the current assignment of the solver
     //! @param init the initialization object
     void init(Assignment assignment, PropagateInit init) { do_init(assignment, init); }
     //! Callback to initialize/setup thread-specific data for the propagator.

--- a/lib/cxx-api/tests/error.cc
+++ b/lib/cxx-api/tests/error.cc
@@ -18,7 +18,7 @@ class TestPropagator : public Heuristic {
     explicit TestPropagator(std::string throw_str) : throw_{std::move(throw_str)} {}
 
   private:
-    void do_init(PropagateInit init) override {
+    void do_init([[maybe_unused]] Assignment assignment, PropagateInit init) override {
         if (throw_.find('i') != std::string::npos) {
             throw std::runtime_error("prop: init");
         }
@@ -26,14 +26,14 @@ class TestPropagator : public Heuristic {
         init.add_watch(init.add_literal());
     }
 
-    void do_propagate([[maybe_unused]] PropagateControl control, [[maybe_unused]] SolverLiteralSpan changes) override {
+    void do_propagate([[maybe_unused]] Assignment assignment, [[maybe_unused]] PropagateControl control,
+                      [[maybe_unused]] SolverLiteralSpan changes) override {
         if (throw_.find('p') != std::string::npos) {
             throw std::runtime_error("prop: propagate");
         }
     }
 
-    auto do_decide([[maybe_unused]] ProgramId thread_id, [[maybe_unused]] Assignment const assignment,
-                   SolverLiteral fallback) -> SolverLiteral override {
+    auto do_decide([[maybe_unused]] Assignment const assignment, SolverLiteral fallback) -> SolverLiteral override {
         if (throw_.find('d') != std::string::npos) {
             throw std::runtime_error("prop: decide");
         }

--- a/lib/cxx-api/tests/propagate.cc
+++ b/lib/cxx-api/tests/propagate.cc
@@ -12,6 +12,7 @@
 #include <array>
 #include <barrier>
 #include <mutex>
+#include <set>
 
 namespace Clingo::Test {
 
@@ -19,7 +20,7 @@ namespace {
 
 class AIFFBPropagator : public Propagator {
   public:
-    void do_init(PropagateInit init) override {
+    void do_init([[maybe_unused]] Assignment assignment, PropagateInit init) override {
         auto watch = [&](const char *p) {
             auto plit = init.base().get(Function(init.library(), p))->literal();
             int slit = init.solver_literal(plit);
@@ -32,6 +33,7 @@ class AIFFBPropagator : public Propagator {
             slit_b = watch("b");
         }
         errors.clear();
+        attached.clear();
         n_threads = init.number_of_threads();
         if (fail_thread < n_threads) {
             barrier.emplace(n_threads);
@@ -39,14 +41,24 @@ class AIFFBPropagator : public Propagator {
             barrier.reset();
         }
     }
+    void do_attach([[maybe_unused]] Assignment assignment, [[maybe_unused]] PropagateControl ctl) override {
+        auto thread_id = assignment.thread_id();
+        REQUIRE(thread_id < n_threads);
+        auto lock = std::lock_guard{mut};
+        REQUIRE(attached.insert(thread_id).second);
+    }
 
-    void do_check(PropagateControl control) override {
+    void do_check(Assignment assignment, PropagateControl control) override {
+        auto thread_id = assignment.thread_id();
         for (int p : {slit_a, slit_b}) {
             if (!control.has_watch(p)) {
                 auto lock = std::lock_guard{mut};
-                errors.push_back("solver " + std::to_string(control.thread_id()) + " misses watch " +
-                                 std::to_string(p));
+                errors.push_back("solver " + std::to_string(thread_id) + " misses watch " + std::to_string(p));
             }
+        }
+        {
+            auto lock = std::lock_guard{mut};
+            REQUIRE(attached.contains(thread_id));
         }
         if (barrier) {
             barrier->arrive_and_wait();
@@ -56,16 +68,16 @@ class AIFFBPropagator : public Propagator {
                     barrier.reset();
                 }
             }
-            if (control.thread_id() == fail_thread) {
-                throw std::runtime_error("Forcing error on solver " + std::to_string(control.thread_id()));
+            if (thread_id == fail_thread) {
+                throw std::runtime_error("Forcing error on solver " + std::to_string(thread_id));
             }
         }
     }
 
-    void do_propagate(PropagateControl control, SolverLiteralSpan changes) override {
+    void do_propagate(Assignment assignment, PropagateControl control, SolverLiteralSpan changes) override {
         auto propagate = [&](auto p, auto q) {
             if (std::ranges::find(changes, p) != changes.end()) {
-                assert(control.assignment().is_true(p));
+                assert(assignment.is_true(p));
                 auto clause = std::vector{-p, q};
                 std::ignore = control.add_clause(clause, ClauseFlags::tag);
             }
@@ -80,6 +92,7 @@ class AIFFBPropagator : public Propagator {
     ProgramId fail_thread = std::numeric_limits<ProgramId>::max();
     std::vector<std::string> errors;
     std::optional<std::barrier<>> barrier;
+    std::set<ProgramId> attached;
     std::mutex mut;
 };
 
@@ -87,7 +100,7 @@ class AssertingPropagator : public Heuristic {
   public:
     AssertingPropagator(bool lock = false) : lock_(lock) {}
 
-    void do_init(PropagateInit init) override {
+    void do_init([[maybe_unused]] Assignment assignment, PropagateInit init) override {
         auto lit = [&](std::string_view name) {
             for (auto base = init.base().get(std::make_pair(name, 0)); auto const &[_, atom] : *base) {
                 return init.solver_literal(atom.literal());
@@ -106,9 +119,8 @@ class AssertingPropagator : public Heuristic {
         }
     }
 
-    void do_propagate(PropagateControl control, SolverLiteralSpan changes) override {
+    void do_propagate(Assignment ass, PropagateControl control, SolverLiteralSpan changes) override {
         REQUIRE(!changes.empty());
-        auto ass = control.assignment();
         if (ass.is_false(value_lit_) && ass.is_false(end_lit_)) {
             auto nogood = std::array{start_lit_, -end_lit_, -value_lit_};
             auto dl = ass.decision_level();
@@ -117,8 +129,7 @@ class AssertingPropagator : public Heuristic {
         }
     }
 
-    auto do_decide(ProgramId thread_id, Assignment assignment, SolverLiteral fallback) -> int override {
-        REQUIRE(thread_id == 0);
+    auto do_decide(Assignment assignment, SolverLiteral fallback) -> int override {
         if (assignment.is_free(end_lit_)) {
             return -end_lit_;
         }
@@ -137,7 +148,7 @@ class AssertingPropagator : public Heuristic {
 
 class InitPropagator : public Propagator {
   public:
-    void do_init(PropagateInit init) override {
+    void do_init(Assignment ass, PropagateInit init) override {
         auto lib = init.library();
         auto a = init.base().get(Function(lib, "a"));
         auto b = init.base().get(Function(lib, "b"));
@@ -158,7 +169,7 @@ class InitPropagator : public Propagator {
 
         // c <=> {a, b} >= 2
         std::ignore = init.add_weight_constraint(lit_c, std::to_array<WeightedLiteral>({{lit_a, 1}, {lit_b, 1}}), 2,
-                                                 WeightConstraintType::equivalence, false);
+                                                 WeightConstraintType::equivalence);
 
         init.add_minimize(lit_a, -1, 0);
 
@@ -166,7 +177,6 @@ class InitPropagator : public Propagator {
         REQUIRE(init.base().size() == 3);
 
         // Assignment checks
-        auto ass = init.assignment();
         REQUIRE(ass.value(lit_a) == std::nullopt);
         REQUIRE(!ass.is_true(lit_a));
         REQUIRE(!ass.is_false(lit_a));
@@ -183,7 +193,7 @@ class InitPropagator : public Propagator {
 
 class AddLiteralPropagator : public Propagator {
   public:
-    void do_check(PropagateControl control) override {
+    void do_check([[maybe_unused]] Assignment assignment, PropagateControl control) override {
         if (!added_) {
             added_ = true;
             int lit = control.add_literal();
@@ -201,7 +211,7 @@ class AddLiteralPropagator : public Propagator {
 
 class HeuristicPropagator : public Heuristic {
   public:
-    void do_init(PropagateInit init) override {
+    void do_init([[maybe_unused]] Assignment assignment, PropagateInit init) override {
         auto lib = init.library();
         auto a = init.base().get(Function(lib, "a"));
         auto b = init.base().get(Function(lib, "b"));
@@ -210,8 +220,7 @@ class HeuristicPropagator : public Heuristic {
         lit_b_ = init.solver_literal(b->literal());
     }
 
-    auto do_decide(ProgramId thread_id, Assignment assignment, SolverLiteral fallback) -> int override {
-        REQUIRE(thread_id == 0);
+    auto do_decide(Assignment assignment, SolverLiteral fallback) -> int override {
         if (assignment.is_free(lit_a_)) {
             return lit_a_;
         }
@@ -228,9 +237,8 @@ class HeuristicPropagator : public Heuristic {
 
 class PropagateControlPropagator : public Propagator {
   public:
-    void do_init(PropagateInit init) override {
+    void do_init(Assignment ass, PropagateInit init) override {
         auto lib = init.library();
-        auto ass = init.assignment();
         init.check_mode(PropagatorCheckMode::none);
         REQUIRE(init.check_mode() == PropagatorCheckMode::none);
         REQUIRE(init.number_of_threads() == 1);
@@ -244,8 +252,7 @@ class PropagateControlPropagator : public Propagator {
         init.add_watch(-lit_a_);
     }
 
-    void do_propagate(PropagateControl control, SolverLiteralSpan changes) override {
-        auto ass = control.assignment();
+    void do_propagate(Assignment ass, PropagateControl control, SolverLiteralSpan changes) override {
         auto trail = ass.trail();
         auto lvl = ass.decision_level();
 
@@ -257,15 +264,14 @@ class PropagateControlPropagator : public Propagator {
         REQUIRE(*(trail.begin(lvl)) == -lit_a_);
         REQUIRE(std::vector<SolverLiteral>{trail.begin(lvl), trail.end(lvl)} == std::vector<SolverLiteral>{-lit_a_});
         REQUIRE(ass.decision(lvl) == -lit_a_);
-        REQUIRE(control.thread_id() == 0);
+        REQUIRE(ass.thread_id() == 0);
         REQUIRE(control.has_watch(-lit_a_));
         REQUIRE(control.propagate());
         REQUIRE(!control.add_clause(std::array{lit_a_}));
     }
 
-    void do_undo(ProgramId thread_id, Assignment assignment, SolverLiteralSpan changes) override {
+    void do_undo(Assignment assignment, SolverLiteralSpan changes) override {
         REQUIRE(assignment.size() > 0);
-        REQUIRE(thread_id == 0);
         REQUIRE(std::ranges::find(changes, -lit_a_) != changes.end());
     }
 
@@ -275,7 +281,7 @@ class PropagateControlPropagator : public Propagator {
 
 class ModePropagator : public Propagator {
   public:
-    void do_init(PropagateInit init) override {
+    void do_init([[maybe_unused]] Assignment assignment, PropagateInit init) override {
         init.check_mode(PropagatorCheckMode::fixpoint);
         init.undo_mode(PropagatorUndoMode::always);
 
@@ -283,17 +289,16 @@ class ModePropagator : public Propagator {
         REQUIRE(init.undo_mode() == PropagatorUndoMode::always);
     }
 
-    void do_check(PropagateControl control) override {
+    void do_check(Assignment assignment, [[maybe_unused]] PropagateControl control) override {
         ++num_check;
-        auto dl = control.assignment().decision_level();
+        auto dl = assignment.decision_level();
         REQUIRE(level.back() <= dl);
         if (level.back() != dl) {
             level.emplace_back(dl);
         }
     }
 
-    void do_undo(ProgramId thread_id, Assignment assignment, SolverLiteralSpan changes) override {
-        REQUIRE(thread_id == 0);
+    void do_undo(Assignment assignment, SolverLiteralSpan changes) override {
         REQUIRE(assignment.size() > 0);
         REQUIRE(changes.empty());
         ++num_undo;
@@ -367,6 +372,7 @@ TEST_CASE_METHOD(Fixture, "propagate exception", "[cxx][propagate][exception]") 
         REQUIRE_THROWS_MATCHES(solve(), std::runtime_error,
                                MessageMatches(ContainsSubstring("solver " + std::to_string(n - 1))));
         REQUIRE(ref.n_threads == n);
+        REQUIRE(ref.attached.size() == n);
     }
 }
 

--- a/lib/cxx-api/tests/propagate.cc
+++ b/lib/cxx-api/tests/propagate.cc
@@ -74,7 +74,8 @@ class AIFFBPropagator : public Propagator {
         }
     }
 
-    void do_propagate(Assignment assignment, PropagateControl control, SolverLiteralSpan changes) override {
+    void do_propagate([[maybe_unused]] Assignment assignment, PropagateControl control,
+                      SolverLiteralSpan changes) override {
         auto propagate = [&](auto p, auto q) {
             if (std::ranges::find(changes, p) != changes.end()) {
                 assert(assignment.is_true(p));

--- a/lib/python-api/src/propagate.cc
+++ b/lib/python-api/src/propagate.cc
@@ -89,6 +89,12 @@ class Assignment {
 
     Assignment(clingo_assignment_t const *assignment) : assignment_(assignment) {}
 
+    [[nodiscard]] auto thread_id() const -> clingo_id_t {
+        clingo_id_t id = 0;
+        handle_error(clingo_assignment_thread_id(assignment_, &id));
+        return id;
+    }
+
     [[nodiscard]] auto size() const -> size_t {
         size_t size = 0;
         handle_error(clingo_assignment_size(assignment_, &size));
@@ -189,15 +195,72 @@ class Assignment {
     clingo_assignment_t const *assignment_;
 };
 
-class PropagateInit {
+class PropagateControl {
   public:
-    PropagateInit(clingo_propagate_init_t *init) : init_{init} {}
-
-    auto assignment() -> Assignment {
-        clingo_assignment_t const *assignment = nullptr;
-        handle_error(clingo_propagate_init_assignment(init_, &assignment));
-        return {assignment};
+    PropagateControl(clingo_propagate_control_t *ctl) : ctl_{ctl} {}
+    PropagateControl(clingo_propagate_init_t const *init) : ctl_{nullptr} {
+        handle_error(clingo_propagate_init_control(init, &ctl_));
     }
+
+    auto add_clause(LitSpan literals, bool tag, bool lock) -> bool {
+        clingo_clause_type_t type = 0;
+        if (tag) {
+            type |= clingo_clause_type_volatile;
+        }
+        if (lock) {
+            type |= clingo_clause_type_static;
+        }
+        auto res = false;
+        handle_error(clingo_propagate_control_add_clause(ctl_, literals.data(), literals.size(), type, &res));
+        return res;
+    }
+
+    auto add_weight_constraint(clingo_literal_t literal, WeightLitSpan literals, clingo_weight_t bound,
+                               clingo_weight_constraint_type_e type) -> bool {
+        auto res = false;
+        handle_error(clingo_propagate_control_add_weight_constraint(ctl_, literal, literals.data(), literals.size(),
+                                                                    bound, type, &res));
+        return res;
+    }
+
+    auto add_literal(bool freeze = true) -> clingo_literal_t {
+        clingo_literal_t lit = 0;
+        handle_error(clingo_propagate_control_add_literal(ctl_, freeze, &lit));
+        return lit;
+    }
+
+    auto add_nogood(LitSpan literals, bool tag, bool lock) -> bool {
+        static thread_local auto lits = LitVec{};
+        lits.clear();
+        lits.reserve(literals.size());
+        std::ranges::transform(literals.begin(), literals.end(), std::back_inserter(lits),
+                               [](auto const &lit) { return -lit; });
+        return add_clause(lits, tag, lock);
+    }
+
+    void add_watch(clingo_literal_t lit) { handle_error(clingo_propagate_control_add_watch(ctl_, lit)); }
+
+    auto has_watch(clingo_literal_t lit) -> bool {
+        auto res = false;
+        handle_error(clingo_propagate_control_has_watch(ctl_, lit, &res));
+        return res;
+    }
+
+    auto propagate() -> bool {
+        auto res = false;
+        handle_error(clingo_propagate_control_propagate(ctl_, &res));
+        return res;
+    }
+
+    void remove_watch(clingo_literal_t lit) { handle_error(clingo_propagate_control_remove_watch(ctl_, lit)); }
+
+  private:
+    clingo_propagate_control_t *ctl_;
+};
+
+class PropagateInit : public PropagateControl {
+  public:
+    PropagateInit(clingo_propagate_init_t *init) : PropagateControl(init), init_{init} {}
 
     auto library() -> PyLibrary {
         clingo_lib_t *lib = nullptr;
@@ -237,53 +300,11 @@ class PropagateInit {
         handle_error(clingo_propagate_init_set_undo_mode(init_, mode));
     }
 
-    auto add_clause(LitSpan literals) -> bool {
-        auto res = false;
-        handle_error(clingo_propagate_init_add_clause(init_, literals.data(), literals.size(), &res));
-        return res;
-    }
-
-    auto add_literal(bool freeze) -> clingo_literal_t {
-        clingo_literal_t lit = 0;
-        handle_error(clingo_propagate_init_add_literal(init_, freeze, &lit));
-        return lit;
-    }
-
     void add_minimize(clingo_literal_t literal, clingo_weight_t weight, clingo_weight_t priority) {
         handle_error(clingo_propagate_init_add_minimize(init_, literal, weight, priority));
     }
 
-    void add_watch(clingo_literal_t lit, std::optional<uint32_t> thread_id) {
-        if (thread_id) {
-            handle_error(clingo_propagate_init_add_watch_to_thread(init_, lit, *thread_id));
-        } else {
-            handle_error(clingo_propagate_init_add_watch(init_, lit));
-        }
-    }
-
-    auto add_weight_constraint(clingo_literal_t literal, WeightLitSpan literals, clingo_weight_t bound,
-                               clingo_weight_constraint_type_e type, bool compare_equal) -> bool {
-        auto res = false;
-        handle_error(clingo_propagate_init_add_weight_constraint(init_, literal, literals.data(), literals.size(),
-                                                                 bound, type, compare_equal, &res));
-        return res;
-    }
-
     void freeze_literal(clingo_literal_t lit) { handle_error(clingo_propagate_init_freeze_literal(init_, lit)); }
-
-    auto propagate() -> bool {
-        auto res = false;
-        handle_error(clingo_propagate_init_propagate(init_, &res));
-        return res;
-    }
-
-    void remove_watch(clingo_literal_t lit, std::optional<uint32_t> thread_id) {
-        if (thread_id) {
-            handle_error(clingo_propagate_init_remove_watch_from_thread(init_, lit, *thread_id));
-        } else {
-            handle_error(clingo_propagate_init_remove_watch(init_, lit));
-        }
-    }
 
     auto solver_literal(clingo_literal_t lit) -> clingo_literal_t {
         clingo_literal_t res = 0;
@@ -295,87 +316,26 @@ class PropagateInit {
     clingo_propagate_init_t *init_;
 };
 
-class PropagateControl {
-  public:
-    PropagateControl(clingo_propagate_control_t *ctl) : ctl_{ctl} {}
-
-    auto add_clause(LitSpan literals, bool tag, bool lock) -> bool {
-        clingo_clause_type_t type = 0;
-        if (tag) {
-            type |= clingo_clause_type_volatile;
-        }
-        if (lock) {
-            type |= clingo_clause_type_static;
-        }
-        auto res = false;
-        handle_error(clingo_propagate_control_add_clause(ctl_, literals.data(), literals.size(), type, &res));
-        return res;
-    }
-
-    auto add_literal() -> clingo_literal_t {
-        clingo_literal_t lit = 0;
-        handle_error(clingo_propagate_control_add_literal(ctl_, &lit));
-        return lit;
-    }
-
-    auto add_nogood(LitSpan literals, bool tag, bool lock) -> bool {
-        static thread_local auto lits = LitVec{};
-        lits.clear();
-        lits.reserve(literals.size());
-        std::ranges::transform(literals.begin(), literals.end(), std::back_inserter(lits),
-                               [](auto const &lit) { return -lit; });
-        return add_clause(lits, tag, lock);
-    }
-
-    void add_watch(clingo_literal_t lit) { handle_error(clingo_propagate_control_add_watch(ctl_, lit)); }
-
-    auto has_watch(clingo_literal_t lit) -> bool {
-        auto res = false;
-        handle_error(clingo_propagate_control_has_watch(ctl_, lit, &res));
-        return res;
-    }
-
-    auto propagate() -> bool {
-        auto res = false;
-        handle_error(clingo_propagate_control_propagate(ctl_, &res));
-        return res;
-    }
-
-    void remove_watch(clingo_literal_t lit) { handle_error(clingo_propagate_control_remove_watch(ctl_, lit)); }
-
-    auto assignment() -> Assignment {
-        clingo_assignment_t const *assignment = nullptr;
-        handle_error(clingo_propagate_control_assignment(ctl_, &assignment));
-        return {assignment};
-    }
-
-    auto thread_id() -> uint32_t {
-        uint32_t id = 0;
-        handle_error(clingo_propagate_control_thread_id(ctl_, &id));
-        return id;
-    }
-
-  private:
-    clingo_propagate_control_t *ctl_;
-};
-
-void Propagator::init(PropagateInit &init) {
-    PYBIND11_OVERRIDE_NAME(void, Propagator, "init", no_op, init);
+void Propagator::init(Assignment &assignment, PropagateInit &init) {
+    PYBIND11_OVERRIDE_NAME(void, Propagator, "init", no_op, assignment, init);
 }
-void Propagator::propagate(PropagateControl &ctl, LitSpan changes) {
-    PYBIND11_OVERRIDE_NAME(void, Propagator, "propagate", no_op, ctl, changes);
+void Propagator::attach(Assignment &assignment, PropagateControl &ctl) {
+    PYBIND11_OVERRIDE_NAME(void, Propagator, "attach", no_op, assignment, ctl);
 }
-void Propagator::undo(uint32_t thread_id, Assignment &assignment, LitSpan changes) {
-    PYBIND11_OVERRIDE_NAME(void, Propagator, "undo", no_op, thread_id, assignment, changes);
+void Propagator::propagate(Assignment &assignment, PropagateControl &ctl, LitSpan changes) {
+    PYBIND11_OVERRIDE_NAME(void, Propagator, "propagate", no_op, assignment, ctl, changes);
 }
-void Propagator::check(PropagateControl &ctl) {
-    PYBIND11_OVERRIDE_NAME(void, Propagator, "check", no_op, ctl);
+void Propagator::undo(Assignment &assignment, LitSpan changes) {
+    PYBIND11_OVERRIDE_NAME(void, Propagator, "undo", no_op, assignment, changes);
 }
-auto Propagator::decide(uint32_t thread_id, Assignment &assignment, clingo_literal_t lit) -> clingo_literal_t {
-    PYBIND11_OVERRIDE_NAME(clingo_literal_t, Propagator, "decide", decide_, thread_id, assignment, lit);
+void Propagator::check(Assignment &assignment, PropagateControl &ctl) {
+    PYBIND11_OVERRIDE_NAME(void, Propagator, "check", no_op, assignment, ctl);
+}
+auto Propagator::decide(Assignment &assignment, clingo_literal_t lit) -> clingo_literal_t {
+    PYBIND11_OVERRIDE_NAME(clingo_literal_t, Propagator, "decide", decide_, assignment, lit);
 }
 
-auto Propagator::decide_([[maybe_unused]] uint32_t thread_id, [[maybe_unused]] Assignment &assignment,
+auto Propagator::decide_([[maybe_unused]] Assignment &assignment,
                          [[maybe_unused]] clingo_literal_t lit) -> clingo_literal_t {
     static_cast<void>(this);
     return lit;
@@ -384,41 +344,50 @@ auto Propagator::decide_([[maybe_unused]] uint32_t thread_id, [[maybe_unused]] A
 void register_propagator(clingo_control_t *ctl, Propagator &prop) {
     // propagator without heuristic
     static constexpr auto c_prop = clingo_propagator_t{
-        [](clingo_propagate_init_t *init, void *data) -> bool {
+        [](clingo_assignment_t const *assignment, clingo_propagate_init_t *init, void *data) -> bool {
             auto *self = static_cast<Propagator *>(data);
             CLINGO_TRY {
                 auto py_init = PropagateInit{init};
-                self->init(py_init);
+                auto py_ass = Assignment{assignment};
+                self->init(py_ass, py_init);
             }
             CLINGO_CATCH;
         },
-        [](clingo_propagate_control_t *control, clingo_literal_t const *changes, size_t size, void *data) -> bool {
+        [](clingo_assignment_t const *assignment, clingo_propagate_control_t *control, void *data) -> bool {
             auto *self = static_cast<Propagator *>(data);
             CLINGO_TRY {
+                auto py_ass = Assignment{assignment};
                 auto py_ctl = PropagateControl{control};
-                self->propagate(py_ctl, LitSpan{changes, size});
+                self->attach(py_ass, py_ctl);
             }
             CLINGO_CATCH;
         },
-        [](clingo_propagate_control_t const *control, clingo_literal_t const *changes, size_t size, void *data) {
+        [](clingo_assignment_t const *assignment, clingo_propagate_control_t *control, clingo_literal_t const *changes,
+           size_t size, void *data) -> bool {
+            auto *self = static_cast<Propagator *>(data);
+            CLINGO_TRY {
+                auto py_ass = Assignment{assignment};
+                auto py_ctl = PropagateControl{control};
+                self->propagate(py_ass, py_ctl, LitSpan{changes, size});
+            }
+            CLINGO_CATCH;
+        },
+        [](clingo_assignment_t const *assignment, clingo_literal_t const *changes, size_t size, void *data) {
             try {
                 auto *self = static_cast<Propagator *>(data);
-                uint32_t thread_id = 0;
-                handle_error(clingo_propagate_control_thread_id(control, &thread_id));
-                clingo_assignment_t const *assignment = nullptr;
-                handle_error(clingo_propagate_control_assignment(control, &assignment));
-                auto py_assignment = Assignment(assignment);
-                self->undo(thread_id, py_assignment, LitSpan{changes, size});
+                auto py_ass = Assignment{assignment};
+                self->undo(py_ass, LitSpan{changes, size});
             } catch (std::exception const &e) {
                 printf("panic: %s\n", e.what());
                 std::abort();
             }
         },
-        [](clingo_propagate_control_t *control, void *data) -> bool {
+        [](clingo_assignment_t const *assignment, clingo_propagate_control_t *control, void *data) -> bool {
             auto *self = static_cast<Propagator *>(data);
             CLINGO_TRY {
+                auto py_ass = Assignment{assignment};
                 auto py_ctl = PropagateControl{control};
-                self->check(py_ctl);
+                self->check(py_ass, py_ctl);
             }
             CLINGO_CATCH;
         },
@@ -428,15 +397,16 @@ void register_propagator(clingo_control_t *ctl, Propagator &prop) {
     // propagator with heuristic
     static constexpr auto c_heu = clingo_propagator_t{
         c_prop.init,
+        c_prop.attach,
         c_prop.propagate,
         c_prop.undo,
         c_prop.check,
-        [](clingo_id_t thread_id, clingo_assignment_t const *assignment, clingo_literal_t fallback, void *data,
+        [](clingo_assignment_t const *assignment, clingo_literal_t fallback, void *data,
            clingo_literal_t *decision) -> bool {
             auto *self = static_cast<Propagator *>(data);
             CLINGO_TRY {
                 auto py_assignment = Assignment{assignment};
-                *decision = self->decide(thread_id, py_assignment, fallback);
+                *decision = self->decide(py_assignment, fallback);
             }
             CLINGO_CATCH;
         },
@@ -457,7 +427,7 @@ Functions and classes to implement custom propagators.
 >>> from typing import Sequence
 >>> from clingo.control import Control
 >>> from clingo.core import Library
->>> from clingo.propagate import PropagateControl, PropagateInit, Propagator
+>>> from clingo.propagate import Assignment, PropagateControl, PropagateInit, Propagator
 >>> from clingo.symbol import Function
 >>>
 >>> LIB = Library()
@@ -472,7 +442,7 @@ Functions and classes to implement custom propagators.
 ...         self.slit_b = 0
 ...
 ...     # add watches for atoms `a` and `b`
-...     def init(self, init: PropagateInit) -> None:
+...     def init(self, assignment: Assignment, init: PropagateInit) -> None:
 ...         # get program literals for atoms `a` and `b`
 ...         plit_a = init.base[Function(LIB, "a")].literal
 ...         plit_b = init.base[Function(LIB, "b")].literal
@@ -484,14 +454,14 @@ Functions and classes to implement custom propagators.
 ...         init.add_watch(self.slit_b)
 ...
 ...     # propagate solver literals `a` and `b`
-...     def propagate(self, control: PropagateControl, changes: Sequence[int]) -> None:
+...     def propagate(self, assignment: Assignment, control: PropagateControl, changes: Sequence[int]) -> None:
 ...         # if `a` is true imply `b`
 ...         if self.slit_a in changes:
-...             assert control.assignment.is_true(self.slit_a)
+...             assert assignment.is_true(self.slit_a)
 ...             control.add_clause([-self.slit_a, self.slit_b])
 ...         # if `b` is true imply `a`
 ...         if self.slit_b in changes:
-...             assert control.assignment.is_true(self.slit_b)
+...             assert assignment.is_true(self.slit_b)
 ...             control.add_clause([-self.slit_b, self.slit_a])
 ...
 >>> ctl = Control(LIB, ["0"])
@@ -657,6 +627,11 @@ Args:
 Returns:
     The truth value of the literal.
 )"_d)
+        .def_property_readonly("thread_id", &Assignment::thread_id, R"(
+Get the id of the thread to which the assignment belongs.
+
+Thread ids are consecutive numbers starting with zero.
+)"_d)
         .def_property_readonly("decision_level", &Assignment::decision_level, R"(
 Get the current decision level.
 )"_d)
@@ -677,141 +652,8 @@ They include, for example, assumptions.
 Get the trail of literals.
 )"_d);
 
-    py::class_<PropagateInit>(propagate, "PropagateInit", R"(
-Class for initializing a propagator.
-
-This class provides methods for setting up propagation, including adding
-clauses, literals, watches, and constraints.
-)"_d)
-        .def("add_clause", &PropagateInit::add_clause, py::arg("literals"), R"(
-Add a clause to the solver.
-
-If the clause could not be added to the solver, there is a top-level conflict
-and the underlying problem is unsatisfiable.
-
-Args:
-    literals:
-        A sequence of solver literals representing the clause.
-
-Returns:
-    Whether the clause could be added without conflict.
-)"_d)
-        .def("add_literal", &PropagateInit::add_literal, py::arg("freeze") = true, R"(
-Add a new literal to the solver.
-
-See also `freeze_literal()`.
-
-Args:
-    freeze:
-        Whether to freeze the literal.
-
-Returns:
-    The newly added solver literal.
-)"_d)
-        .def("add_minimize", &PropagateInit::add_minimize, py::arg("literal"), py::arg("weight"),
-             py::arg("priority") = 0,
-             R"(
-Add a weighted literal to minimize to the solver.
-
-Args:
-    literal:
-        The literal to minimize.
-    weight:
-        The weight of the literal.
-    priority:
-        The priority of the literal.
-)"_d)
-        .def("add_watch", &PropagateInit::add_watch, py::arg("literal"), py::arg("thread_id") = std::nullopt, R"(
-Add a watch for the given solver literal.
-
-Args:
-    literal:
-        The literal to watch.
-    thread_id:
-        The id of the thread to add the watch to. If None, adds to all threads.
-)"_d)
-        .def("add_weight_constraint", &PropagateInit::add_weight_constraint, py::arg("literal"), py::arg("literals"),
-             py::arg("bound"),
-             py::arg("type") = clingo_weight_constraint_type_e::clingo_weight_constraint_type_equivalence,
-             py::arg("compare_equal") = false, R"(
-Add a weight constraint to the solver.
-
-See `add_clause` for how to interpret the return value.
-
-Args:
-    literal:
-        The literal associated with the constraint.
-    literals:
-        A sequence of (literal, weight) tuples.
-    bound:
-        The bound of the weight constraint.
-    type:
-        The type of the weight constraint.
-    compare_equal:
-        Whether to use equality comparison.
-
-Returns:
-    Whether the weight constraint could be added without conflict.
-)"_d)
-        .def("freeze_literal", &PropagateInit::freeze_literal, py::arg("literal"), R"(
-Freeze the given literal.
-
-Frozen literals are exempt from simplification. This is important for literals
-whose truth values a propagator has to track.
-
-Args:
-    literal:
-        The literal to freeze.
-)"_d)
-        .def("propagate", &PropagateInit::propagate, R"(
-Perform initial propagation.
-
-See the `add_clause()` for how to intepret the return value.
-
-Returns:
-    True if propagation was successful, False otherwise.
-)"_d)
-        .def("remove_watch", &PropagateInit::remove_watch, py::arg("literal"), py::arg("thread_id") = std::nullopt, R"(
-Remove the watch for the given literal.
-
-Args:
-    literal:
-        The literal to remove the watch for.
-    thread_id:
-        The id of the thread to remove the watch from. If None, removes from
-        all threads.
-)"_d)
-        .def("solver_literal", &PropagateInit::solver_literal, py::arg("literal"), R"(
-Map the given program literal to a solver literal.
-
-Args:
-    literal:
-        The program literal to map.
-
-Returns:
-    The corresponding solver literal.
-)"_d)
-        .def_property_readonly("assignment", &PropagateInit::assignment, R"(
-The current assignment.
-)"_d)
-        .def_property_readonly("library", &PropagateInit::library, R"(
-The library object managing symbols.
-)"_d)
-        .def_property_readonly("base", &PropagateInit::base, R"(
-The base object to inspect the grounder's base.
-)"_d)
-        .def_property("check_mode", &PropagateInit::get_check_mode, &PropagateInit::set_check_mode, R"(
-Get/set the check mode for the propagator.
-)"_d)
-        .def_property_readonly("number_of_threads", &PropagateInit::number_of_threads, R"(
-The number of solver threads.
-)"_d)
-        .def_property("undo_mode", &PropagateInit::get_undo_mode, &PropagateInit::set_undo_mode, R"(
-Get/set the undo mode for the propagator.
-)"_d);
-
     py::class_<PropagateControl>(propagate, "PropagateControl", R"(
-Class for controlling propagation.
+Class for controlling propagators.
 
 This class provides methods for adding clauses, literals, and nogoods, as well
 as managing watches and performing propagation.
@@ -836,11 +678,36 @@ Args:
 Returns:
     Whether the clause could be integrated without conflict.
 )"_d)
-        .def("add_literal", &PropagateControl::add_literal, R"(
+        .def("add_weight_constraint", &PropagateControl::add_weight_constraint, py::arg("literal"), py::arg("literals"),
+             py::arg("bound"),
+             py::arg("type") = clingo_weight_constraint_type_e::clingo_weight_constraint_type_equivalence,
+             R"(
+Add a weight constraint to the solver.
+
+See `add_clause` for how to interpret the return value.
+
+Args:
+    literal:
+        The literal associated with the constraint.
+    literals:
+        A sequence of (literal, weight) tuples.
+    bound:
+        The bound of the weight constraint.
+    type:
+        The type of the weight constraint.
+
+Returns:
+    Whether the weight constraint could be added without conflict.
+)"_d)
+        .def("add_literal", &PropagateControl::add_literal, py::arg("freeze") = true, R"(
 Add a literal to the solver.
 
-This literal is only added to the associated solving thread and deleted after
-the solve call.
+If the function is called in the context of a particular solver thread, the literal is only added to
+that thread and deleted after the active solve call.
+
+Args:
+    freeze:
+        Whether to freeze the literal.
 
 Returns:
     A fresh solver literal.
@@ -880,7 +747,7 @@ Perform propagation in the solver.
 
 If this function returns False, the propagator must add no further
 clauses/literals and immediately return from the corresponding
-`Propagator.propagate()` or `Propagator.check()` call.
+`Propagator.init()`, `Propagator.propagate()` or `Propagator.check()` call.
 
 Returns:
     True if propagation was successful, False otherwise.
@@ -892,12 +759,61 @@ This function has no effect if the literal is not watched.
 
 Args:
     literal: The literal to remove the watch for.
+)"_d);
+
+    py::class_<PropagateInit, PropagateControl>(propagate, "PropagateInit", R"(
+Class for initializing a propagator.
+
+This class extends PropagateControl and additionally provides methods for freezing and looking up literals, adding
+constraints, and configuring the propagator's behavior.
 )"_d)
-        .def_property_readonly("assignment", &PropagateControl::assignment, R"(
-The current assignment.
+        .def("add_minimize", &PropagateInit::add_minimize, py::arg("literal"), py::arg("weight"),
+             py::arg("priority") = 0,
+             R"(
+Add a weighted literal to minimize to the solver.
+
+Args:
+    literal:
+        The literal to minimize.
+    weight:
+        The weight of the literal.
+    priority:
+        The priority of the literal.
 )"_d)
-        .def_property_readonly("thread_id", &PropagateControl::thread_id, R"(
-The id of the current solving thread.
+        .def("freeze_literal", &PropagateInit::freeze_literal, py::arg("literal"), R"(
+Freeze the given literal.
+
+Frozen literals are exempt from simplification. This is important for literals
+whose truth values a propagator has to track.
+
+Args:
+    literal:
+        The literal to freeze.
+)"_d)
+        .def("solver_literal", &PropagateInit::solver_literal, py::arg("literal"), R"(
+Map the given program literal to a solver literal.
+
+Args:
+    literal:
+        The program literal to map.
+
+Returns:
+    The corresponding solver literal.
+)"_d)
+        .def_property_readonly("library", &PropagateInit::library, R"(
+The library object managing symbols.
+)"_d)
+        .def_property_readonly("base", &PropagateInit::base, R"(
+The base object to inspect the grounder's base.
+)"_d)
+        .def_property("check_mode", &PropagateInit::get_check_mode, &PropagateInit::set_check_mode, R"(
+Get/set the check mode for the propagator.
+)"_d)
+        .def_property_readonly("number_of_threads", &PropagateInit::number_of_threads, R"(
+The number of solver threads.
+)"_d)
+        .def_property("undo_mode", &PropagateInit::get_undo_mode, &PropagateInit::set_undo_mode, R"(
+Get/set the undo mode for the propagator.
 )"_d);
 
     py::class_<Propagator>(propagate, "Propagator", R"(
@@ -908,7 +824,7 @@ for use with the solver. They can be left empty to use their default
 implementation.
 )")
         .def(py::init<>())
-        .def("init", &Propagator::init, py::arg("init"), R"(
+        .def("init", &Propagator::init, py::arg("assignment"), py::arg("init"), R"(
 Initialize the propagator.
 
 This method is called once before each solving step. It is used to map
@@ -916,25 +832,43 @@ relevant program literals to solver literals, add watches for solver
 literals, and initialize the propagator's internal state.
 
 Args:
+    assignment:
+        The current assignment.
     init:
         The propagate init object for initializing the propagator.
 )"_d)
-        .def("propagate", &Propagator::propagate, py::arg("control"), py::arg("changes"), R"(
-Propagate given a set of changes.
+        .def("attach", &Propagator::attach, py::arg("assignment"), py::arg("control"), R"(
+Initialize solver thread with given id.
 
-This method is called during propagation with a non-empty list watched literals
+This function is called once for each solving thread before solving of the
+current step is started.
+It can be used to add thread-specific watches and literals, or
+initialize thread-specific data structures.
+
+Args:
+    assignment:
+        The current assignment.
+    control:
+        The propagate control object for managing propagation.
+)"_d)
+        .def("propagate", &Propagator::propagate, py::arg("assignment"), py::arg("control"), py::arg("changes"), R"(
+Propagate given set of changes.
+
+This method is called during propagation with a non-empty list of watched literals
 that have been assigned truth values. A propagator should add clauses to
 propagate literals and to implement its constraints.
 
 Typical propagators add unit-resulting or conflicting constraints only.
 
 Args:
+    assignment:
+        The current assignment.
     control:
         The propagate control object for managing propagation.
     changes:
         A list of literals that have changed.
 )"_d)
-        .def("undo", &Propagator::undo, py::arg("thread_id"), py::arg("assignment"), py::arg("changes"), R"(
+        .def("undo", &Propagator::undo, py::arg("assignment"), py::arg("changes"), R"(
 Undo previous assignments.
 
 This method is called to undo previous assignments.
@@ -942,14 +876,12 @@ This method is called to undo previous assignments.
 See also `PropagateInit.undo_mode`.
 
 Args:
-    thread_id:
-        The id of the current solver thread.
     assignment:
         The current assignment.
     changes:
         The literals whose assignment is undone.
 )"_d)
-        .def("check", &Propagator::check, py::arg("control"), R"(
+        .def("check", &Propagator::check, py::arg("assignment"), py::arg("control"), R"(
 Check if the current assignment is valid.
 
 This method is called on propagation fixpoints or total assignments (see
@@ -957,17 +889,17 @@ This method is called on propagation fixpoints or total assignments (see
 constraints here.
 
 Args:
+    assignment:
+        The current assignment.
     control:
         The propagate control object for managing propagation.
 )"_d)
-        .def("decide", &Propagator::decide, py::arg("thread_id"), py::arg("assignment"), py::arg("fallback"), R"(
+        .def("decide", &Propagator::decide, py::arg("assignment"), py::arg("fallback"), R"(
 Make a decision on the next literal to assign.
 
 This method is called to decide on a literal to be assigned next.
 
 Args:
-    thread_id:
-        The id of the current solver thread.
     assignment:
         The current assignment.
     fallback:

--- a/lib/python-api/src/propagate.hh
+++ b/lib/python-api/src/propagate.hh
@@ -14,20 +14,20 @@ class Assignment;
 
 class Propagator {
   public:
-    void init(PropagateInit &init);
-    void propagate(PropagateControl &ctl, LitSpan changes);
-    void undo(uint32_t thread_id, Assignment &assignment, LitSpan changes);
-    void check(PropagateControl &ctl);
-    auto decide(uint32_t thread_id, Assignment &assignment, clingo_literal_t lit) -> clingo_literal_t;
+    void init(Assignment &assignment, PropagateInit &init);
+    void attach(Assignment &assignment, PropagateControl &ctl);
+    void propagate(Assignment &assignment, PropagateControl &ctl, LitSpan changes);
+    void undo(Assignment &assignment, LitSpan changes);
+    void check(Assignment &assignment, PropagateControl &ctl);
+    auto decide(Assignment &assignment, clingo_literal_t lit) -> clingo_literal_t;
 
   private:
     template <class... Args> void no_op([[maybe_unused]] Args const &...args) {}
 
-    auto decide_([[maybe_unused]] uint32_t thread_id, [[maybe_unused]] Assignment &assignment,
-                 [[maybe_unused]] clingo_literal_t lit) -> clingo_literal_t;
+    auto decide_([[maybe_unused]] Assignment &assignment, [[maybe_unused]] clingo_literal_t lit) -> clingo_literal_t;
 };
 
-//! Register a proagator with the given control object.
+//! Register a propagator with the given control object.
 //!
 //! The given data reference should be stored in the Control wrapper class.
 //! It's exception element is used to store exceptions thrown in C callbacks

--- a/lib/python-api/stubs/propagate.pyi
+++ b/lib/python-api/stubs/propagate.pyi
@@ -7,7 +7,7 @@ Functions and classes to implement custom propagators.
 >>> from typing import Sequence
 >>> from clingo.control import Control
 >>> from clingo.core import Library
->>> from clingo.propagate import PropagateControl, PropagateInit, Propagator
+>>> from clingo.propagate import Assignment, PropagateControl, PropagateInit, Propagator
 >>> from clingo.symbol import Function
 >>>
 >>> LIB = Library()
@@ -22,7 +22,7 @@ Functions and classes to implement custom propagators.
 ...         self.slit_b = 0
 ...
 ...     # add watches for atoms `a` and `b`
-...     def init(self, init: PropagateInit) -> None:
+...     def init(self, assignment: Assignment, init: PropagateInit) -> None:
 ...         # get program literals for atoms `a` and `b`
 ...         plit_a = init.base[Function(LIB, "a")].literal
 ...         plit_b = init.base[Function(LIB, "b")].literal
@@ -34,14 +34,14 @@ Functions and classes to implement custom propagators.
 ...         init.add_watch(self.slit_b)
 ...
 ...     # propagate solver literals `a` and `b`
-...     def propagate(self, control: PropagateControl, changes: Sequence[int]) -> None:
+...     def propagate(self, assignment: Assignment, control: PropagateControl, changes: Sequence[int]) -> None:
 ...         # if `a` is true imply `b`
 ...         if self.slit_a in changes:
-...             assert control.assignment.is_true(self.slit_a)
+...             assert assignment.is_true(self.slit_a)
 ...             control.add_clause([-self.slit_a, self.slit_b])
 ...         # if `b` is true imply `a`
 ...         if self.slit_b in changes:
-...             assert control.assignment.is_true(self.slit_b)
+...             assert assignment.is_true(self.slit_b)
 ...             control.add_clause([-self.slit_b, self.slit_a])
 ...
 >>> ctl = Control(LIB, ["0"])
@@ -348,6 +348,14 @@ class Assignment:
         """
 
     @property
+    def thread_id(self) -> int:
+        """
+        Get the id of the thread to which the assignment belongs.
+
+        Thread ids are consecutive numbers starting with zero.
+        """
+
+    @property
     def trail(self) -> Trail:
         """
         Get the trail of literals.
@@ -355,7 +363,7 @@ class Assignment:
 
 class PropagateControl:
     """
-    Class for controlling propagation.
+    Class for controlling propagators.
 
     This class provides methods for adding clauses, literals, and nogoods, as well
     as managing watches and performing propagation.
@@ -386,12 +394,16 @@ class PropagateControl:
             Whether the clause could be integrated without conflict.
         """
 
-    def add_literal(self) -> int:
+    def add_literal(self, freeze: bool = True) -> int:
         """
         Add a literal to the solver.
 
-        This literal is only added to the associated solving thread and deleted after
-        the solve call.
+        If the function is called in the context of a particular solver thread, the literal is only added to
+        that thread and deleted after the active solve call.
+
+        Args:
+            freeze:
+                Whether to freeze the literal.
 
         Returns:
             A fresh solver literal.
@@ -423,6 +435,32 @@ class PropagateControl:
             literal: The literal to watch.
         """
 
+    def add_weight_constraint(
+        self,
+        literal: int,
+        literals: typing.Sequence[tuple[int, int]],
+        bound: int,
+        type: WeightConstraintType = WeightConstraintType.Equivalence,
+    ) -> bool:
+        """
+        Add a weight constraint to the solver.
+
+        See `add_clause` for how to interpret the return value.
+
+        Args:
+            literal:
+                The literal associated with the constraint.
+            literals:
+                A sequence of (literal, weight) tuples.
+            bound:
+                The bound of the weight constraint.
+            type:
+                The type of the weight constraint.
+
+        Returns:
+            Whether the weight constraint could be added without conflict.
+        """
+
     def has_watch(self, literal: int) -> bool:
         """
         Check if a watch exists for the given solver literal.
@@ -440,7 +478,7 @@ class PropagateControl:
 
         If this function returns False, the propagator must add no further
         clauses/literals and immediately return from the corresponding
-        `Propagator.propagate()` or `Propagator.check()` call.
+        `Propagator.init()`, `Propagator.propagate()` or `Propagator.check()` call.
 
         Returns:
             True if propagation was successful, False otherwise.
@@ -456,57 +494,16 @@ class PropagateControl:
             literal: The literal to remove the watch for.
         """
 
-    @property
-    def assignment(self) -> Assignment:
-        """
-        The current assignment.
-        """
-
-    @property
-    def thread_id(self) -> int:
-        """
-        The id of the current solving thread.
-        """
-
-class PropagateInit:
+class PropagateInit(PropagateControl):
     """
     Class for initializing a propagator.
 
-    This class provides methods for setting up propagation, including adding
-    clauses, literals, watches, and constraints.
+    This class extends PropagateControl and additionally provides methods for freezing and looking up literals, adding
+    constraints, and configuring the propagator's behavior.
     """
 
     @staticmethod
     def _pybind11_conduit_v1_(*args, **kwargs): ...
-    def add_clause(self, literals: typing.Sequence[int]) -> bool:
-        """
-        Add a clause to the solver.
-
-        If the clause could not be added to the solver, there is a top-level conflict
-        and the underlying problem is unsatisfiable.
-
-        Args:
-            literals:
-                A sequence of solver literals representing the clause.
-
-        Returns:
-            Whether the clause could be added without conflict.
-        """
-
-    def add_literal(self, freeze: bool = True) -> int:
-        """
-        Add a new literal to the solver.
-
-        See also `freeze_literal()`.
-
-        Args:
-            freeze:
-                Whether to freeze the literal.
-
-        Returns:
-            The newly added solver literal.
-        """
-
     def add_minimize(self, literal: int, weight: int, priority: int = 0) -> None:
         """
         Add a weighted literal to minimize to the solver.
@@ -518,46 +515,6 @@ class PropagateInit:
                 The weight of the literal.
             priority:
                 The priority of the literal.
-        """
-
-    def add_watch(self, literal: int, thread_id: int | None = None) -> None:
-        """
-        Add a watch for the given solver literal.
-
-        Args:
-            literal:
-                The literal to watch.
-            thread_id:
-                The id of the thread to add the watch to. If None, adds to all threads.
-        """
-
-    def add_weight_constraint(
-        self,
-        literal: int,
-        literals: typing.Sequence[tuple[int, int]],
-        bound: int,
-        type: WeightConstraintType = WeightConstraintType.Equivalence,
-        compare_equal: bool = False,
-    ) -> bool:
-        """
-        Add a weight constraint to the solver.
-
-        See `add_clause` for how to interpret the return value.
-
-        Args:
-            literal:
-                The literal associated with the constraint.
-            literals:
-                A sequence of (literal, weight) tuples.
-            bound:
-                The bound of the weight constraint.
-            type:
-                The type of the weight constraint.
-            compare_equal:
-                Whether to use equality comparison.
-
-        Returns:
-            Whether the weight constraint could be added without conflict.
         """
 
     def freeze_literal(self, literal: int) -> None:
@@ -572,28 +529,6 @@ class PropagateInit:
                 The literal to freeze.
         """
 
-    def propagate(self) -> bool:
-        """
-        Perform initial propagation.
-
-        See the `add_clause()` for how to intepret the return value.
-
-        Returns:
-            True if propagation was successful, False otherwise.
-        """
-
-    def remove_watch(self, literal: int, thread_id: int | None = None) -> None:
-        """
-        Remove the watch for the given literal.
-
-        Args:
-            literal:
-                The literal to remove the watch for.
-            thread_id:
-                The id of the thread to remove the watch from. If None, removes from
-                all threads.
-        """
-
     def solver_literal(self, literal: int) -> int:
         """
         Map the given program literal to a solver literal.
@@ -604,12 +539,6 @@ class PropagateInit:
 
         Returns:
             The corresponding solver literal.
-        """
-
-    @property
-    def assignment(self) -> Assignment:
-        """
-        The current assignment.
         """
 
     @property
@@ -660,7 +589,23 @@ class Propagator:
     @staticmethod
     def _pybind11_conduit_v1_(*args, **kwargs): ...
     def __init__(self) -> None: ...
-    def check(self, control: PropagateControl) -> None:
+    def attach(self, assignment: Assignment, control: PropagateControl) -> None:
+        """
+        Initialize solver thread with given id.
+
+        This function is called once for each solving thread before solving of the
+        current step is started.
+        It can be used to add thread-specific watches and literals, or
+        initialize thread-specific data structures.
+
+        Args:
+            assignment:
+                The current assignment.
+            control:
+                The propagate control object for managing propagation.
+        """
+
+    def check(self, assignment: Assignment, control: PropagateControl) -> None:
         """
         Check if the current assignment is valid.
 
@@ -669,19 +614,19 @@ class Propagator:
         constraints here.
 
         Args:
+            assignment:
+                The current assignment.
             control:
                 The propagate control object for managing propagation.
         """
 
-    def decide(self, thread_id: int, assignment: Assignment, fallback: int) -> int:
+    def decide(self, assignment: Assignment, fallback: int) -> int:
         """
         Make a decision on the next literal to assign.
 
         This method is called to decide on a literal to be assigned next.
 
         Args:
-            thread_id:
-                The id of the current solver thread.
             assignment:
                 The current assignment.
             fallback:
@@ -691,7 +636,7 @@ class Propagator:
             The literal to assign or 0 if no decision was made.
         """
 
-    def init(self, init: PropagateInit) -> None:
+    def init(self, assignment: Assignment, init: PropagateInit) -> None:
         """
         Initialize the propagator.
 
@@ -700,32 +645,37 @@ class Propagator:
         literals, and initialize the propagator's internal state.
 
         Args:
+            assignment:
+                The current assignment.
             init:
                 The propagate init object for initializing the propagator.
         """
 
     def propagate(
-        self, control: PropagateControl, changes: typing.Sequence[int]
+        self,
+        assignment: Assignment,
+        control: PropagateControl,
+        changes: typing.Sequence[int],
     ) -> None:
         """
-        Propagate given a set of changes.
+        Propagate given set of changes.
 
-        This method is called during propagation with a non-empty list watched literals
+        This method is called during propagation with a non-empty list of watched literals
         that have been assigned truth values. A propagator should add clauses to
         propagate literals and to implement its constraints.
 
         Typical propagators add unit-resulting or conflicting constraints only.
 
         Args:
+            assignment:
+                The current assignment.
             control:
                 The propagate control object for managing propagation.
             changes:
                 A list of literals that have changed.
         """
 
-    def undo(
-        self, thread_id: int, assignment: Assignment, changes: typing.Sequence[int]
-    ) -> None:
+    def undo(self, assignment: Assignment, changes: typing.Sequence[int]) -> None:
         """
         Undo previous assignments.
 
@@ -734,8 +684,6 @@ class Propagator:
         See also `PropagateInit.undo_mode`.
 
         Args:
-            thread_id:
-                The id of the current solver thread.
             assignment:
                 The current assignment.
             changes:

--- a/lib/python-api/tests/test_error.py
+++ b/lib/python-api/tests/test_error.py
@@ -97,29 +97,35 @@ class Prop(Propagator):
         super().__init__()
         self.throw = throw
 
-    def init(self, init: PropagateInit) -> None:
+    def init(self, assignment: Assignment, init: PropagateInit) -> None:
         """
         Test throwing errors in init.
         """
+        assert assignment
         if "i" in self.throw:
             raise RuntimeError("prop: init")
         init.check_mode = CheckMode.Total
         init.add_watch(init.add_literal())
 
-    def propagate(self, control: PropagateControl, changes: Sequence[int]) -> None:
+    def propagate(
+        self,
+        assignment: Assignment,
+        control: PropagateControl,
+        changes: Sequence[int],
+    ) -> None:
         """
         Test throwing errors in propagate.
         """
+        assert assignment
         assert changes
         assert control
         if "p" in self.throw:
             raise RuntimeError("prop: propagate")
 
-    def decide(self, thread_id: int, assignment: Assignment, fallback: int) -> int:
+    def decide(self, assignment: Assignment, fallback: int) -> int:
         """
         Test throwing errors in decide.
         """
-        assert thread_id == 0
         assert assignment
         if "d" in self.throw:
             raise RuntimeError("prop: decide")

--- a/lib/python-api/tests/test_propagate.py
+++ b/lib/python-api/tests/test_propagate.py
@@ -32,6 +32,7 @@ class AIFFBPropagator(Propagator):
     errors: list[str]
     fail_thread: int
     barrier: Optional[Barrier]
+    weight_con: bool
 
     def __init__(self) -> None:
         super().__init__()
@@ -40,11 +41,13 @@ class AIFFBPropagator(Propagator):
         self.n_threads = 1
         self.fail_thread = -1
         self.barrier = None
+        self.weight_con = False
 
-    def init(self, init: PropagateInit) -> None:
+    def init(self, assignment: Assignment, init: PropagateInit) -> None:
         """
         Add watches for atoms `a` and `b`.
         """
+        assert assignment
 
         def watch(p):
             plit = init.base[Function(init.library, p)].literal
@@ -62,21 +65,36 @@ class AIFFBPropagator(Propagator):
             Barrier(init.number_of_threads) if self.fail_thread >= 0 else None
         )
 
-    def check(self, control: PropagateControl) -> None:
+    def check(self, assignment: Assignment, control: PropagateControl) -> None:
         """
         Check if watches are set correctly.
         """
+        assert assignment
+        thread_id = assignment.thread_id
         for p in [self.slit_a, self.slit_b]:
             if not control.has_watch(p):
-                self.errors.append(f"solver {control.thread_id} misses watch {p}")
+                self.errors.append(f"solver {thread_id} misses watch {p}")
+
+        if self.weight_con:
+            control.add_weight_constraint(
+                1,
+                [(self.slit_a, 1), (self.slit_b, 1)],
+                2,
+                WeightConstraintType.Equivalence,
+            )
 
         if self.barrier:
             self.barrier.wait()
             self.barrier = None
-            if control.thread_id == self.fail_thread:
-                raise ValueError(f"Forcing error on solver {control.thread_id}")
+            if thread_id == self.fail_thread:
+                raise ValueError(f"Forcing error on solver {thread_id}")
 
-    def propagate(self, control: PropagateControl, changes: Sequence[int]) -> None:
+    def propagate(
+        self,
+        assignment: Assignment,
+        control: PropagateControl,
+        changes: Sequence[int],
+    ) -> None:
         """
         Propagate solver literals `a` and `b`.
         """
@@ -84,11 +102,12 @@ class AIFFBPropagator(Propagator):
         def propagate(p, q):
             # propagate a implies b
             if p in changes:
-                assert control.assignment.is_true(p)
+                assert assignment.is_true(p)
                 control.add_clause([-p, q], tag=True)
 
-        propagate(self.slit_a, self.slit_b)
-        propagate(self.slit_b, self.slit_a)
+        if not self.weight_con:
+            propagate(self.slit_a, self.slit_b)
+            propagate(self.slit_b, self.slit_a)
 
 
 class AssertingPropagator(Propagator):
@@ -103,10 +122,11 @@ class AssertingPropagator(Propagator):
         self._value_lit = 0
         self._lock = lock
 
-    def init(self, init: PropagateInit) -> None:
+    def init(self, assignment: Assignment, init: PropagateInit) -> None:
         """
         Test init.
         """
+        assert assignment
         for atom in init.base[("start", 0)].values():
             self._start_lit = init.solver_literal(atom.literal)
         for atom in init.base[("end", 0)].values():
@@ -117,12 +137,11 @@ class AssertingPropagator(Propagator):
             init.add_watch(lit)
             init.add_watch(-lit)
 
-    def propagate(self, control: PropagateControl, changes):
+    def propagate(self, ass: Assignment, control: PropagateControl, changes):
         """
         Test propagate.
         """
         assert changes
-        ass = control.assignment
         if ass.is_false(self._value_lit) and ass.is_false(self._end_lit):
             nogood = [self._start_lit, -self._end_lit, -self._value_lit]
             dl = ass.decision_level
@@ -130,11 +149,10 @@ class AssertingPropagator(Propagator):
             assert ass.decision_level == dl
             assert not result
 
-    def decide(self, thread_id: int, assignment: Assignment, fallback: int) -> int:
+    def decide(self, assignment: Assignment, fallback: int) -> int:
         """
         Test decide.
         """
-        assert thread_id == 0
         if assignment.is_free(self._end_lit):
             return -self._end_lit
         if assignment.is_free(self._value_lit):
@@ -151,11 +169,13 @@ class InitPropagator(Propagator):
     def __init__(self, lib: Library):
         super().__init__()
         self._lib = lib
+        self._init = False
 
-    def init(self, init: PropagateInit):
+    def init(self, assignment: Assignment, init: PropagateInit):
         """
         Test init.
         """
+        self._init = True
         a = init.base[Function(self._lib, "a")]
         b = init.base[Function(self._lib, "b")]
         c = init.base[Function(self._lib, "c")]
@@ -170,23 +190,28 @@ class InitPropagator(Propagator):
         init.add_clause([lit, -lit_b])
         # c <=> {a, b} >= 2
         init.add_weight_constraint(
-            lit_c, [(lit_a, 1), (lit_b, 1)], 2, WeightConstraintType.Equivalence, False
+            lit_c, [(lit_a, 1), (lit_b, 1)], 2, WeightConstraintType.Equivalence
         )
         init.add_minimize(lit_a, -1, 0)
         assert init.propagate()
         assert len(init.base) == 3
         # test assignment
-        assert init.assignment.value(lit_a) is None
-        assert not init.assignment.is_true(lit_a)
-        assert not init.assignment.is_false(lit_a)
-        assert not init.assignment.is_fixed(lit_a)
-        assert init.assignment.decision_level == 0
-        assert lit_a in init.assignment
-        assert not init.assignment.has_conflict
-        assert not init.assignment.is_total
-        assert init.assignment.root_level == 0
-        assert len(init.assignment) == 5
-        assert len(list(init.assignment)) == 5
+        assert assignment.value(lit_a) is None
+        assert not assignment.is_true(lit_a)
+        assert not assignment.is_false(lit_a)
+        assert not assignment.is_fixed(lit_a)
+        assert assignment.decision_level == 0
+        assert lit_a in assignment
+        assert not assignment.has_conflict
+        assert not assignment.is_total
+        assert assignment.root_level == 0
+        assert len(assignment) == 5
+        assert len(list(assignment)) == 5
+
+    def attach(self, assignment: Assignment, ctl: PropagateControl):
+        assert assignment
+        assert ctl
+        assert self._init
 
 
 class AddLiteralPropagator(Propagator):
@@ -197,20 +222,29 @@ class AddLiteralPropagator(Propagator):
 
     def __init__(self):
         super().__init__()
-        self._added = False
+        self._lit = 0
 
-    def check(self, control: PropagateControl):
+    def add_lit(self, control: PropagateControl):
+        self._lit = control.add_literal()
+        assert not control.has_watch(self._lit)
+        control.add_watch(self._lit)
+        assert control.has_watch(self._lit)
+        control.remove_watch(self._lit)
+        assert not control.has_watch(self._lit)
+
+    def attach(self, assignment: Assignment, control: PropagateControl) -> None:
+        assert self._lit == 0
+        assert assignment
+        self.add_lit(control)
+        self._lit = 1
+
+    def check(self, assignment: Assignment, control: PropagateControl) -> None:
         """
         Test check.
         """
-        if not self._added:
-            self._added = True
-            lit = control.add_literal()
-            assert not control.has_watch(lit)
-            control.add_watch(lit)
-            assert control.has_watch(lit)
-            control.remove_watch(lit)
-            assert not control.has_watch(lit)
+        assert assignment
+        if self._lit == 1:
+            self.add_lit(control)
 
 
 class HeuristicPropagator(Propagator):
@@ -224,20 +258,20 @@ class HeuristicPropagator(Propagator):
         self._lit_a = 0
         self._lit_b = 0
 
-    def init(self, init: PropagateInit):
+    def init(self, assignment: Assignment, init: PropagateInit):
         """
         Test init.
         """
+        assert assignment
         a = init.base[Function(self._lib, "a")]
         b = init.base[Function(self._lib, "b")]
         self._lit_a = init.solver_literal(a.literal)
         self._lit_b = init.solver_literal(b.literal)
 
-    def decide(self, thread_id: int, assignment: Assignment, fallback: int) -> int:
+    def decide(self, assignment: Assignment, fallback: int) -> int:
         """
         Test decide.
         """
-        assert thread_id == 0
         if assignment.is_free(self._lit_a):
             return self._lit_a
         if assignment.is_free(self._lit_b):
@@ -258,11 +292,11 @@ class PropagateControlPropagator(Propagator):
         self._lit_a = 0
         self._lib = lib
 
-    def init(self, init: PropagateInit):
+    def init(self, assignment: Assignment, init: PropagateInit):
         """
         Test initialization.
         """
-        ass = init.assignment
+        ass = assignment
         init.check_mode = CheckMode.Off
         assert init.check_mode == CheckMode.Off
         assert init.number_of_threads == 1
@@ -273,11 +307,15 @@ class PropagateControlPropagator(Propagator):
         assert -self._lit_a in ass
         init.add_watch(-self._lit_a)
 
-    def propagate(self, control: PropagateControl, changes: Sequence[int]):
+    def propagate(
+        self,
+        ass: Assignment,
+        control: PropagateControl,
+        changes: Sequence[int],
+    ):
         """
         Test propagation.
         """
-        ass = control.assignment
         trail = ass.trail
         lvl = ass.decision_level
         assert -self._lit_a in changes
@@ -288,17 +326,16 @@ class PropagateControlPropagator(Propagator):
         assert trail[trail.begin(lvl)] == -self._lit_a
         assert list(trail[trail.begin(lvl) : trail.end(lvl)]) == [-self._lit_a]
         assert ass.decision(lvl) == -self._lit_a
-        assert control.thread_id == 0
+        assert ass.thread_id == 0
         assert control.has_watch(-self._lit_a)
         assert control.propagate()
         assert not control.add_clause([self._lit_a])
 
-    def undo(self, thread_id: int, assignment: Assignment, changes: Sequence[int]):
+    def undo(self, assignment: Assignment, changes: Sequence[int]):
         """
         Test undo.
         """
         assert assignment
-        assert thread_id == 0
         assert -self._lit_a in changes
 
 
@@ -313,33 +350,32 @@ class ModePropagator(Propagator):
         self.num_undo = 0
         self.level = [0]
 
-    def init(self, init: PropagateInit):
+    def init(self, assignment: Assignment, init: PropagateInit):
         """
         Test init.
         """
+        assert assignment
         init.check_mode = CheckMode.Fixpoint
         init.undo_mode = UndoMode.Always
 
         assert init.check_mode == CheckMode.Fixpoint
         assert init.undo_mode == UndoMode.Always
 
-    def check(self, control: PropagateControl) -> None:
+    def check(self, assignment: Assignment, control: PropagateControl) -> None:
         """
         Test propagate.
         """
+        assert control
         self.num_check += 1
-        dl = control.assignment.decision_level
+        dl = assignment.decision_level
         assert self.level[-1] <= dl
         if self.level[-1] != dl:
             self.level.append(dl)
 
-    def undo(
-        self, thread_id: int, assignment: Assignment, changes: Sequence[int]
-    ) -> None:
+    def undo(self, assignment: Assignment, changes: Sequence[int]) -> None:
         """
         Test undo.
         """
-        assert thread_id == 0
         assert assignment
         assert not changes
         self.num_undo += 1
@@ -433,7 +469,7 @@ class TestPropagate:
         mcb = MCB()
         with self.ctl.solve(on_model=mcb) as hnd:
             assert hnd.get().satisfiable
-        assert mcb.symbols == [[], []]
+        assert mcb.symbols == [[], [], [], []]
 
     def test_heuristic(self):
         """
@@ -477,6 +513,22 @@ class TestPropagate:
             assert prop.n_threads == n, "init called with wrong number of threads"
             assert not prop.errors
             assert mcb.symbols == [["a", "b"]]
+
+    def test_aiffb_wc(self):
+        """
+        Test the example a iff b propagator with weight constraints.
+        """
+        prop = AIFFBPropagator()
+        self.ctl.register_propagator(prop)
+        self.ctl.parse_string("1 { a; b }.")
+        self.ctl.ground()
+        prop.weight_con = True
+
+        mcb = MCB()
+        with self.ctl.solve(on_model=mcb) as hnd:
+            assert hnd.get().satisfiable
+        assert not prop.errors
+        assert mcb.symbols == [["a", "b"]]
 
     def test_exception_propagation(self):
         """


### PR DESCRIPTION
* update clasp
* adjust C-API:
  - drop clingo_propagate_init_add_watch{_to_thread}
  - drop clingo_propagate_init_remove_watch{_from_thread}
  - drop clingo_propagate_init_assignment
  - drop clingo_propagate_init_add_literal
  - drop clingo_propagate_init_add_clause
  - drop clingo_propagate_init_propagate
  - drop clingo_propagate_control_thread_id
  - drop clingo_propagate_control_assignment
  - add clingo_propagate_init_control for converting a
    clingo_propagate_init_t into a clingo_propagate_control_t object
  - adjust signatures of clingo_propagator functions: thread_id and
    current assignment are now explicit function parameters
  - **add clingo_propagator_attach_callback_t for initializing solving
    threads**
* adjust C++-API and tests
* adjust Python-API and tests