### PR TITLE
Update clasp.

### DIFF
--- a/lib/c-api/src/main.cc
+++ b/lib/c-api/src/main.cc
@@ -213,10 +213,11 @@ class ClingoApp : public Clasp::Cli::ClaspAppBase {
         if (mode_ != Mode::solve && mode_ != Mode::clasp) {
             return nullptr;
         }
+        auto om = mode_ == Mode::clasp ? Clasp::Cli::Output::mode_default : Clasp::Cli::Output::mode_clingo;
         if (!app_.has_print_model() || !Clasp::Cli::ClaspAppOptions::isTextOutput(outf)) {
-            return ClaspAppBase::createOutput(sink, f, outf);
+            return ClaspAppBase::createOutput(sink, f, outf, om);
         }
-        auto output = createTextOutput(sink, f);
+        auto output = createTextOutput(sink, f, om);
         output->setModelPrinter(
             [this](Clasp::Cli::TextOutput &out, const Clasp::SharedContext &ctx, const Clasp::Model &mdl) {
                 auto prt = [&]() { out.printModelValues(ctx, mdl); };


### PR DESCRIPTION
* Fix output of show terms in brave/cautious reasoning.
* Fix gcc/clang search space inconsistencies.
* Set default output atom sorting to "natural" in clingo mode.
* Add potassco_default_options to install targets.
* Disable ansi colors on emscripten.
