### PR TITLE
Fix/nested instantiation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ CMakeLists.txt.user
 __pycache__
 compile_commands.json
 wheelhouse
+/bug*

--- a/lib/ground/src/assignment_aggregate.cc
+++ b/lib/ground/src/assignment_aggregate.cc
@@ -630,11 +630,11 @@ class MatcherAssignAggrStrat : public Matcher {
         : state_{&state}, insts_{std::move(insts)}, matcher_{std::move(matcher)} {}
 
   private:
-    void do_init(InstantiationContext const &ctx, [[maybe_unused]] size_t gen) override {
+    void do_init(InstantiationContext const &ctx, size_t gen) override {
         for (auto &inst : insts_) {
-            inst.init(ctx, 0);
+            inst.init(ctx, gen);
         }
-        matcher_->init(ctx, 0);
+        matcher_->init(ctx, gen);
     }
     void do_match(EvalContext const &ctx) override {
         auto [it, ins] = state_->insert_atom(ctx);

--- a/lib/ground/src/body_aggregate.cc
+++ b/lib/ground/src/body_aggregate.cc
@@ -733,9 +733,9 @@ class MatcherBdAggrStrat : public OnceMatcher {
         : state_{&state}, insts_{std::move(insts)}, offset_{&offset}, positive_{positive} {}
 
   private:
-    void do_init(InstantiationContext const &ctx, [[maybe_unused]] size_t gen) override {
+    void do_init(InstantiationContext const &ctx, size_t gen) override {
         for (auto &inst : insts_) {
-            inst.init(ctx, 0);
+            inst.init(ctx, gen);
         }
     }
     auto do_once(EvalContext const &ctx) -> bool override {

--- a/lib/ground/src/condlit.cc
+++ b/lib/ground/src/condlit.cc
@@ -416,16 +416,13 @@ class MatcherCondLitStrat : public OnceMatcher {
     MatcherCondLitStrat(StateCondLit &state, Instantiator inst) : state_{&state}, inst_{std::move(inst)} {}
 
   private:
+    void do_init(InstantiationContext const &ctx, size_t gen) override { inst_.init(ctx, gen); }
     auto do_once(EvalContext const &ctx) -> bool override {
-        if (init_) {
-            state_->base_empty().update(0);
-        } else {
-            init_ = true;
-            inst_.init(ctx, 0);
-        }
+        state_->base_empty().update(0);
         auto [it, ins] = state_->add_empty(ctx.ass());
         if (ins) {
             CLINGO_REPORT(ctx.log(), trace) << "<<< begin nested instantiation";
+            // NOTE: marks the previously inserted element as new
             state_->base_empty().update(1);
             std::ignore = inst_.instantiate(ctx.log(), ctx.store(), ctx.out());
             CLINGO_REPORT(ctx.log(), trace) << ">>> end nested instantiation";
@@ -444,7 +441,6 @@ class MatcherCondLitStrat : public OnceMatcher {
 
     StateCondLit *state_;
     Instantiator inst_;
-    bool init_ = false;
 };
 
 } // namespace

--- a/lib/ground/src/literal.cc
+++ b/lib/ground/src/literal.cc
@@ -408,7 +408,11 @@ auto LitSymbolic::do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherTy
 
 auto LitSymbolic::do_score(std::vector<bool> const &bound) const -> double {
     if (sign_ != Sign::once) {
-        return atom_->score(static_cast<double>(base_->size()), bound);
+        auto size = base_->size();
+        if (single_pass() && size == 0) {
+            return -1;
+        }
+        return atom_->score(static_cast<double>(size), bound);
     }
     return 0;
 }
@@ -490,6 +494,7 @@ auto LitProject::do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherTyp
         void do_match(EvalContext const &ctx) override { matcher_->match(ctx); }
         auto do_next(EvalContext const &ctx) -> bool override { return matcher_->next(ctx); }
         void do_print(std::ostream &out) const override { matcher_->print(out); }
+        [[nodiscard]] auto do_type() const -> MatcherType override { return matcher_->type(); }
 
         ProjectState *state_;
         UMatcher matcher_;
@@ -513,7 +518,11 @@ auto LitProject::do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherTyp
 
 auto LitProject::do_score(std::vector<bool> const &bound) const -> double {
     if (sign_ != Sign::once) {
-        return atom_->score(static_cast<double>(state_->base().size()), bound);
+        auto size = state_->base().size();
+        if (single_pass() && size == 0) {
+            return -1;
+        }
+        return atom_->score(static_cast<double>(size), bound);
     }
     return 0;
 }

--- a/lib/python-api/tests/resources/cond-09.lp
+++ b/lib/python-api/tests/resources/cond-09.lp
@@ -1,0 +1,8 @@
+a.
+1 { a : d(*) } 1.
+b.
+b :- a, #false: not not d(*).
+d(1) :- b.
+
+%% { "options": ["0"]
+%% , "solutions": [["a", "b", "d(1)"]] }


### PR DESCRIPTION
Generation counts were not handled correctly when grounding stratified constructs in a recursive context. This PR ensures that involved generation counts are handled correctly.