### PR TITLE
Minor profile cleanup

### DIFF
--- a/lib/c-api/src/main.cc
+++ b/lib/c-api/src/main.cc
@@ -174,6 +174,13 @@ class ClingoApp : public Clasp::Cli::ClaspAppBase {
         return mode_ != Mode::clasp ? Clasp::ProblemType::asp : Clasp::ClaspFacade::detectProblemType(getStream());
     }
 
+    auto onEvent(const Clasp::Event &ev) -> void override {
+        BaseType::onEvent(ev);
+        if (const auto *g = Clasp::event_cast<Control::Grounded>(ev); g != nullptr && !g->params.empty()) {
+            ctl_->slv->print_summary(false);
+        }
+    }
+
     void initOptions(Potassco::ProgramOptions::OptionContext &root) override {
         using namespace Potassco::ProgramOptions;
         BaseType::initOptions(root);
@@ -241,10 +248,7 @@ class ClingoApp : public Clasp::Cli::ClaspAppBase {
             // NOTE: member for createTextOutput
             ctl_->bind(&slv, &slv.clasp_config(), &slv.clasp_facade());
 
-            struct SummaryGuard {
-                ClingoApp *self;
-                ~SummaryGuard() { self->ctl_->slv->print_summary(true); }
-            } guard{this};
+            POTASSCO_SCOPE_EXIT({ ctl_->slv->print_summary(true); });
 
             if (app_.has_main()) {
                 if (mode_ == Mode::solve) {

--- a/lib/control/include/clingo/control/grounder.hh
+++ b/lib/control/include/clingo/control/grounder.hh
@@ -19,7 +19,7 @@ class Grounder {
   public:
     struct Impl;
     //! Create a grounder object.
-    Grounder(Logger &log, SymbolStore &store, Input::RewriteOptions opts, OutputStm &out, bool has_output);
+    Grounder(Logger &log, SymbolStore &store, Input::RewriteOptions opts, OutputStm &out);
     //! Destroy grounder.
     ~Grounder() noexcept;
     //! Join with the given program.
@@ -59,7 +59,7 @@ class Grounder {
     [[nodiscard]] auto base() const -> Ground::Bases const &;
     //! Get the contained symbol store.
     [[nodiscard]] auto store() const -> SymbolStore &;
-    //! Get the contained symbol store.
+    //! Get the contained logger.
     [[nodiscard]] auto log() const -> Logger &;
 
   private:

--- a/lib/control/include/clingo/control/solver.hh
+++ b/lib/control/include/clingo/control/solver.hh
@@ -582,7 +582,7 @@ class Grounded : public Clasp::Event {
   public:
     explicit Grounded(Input::ProgramParamVec const &params)
         : Event(this, subsystem_load, verbosity_quiet), params(params) {}
-    Input::ProgramParamVec const &params; // NOLINT
+    std::span<Input::ProgramParamVec::value_type const> params;
 };
 
 //! A grounder and solver for logic programs.

--- a/lib/control/include/clingo/control/solver.hh
+++ b/lib/control/include/clingo/control/solver.hh
@@ -576,6 +576,15 @@ class SymbolTable {
 //! A unique pointer to a symbol table.
 using USymbolTable = std::unique_ptr<SymbolTable>;
 
+//! Event emitted by a solver after the program is grounded.
+// TODO: Simplify/Move on next output refactoring
+class Grounded : public Clasp::Event {
+  public:
+    explicit Grounded(Input::ProgramParamVec const &params)
+        : Event(this, subsystem_load, verbosity_quiet), params(params) {}
+    Input::ProgramParamVec const &params; // NOLINT
+};
+
 //! A grounder and solver for logic programs.
 //!
 //! Takes care of parsing, grounding, and solving.
@@ -697,7 +706,7 @@ class Solver : public BaseView {
 
     //! Print per step summaries.
     //!
-    //! Currently outputs profiling data if enabled.
+    //! Currently, outputs profiling data if enabled.
     auto print_summary(bool final) { grd_.print_summary(final); }
 
     //! Accept a visitor for the profile nodes.

--- a/lib/control/src/grounder.cc
+++ b/lib/control/src/grounder.cc
@@ -144,8 +144,8 @@ class Builder : public Input::DependencyBuilder {
 //! Class storing/hiding relevant state for grounding.
 struct Grounder::Impl : CppClingo::SymbolOwner {
     //! Construct the grounder implementation.
-    Impl(Logger &log, SymbolStore &store, Input::RewriteOptions opts, OutputStm &out, bool has_output)
-        : log{&log}, store{&store}, prg{opts}, out{&out}, has_output{has_output} {
+    Impl(Logger &log, SymbolStore &store, Input::RewriteOptions opts, OutputStm &out)
+        : log{&log}, store{&store}, prg{opts}, out{&out} {
         this->store->gc_add_owner(*this);
     }
     //! Destroy the grounder implementation.
@@ -282,12 +282,10 @@ struct Grounder::Impl : CppClingo::SymbolOwner {
     OutputStm *out;
     //! Indicate that the logic program might still be satisfiable.
     bool is_sat = true;
-    //! Whether the grounder has an associated text ouput.
-    bool has_output;
 };
 
-Grounder::Grounder(Logger &log, SymbolStore &store, Input::RewriteOptions opts, OutputStm &out, bool has_output)
-    : impl_{std::make_unique<Impl>(log, store, opts, out, has_output)} {
+Grounder::Grounder(Logger &log, SymbolStore &store, Input::RewriteOptions opts, OutputStm &out)
+    : impl_{std::make_unique<Impl>(log, store, opts, out)} {
 }
 
 Grounder::~Grounder() noexcept = default;
@@ -358,10 +356,12 @@ auto Grounder::const_map() -> Input::ConstMap const & {
 
 void Grounder::print_summary(bool final) {
     auto p = impl_->prg.profile();
-    if (final && intersects(p, Input::ProfileFlags::accu)) {
+    auto f = final ? Input::ProfileFlags::accu : Input::ProfileFlags::step;
+    if (intersects(p, f)) {
         auto d = intersects(p, Input::ProfileFlags::detailed) ? Ground::ProfileDetail::detailed
                                                               : Ground::ProfileDetail::compact;
-        impl_->profile.print(std::cerr, Ground::ProfileType::accu, d);
+        auto t = final ? Ground::ProfileType::accu : Ground::ProfileType::step;
+        impl_->profile.print(std::cerr, t, d);
     }
 }
 
@@ -392,13 +392,6 @@ auto Grounder::ground(Input::ProgramParamVec const &params, Ground::ScriptCallba
     }
     impl_->out->end_step();
     if (p != Input::ProfileFlags::off && !params.empty()) {
-        // NOTE: It would be better to use an event here that can be handled by
-        // the text output.
-        if (impl_->has_output && intersects(p, Input::ProfileFlags::step)) {
-            auto d = intersects(p, Input::ProfileFlags::detailed) ? Ground::ProfileDetail::detailed
-                                                                  : Ground::ProfileDetail::compact;
-            impl_->profile.print(std::cerr, Ground::ProfileType::step, d);
-        }
         impl_->profile.end_step();
     }
     return impl_->is_sat;

--- a/lib/control/src/solver.cc
+++ b/lib/control/src/solver.cc
@@ -1022,7 +1022,7 @@ auto SymbolTable::output(CppClingo::Symbol const &sym) -> State & {
 Solver::Solver(Clasp::ClaspFacade &clasp, Clasp::Cli::ClaspCliConfig &clasp_config, Logger &log, SymbolStore &store,
                Scripts &scripts, Input::RewriteOptions ropts, SolverOptions sopts, FILE *out)
     : clasp_{&clasp}, clasp_config_{&clasp_config}, buf_{out}, out_{make_output_(store, sopts.mode)},
-      grd_{log, store, ropts, *out_, clasp.ctx.eventHandler() != nullptr}, scripts_{&scripts}, opts_{sopts} {
+      grd_{log, store, ropts, *out_}, scripts_{&scripts}, opts_{sopts} {
 }
 
 auto Solver::make_output_(SymbolStore &store, AppMode mode) -> UOutputStm {
@@ -1210,6 +1210,7 @@ void Solver::ground(Input::ProgramParamVec const &params, Ground::ScriptCallback
     if (opts_.mode >= AppMode::ground) {
         prepare_();
         std::ignore = grd_.ground(params, ctx != nullptr ? ctx : scripts_);
+        clasp_->ctx.report(Grounded{params});
     }
 }
 

--- a/lib/control/src/solver.cc
+++ b/lib/control/src/solver.cc
@@ -758,23 +758,21 @@ class SolveHandleImpl : public SolveHandle {
 };
 
 //! Integrate facts and inform the grounder about updated domains.
-void end_step(std::vector<std::pair<prg_lit_t, SharedSymbol>> &added, Clasp::Asp::LogicProgram &prg, Grounder *grd) {
+void end_step(std::vector<std::pair<prg_lit_t, SharedSymbol>> &added, Clasp::Asp::LogicProgram &prg, Grounder &grd) {
     for (auto const &[lit, sym] : added) {
         assert(lit > 0);
         auto sig = sym->signature();
         assert(sig.has_value());
-        grd->mark_sig(*sig);
+        grd.mark_sig(*sig);
         if (prg.isFact(lit)) {
-            auto *base = grd->base().get_base(*sig);
+            auto *base = grd.base().get_base(*sig);
             assert(base != nullptr);
             auto it = base->find(*sym);
             assert(it.has_value() && it->value().state != Ground::StateAtom::unknown);
             it->value().state = Ground::StateAtom::fact;
         }
     }
-    if (grd != nullptr) {
-        std::ignore = grd->ground({});
-    }
+    std::ignore = grd.ground({});
 }
 
 class BackendHandleImpl : public BackendHandle {
@@ -806,7 +804,11 @@ class BackendHandleImpl : public BackendHandle {
         throw std::runtime_error("invalid atom");
     }
 
-    void do_close() override { end_step(added_, *prg_, std::exchange(grd_, nullptr)); }
+    void do_close() override {
+        if (auto *grd = std::exchange(grd_, nullptr); grd != nullptr) {
+            end_step(added_, *prg_, *grd);
+        }
+    }
 
     Grounder *grd_;
     ProgramBackend *backend_;
@@ -844,7 +846,7 @@ class Solver::ProgramBackendAdapter : public ProgramBackendImpl {
     void do_end() override {
         solver_->clasp_facade().asp()->removeAssumption();
         solver_->clasp_facade().asp()->addAssumption(assumptions_);
-        end_step(added_, *solver_->clasp_->asp(), &solver_->grd_);
+        end_step(added_, *solver_->clasp_->asp(), solver_->grd_);
         added_.clear();
         assumptions_.clear();
     }

--- a/lib/control/tests/logger.cc
+++ b/lib/control/tests/logger.cc
@@ -18,7 +18,7 @@ TEST_CASE("logger_test") {
         log.set_level(LogLevel::info);
         auto buf = Util::OutputBuffer{};
         auto out = Output::make_text_output(buf);
-        Control::Grounder grd{log, *store, opts, *out, false};
+        Control::Grounder grd{log, *store, opts, *out};
         grd.parse(str);
         auto params = Input::ProgramParamVec{{store->string("base"), {}}};
         REQUIRE(grd.ground(params));

--- a/lib/control/tests/text.cc
+++ b/lib/control/tests/text.cc
@@ -16,7 +16,7 @@ TEST_CASE("grounder_text") {
         log.set_level(LogLevel::error);
         auto buf = Util::OutputBuffer{};
         auto out = Output::make_text_output(buf);
-        Control::Grounder grd{log, *store, opts, *out, false};
+        Control::Grounder grd{log, *store, opts, *out};
         auto params = Input::ProgramParamVec{{store->string("base"), {}}};
         SECTION("fact") {
             grd.parse("#show. a.");

--- a/lib/control/tests/text.cc
+++ b/lib/control/tests/text.cc
@@ -16,7 +16,7 @@ TEST_CASE("grounder_text") {
         log.set_level(LogLevel::error);
         auto buf = Util::OutputBuffer{};
         auto out = Output::make_text_output(buf);
-        Control::Grounder grd{log, *store, opts, *out};
+        auto grd = Control::Grounder{log, *store, opts, *out};
         auto params = Input::ProgramParamVec{{store->string("base"), {}}};
         SECTION("fact") {
             grd.parse("#show. a.");


### PR DESCRIPTION
### fix potential UB in end_step()
* end_step() dereferenced the passed in grounder pointer in its
  internal loop without checking for nullptr first. Change signature
  so that it now takes the grounder by reference.

### simplify profile output handling
* move step profile output logic to Grounder::print_summary()
* add event type for signaling that grounding has finished and
  let ClingoApp handle it by calling Grounder::print_summary()
* NOTE: for consistency with the old behavior, the event is not
  emitted when grounding is invoked from a backend handler -
  in that case, the params vector is always empty and no profile
  data is created