### PR TITLE
add failing test case for min recursive min aggregate

### DIFF
--- a/lib/control/tests/text.cc
+++ b/lib/control/tests/text.cc
@@ -31,6 +31,34 @@ TEST_CASE("grounder_text") {
             REQUIRE(buf.view() == "a.\n"
                                   "b.\n#show.\n");
         }
+        SECTION("bug-min") {
+            grd.parse(R"(
+                edge(1,2).
+                edge(2,3).
+
+                dom(1,2).
+                dom(2,3).
+                dom(1,3).
+
+                dist(X,X,0) :- X=1..3.
+                dist(X,Y,M+1) :- dom(X,Y), M = #min{N: dist(X,Z,N), edge(Z,Y)}, M != #sup.)");
+            REQUIRE(grd.ground(params));
+            REQUIRE(buf.view() == "edge(1,2).\n"
+                                  "edge(2,3).\n"
+                                  "dom(1,2).\n"
+                                  "dom(2,3).\n"
+                                  "dom(1,3).\n"
+                                  "dist(1,1,0).\n"
+                                  "dist(2,2,0).\n"
+                                  "dist(3,3,0).\n"
+                                  "dist(1,2,1) :- #min { 0 } = 0.\n"
+                                  "dist(2,3,1) :- #min { 0 } = 0.\n"
+                                  "dist(1,3,2) :- #min { 1: dist(1,2,1) } = 1.\n"
+                                  "#show edge/2.\n"
+                                  "#show dom/2.\n"
+                                  "#show dist/3.\n"
+                                  "#show.\n");
+        }
         SECTION("normal") {
             grd.parse("#show. a :- not b. b :- not a.");
             REQUIRE(grd.ground(params));

--- a/lib/ground/src/assignment_aggregate.cc
+++ b/lib/ground/src/assignment_aggregate.cc
@@ -42,10 +42,12 @@ void AtomAssignAggr::accumulate(AggregateFunction fun, SymbolSpan tup, bool fact
             if (fact) {
                 if (auto *it = std::ranges::lower_bound(vals, val, cmp); it != vals.end()) {
                     vals.erase(it, vals.end());
+                    propagated_vals_ = std::min(vals.size(), propagated_vals_);
                     vals.emplace_back(val);
                 }
             } else {
                 if (auto *it = std::ranges::lower_bound(vals, val, cmp); it != vals.end() && *it != val) {
+                    propagated_vals_ = std::min(static_cast<size_t>(it - vals.begin()), propagated_vals_);
                     vals.emplace(it, val);
                 }
             }

--- a/lib/ground/src/assignment_aggregate.cc
+++ b/lib/ground/src/assignment_aggregate.cc
@@ -577,7 +577,7 @@ void StmAssignAggrElem::do_init(size_t gen) {
 auto StmAssignAggrElem::get_cond_(EvalContext const &ctx) -> std::pair<size_t, bool> {
     bool fact = true;
     auto &out = ctx.out().cond();
-    for (auto const &lit : body_) {
+    for (auto const &lit : std::span{body_}.subspan(0, num_cond_)) {
         if (lit->output(ctx, out)) {
             fact = false;
         }

--- a/lib/ground/src/body_aggregate.cc
+++ b/lib/ground/src/body_aggregate.cc
@@ -679,7 +679,7 @@ void StmBdAggrElem::do_init(size_t gen) {
 auto StmBdAggrElem::get_cond_(EvalContext const &ctx) -> std::pair<size_t, bool> {
     bool fact = true;
     auto &out = ctx.out().cond();
-    for (auto const &lit : body_) {
+    for (auto const &lit : std::span{body_}.subspan(0, num_cond_)) {
         if (lit->output(ctx, out)) {
             fact = false;
         }

--- a/lib/python-api/CMakeLists.txt
+++ b/lib/python-api/CMakeLists.txt
@@ -109,7 +109,7 @@ if(CLINGO_BUILD_APP)
     target_compile_definitions(clingo-python-embed PUBLIC CLINGO_PYTHON_ENABLED)
     target_link_libraries(clingo-python-embed PRIVATE pybind11::embed clingo clingo-python)
 
-    target_compile_definitions(pyclingo PUBLIC CLINGO_PYTHON_EMBED)
+    target_compile_definitions(clingo-python PUBLIC CLINGO_PYTHON_EMBED)
 endif()
 
 if(CLINGO_BUILD_TESTS)


### PR DESCRIPTION
There seems to be a problem with grounding recursive min aggregates. It seems like the elements of the aggregate are grounded correctly but the aggregate is not propagated correctly in the second generation.