### PR TITLE
update clasp

### DIFF
--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -15,6 +15,7 @@ on:
 jobs:
   build:
     strategy:
+      fail-fast: false
       matrix:
         include:
           - os: ubuntu-latest

--- a/examples/python-api/tmode/README.md
+++ b/examples/python-api/tmode/README.md
@@ -1,0 +1,31 @@
+# Solving Temporal Programs
+
+This example demonstrates how to transform temporal logic programs for
+incremental solving using clingo's Python API. The transformation rewrites
+temporal programs by adding a time parameter to symbolic atoms and program
+directives, enabling temporal reasoning and incremental solving.
+
+## Features
+
+- Adds a time parameter to all symbolic atoms and program directives.
+- Converts temporal program sections (`final`, `initial`, `dynamic`, `static`)
+  to their incremental counterparts.
+- Injects temporal control atoms as needed.
+- Provides a command-line interface for solving temporal logic programs.
+
+## Usage
+
+Transform a temporal ASP program using the command-line interface:
+
+```bash
+python tmode.py <input-files>
+```
+
+## Example
+
+Given an input file `example.lp` containing temporal logic rules, running the
+script computes its temporal stable models.
+
+```bash
+python tmode.py example.lp
+```

--- a/examples/python-api/tmode/example.lp
+++ b/examples/python-api/tmode/example.lp
@@ -1,0 +1,16 @@
+#program initial.
+
+q(0).
+
+#program dynamic.
+
+q(X+1) :- q'(X).
+r(X) :- r'(X).
+
+#program static.
+
+r(X) :- q(X).
+
+#program final.
+
+:- #sum { X : r(X) } < 10.

--- a/examples/python-api/tmode/example2.lp
+++ b/examples/python-api/tmode/example2.lp
@@ -1,0 +1,8 @@
+q(0) :- initially.
+
+q(X+1) :- q'(X), not initially.
+r(X) :- r'(X), not initially.
+
+r(X) :- q(X).
+
+:- #sum { X : r(X) } < 10, finally.

--- a/examples/python-api/tmode/tmode.py
+++ b/examples/python-api/tmode/tmode.py
@@ -22,6 +22,7 @@ Example:
 import sys
 from collections.abc import Sequence
 from functools import singledispatchmethod
+from textwrap import dedent
 from typing import Any
 
 from clingo import ast
@@ -219,9 +220,7 @@ class TModeApp(App):
 
         Integrates the Transformer into a clingo.App for use with clingo_main.
         """
-        # TODO:
-        # - step -> state
-        # - hide initially and query
+        # TODO: step -> state
         options.set_default_value("out-pred-sep", "\n")
         options.set_default_value("out-step", "last")
         options.set_default_value("iquery", "finally")
@@ -235,7 +234,17 @@ class TModeApp(App):
             files: List of input file paths.
         """
         control.join(Transformer(self._lib)(files))
-        control.parse_string("#include <incmode>. #program base. initially(0).")
+        control.parse_string(
+            dedent(
+                """\
+                #include <incmode>.
+                #program base.
+                initially(0).
+                #show initially/1. [false]
+                #show finally/1. [false]
+                """
+            )
+        )
         control.main()
 
 

--- a/examples/python-api/tmode/tmode.py
+++ b/examples/python-api/tmode/tmode.py
@@ -220,9 +220,8 @@ class TModeApp(App):
 
         Integrates the Transformer into a clingo.App for use with clingo_main.
         """
-        # TODO: step -> state
         options.set_default_value("out-pred-sep", "\n")
-        options.set_default_value("out-step", "last")
+        options.set_default_value("out-step", "last:State")
         options.set_default_value("iquery", "finally")
 
     def main(self, control: Control, files: Sequence[str]) -> None:

--- a/examples/python-api/tmode/tmode.py
+++ b/examples/python-api/tmode/tmode.py
@@ -22,12 +22,15 @@ Example:
 import sys
 from collections.abc import Sequence
 from functools import singledispatchmethod
+from typing import Any
 
 from clingo import ast
 from clingo.app import App, AppOptions, clingo_main
 from clingo.control import Control
-from clingo.core import Library
+from clingo.core import Library, Location
 from clingo.symbol import Function, Number, Symbol, SymbolType
+
+Term = ast.TermSymbolic | ast.TermBinaryOperation
 
 
 class Transformer:
@@ -35,8 +38,8 @@ class Transformer:
     Transformer to convert temporal logic programs into incremental ones.
 
     Adds a time parameter to all symbolic atoms and program directives.
-    Converts 'final' programs into 'static' ones with an additional 'query(T)'
-    atom in their body.
+    Converts 'final' programs into 'static' ones with an additional
+    'finally(T)' atom in their body.
 
     Args:
         lib: clingo AST library instance.
@@ -56,7 +59,7 @@ class Transformer:
         self._final = False
         self._current = "initial"
 
-    def _get_param(self, name, location):
+    def _get_param(self, name: str, location: Location) -> tuple[str, Term]:
         """
         Extract the time parameter from the given name.
 
@@ -69,10 +72,10 @@ class Transformer:
         """
         n = name.replace("'", "")
         primes = len(name) - len(n)
-        if n == "finally":
-            n = "query"
         if self._current == "base":
-            param = ast.TermSymbolic(self._lib, location, Number(self._lib, -primes))
+            param: Term = ast.TermSymbolic(
+                self._lib, location, Number(self._lib, -primes)
+            )
         else:
             param = ast.TermSymbolic(self._lib, location, self._param)
             if primes > 0:
@@ -86,7 +89,7 @@ class Transformer:
         return n, param
 
     @singledispatchmethod
-    def _rewrite_term(self, expr):
+    def _rewrite_term(self, expr: Any) -> Any:
         """
         Recursively rewrite terms by adding the time parameter.
 
@@ -99,7 +102,7 @@ class Transformer:
         return expr.transform(self._lib, self._rewrite_term)
 
     @_rewrite_term.register
-    def _(self, expr: ast.TermFunction):
+    def _(self, expr: ast.TermFunction) -> Any:
         name, param = self._get_param(expr.name, expr.location)
         pool = []
         for args in expr.pool:
@@ -109,10 +112,10 @@ class Transformer:
         return expr.update(self._lib, name=name, pool=pool)
 
     @_rewrite_term.register
-    def _(self, expr: ast.TermSymbolic):
+    def _(self, expr: ast.TermSymbolic) -> Any:
         if expr.symbol.type == SymbolType.Function:
             name, param = self._get_param(expr.symbol.name, expr.location)
-            args = []
+            args: list[Term] = []
             for arg in expr.symbol.arguments:
                 args.append(ast.TermSymbolic(self._lib, expr.location, arg))
             args.append(param)
@@ -122,12 +125,12 @@ class Transformer:
         raise RuntimeError("not implemented")
 
     @singledispatchmethod
-    def _rewrite_stm(self, expr):
+    def _rewrite_stm(self, expr: Any) -> Any:
         """
         Rewrite statements by adding the time parameter.
 
         If the program section is 'final', converts it to 'static' and adds a
-        'query(T)' atom to the body.
+        'finally(T)' atom to the body.
 
         Args:
             expr: AST statement.
@@ -140,7 +143,7 @@ class Transformer:
             loc = ret.location
             sym = ast.TermSymbolic(self._lib, loc, self._param)
             arg = ast.ArgumentTuple(self._lib, [sym])
-            fun = ast.TermFunction(self._lib, loc, "query", [arg], False)
+            fun = ast.TermFunction(self._lib, loc, "finally", [arg], False)
             lit = ast.LiteralSymbolic(self._lib, loc, ast.Sign.NoSign, fun)
             bdy = list(ret.body)
             bdy.append(ast.BodySimpleLiteral(self._lib, lit))
@@ -148,11 +151,11 @@ class Transformer:
         return ret
 
     @_rewrite_stm.register
-    def _(self, expr: ast.LiteralSymbolic):
+    def _(self, expr: ast.LiteralSymbolic) -> Any:
         return expr.update(self._lib, atom=self._rewrite_term(expr.atom))
 
     @_rewrite_stm.register
-    def _(self, expr: ast.StatementProgram):
+    def _(self, expr: ast.StatementProgram) -> Any:
         args = list(expr.arguments)
         name = expr.name
         self._final = False
@@ -175,11 +178,11 @@ class Transformer:
         return expr.update(self._lib, name=name, arguments=args)
 
     @_rewrite_stm.register
-    def _(self, expr: ast.StatementShowSignature):
+    def _(self, expr: ast.StatementShowSignature) -> Any:
         return expr.update(self._lib, arity=expr.arity + 1)
 
     @_rewrite_stm.register
-    def _(self, expr: ast.StatementProjectSignature):
+    def _(self, expr: ast.StatementProjectSignature) -> Any:
         return expr.update(self._lib, arity=expr.arity + 1)
 
     def __call__(self, files: Sequence[str]) -> ast.Program:
@@ -206,7 +209,7 @@ class TModeApp(App):
 
     _lib: Library
 
-    def __init__(self, lib):
+    def __init__(self, lib: Library):
         super().__init__("tmode", "1.0.0")
         self._lib = lib
 
@@ -221,6 +224,7 @@ class TModeApp(App):
         # - hide initially and query
         options.set_default_value("out-pred-sep", "\n")
         options.set_default_value("out-step", "last")
+        options.set_default_value("iquery", "finally")
 
     def main(self, control: Control, files: Sequence[str]) -> None:
         """

--- a/examples/python-api/tmode/tmode.py
+++ b/examples/python-api/tmode/tmode.py
@@ -1,0 +1,240 @@
+"""
+Temporal Mode Application for clingo.
+
+This module provides a temporal mode transformation for logic programs using
+clingo's Python API. It rewrites temporal logic programs by adding a time
+parameter to all symbolic atoms and program directives, enabling incremental
+solving. The transformation also adapts program sections (e.g., 'final',
+'initial', 'dynamic', 'static', 'base') to their incremental counterparts and
+injects temporal control atoms as needed.
+
+Usage:
+    python tmode.py <input-files>
+
+Classes:
+    Transformer: Rewrites temporal logic programs for incremental solving.
+    TModeApp:    Command-line application for temporal mode transformation.
+
+Example:
+    $ python tmode.py example.lp
+"""
+
+import sys
+from collections.abc import Sequence
+from functools import singledispatchmethod
+
+from clingo import ast
+from clingo.app import App, AppOptions, clingo_main
+from clingo.control import Control
+from clingo.core import Library
+from clingo.symbol import Function, Number, Symbol, SymbolType
+
+
+class Transformer:
+    """
+    Transformer to convert temporal logic programs into incremental ones.
+
+    Adds a time parameter to all symbolic atoms and program directives.
+    Converts 'final' programs into 'static' ones with an additional 'query(T)'
+    atom in their body.
+
+    Args:
+        lib: clingo AST library instance.
+
+    Usage:
+        transformer = Transformer(lib)
+        new_program = transformer(["input.lp"])
+    """
+
+    _lib: Library
+    _param: Symbol
+    _current: str
+
+    def __init__(self, lib):
+        self._lib = lib
+        self._param = Function(self._lib, "__t")
+        self._final = False
+        self._current = "initial"
+
+    def _get_param(self, name, location):
+        """
+        Extract the time parameter from the given name.
+
+        Args:
+            name: The name of the atom or directive.
+            location: The AST location object.
+
+        Returns:
+            A tuple of form (base name, time parameter term).
+        """
+        n = name.replace("'", "")
+        primes = len(name) - len(n)
+        if n == "finally":
+            n = "query"
+        if self._current == "base":
+            param = ast.TermSymbolic(self._lib, location, Number(self._lib, -primes))
+        else:
+            param = ast.TermSymbolic(self._lib, location, self._param)
+            if primes > 0:
+                param = ast.TermBinaryOperation(
+                    self._lib,
+                    location,
+                    param,
+                    ast.BinaryOperator.Minus,
+                    ast.TermSymbolic(self._lib, location, Number(self._lib, primes)),
+                )
+        return n, param
+
+    @singledispatchmethod
+    def _rewrite_term(self, expr):
+        """
+        Recursively rewrite terms by adding the time parameter.
+
+        Args:
+            expr: AST term expression.
+
+        Returns:
+            AST term with time parameter added.
+        """
+        return expr.transform(self._lib, self._rewrite_term)
+
+    @_rewrite_term.register
+    def _(self, expr: ast.TermFunction):
+        name, param = self._get_param(expr.name, expr.location)
+        pool = []
+        for args in expr.pool:
+            x = list(args.arguments)
+            x.append(param)
+            pool.append(args.update(self._lib, arguments=x))
+        return expr.update(self._lib, name=name, pool=pool)
+
+    @_rewrite_term.register
+    def _(self, expr: ast.TermSymbolic):
+        if expr.symbol.type == SymbolType.Function:
+            name, param = self._get_param(expr.symbol.name, expr.location)
+            args = []
+            for arg in expr.symbol.arguments:
+                args.append(ast.TermSymbolic(self._lib, expr.location, arg))
+            args.append(param)
+            pool = [ast.ArgumentTuple(self._lib, args)]
+            sym = ast.TermFunction(self._lib, expr.location, name, pool)
+            return sym
+        raise RuntimeError("not implemented")
+
+    @singledispatchmethod
+    def _rewrite_stm(self, expr):
+        """
+        Rewrite statements by adding the time parameter.
+
+        If the program section is 'final', converts it to 'static' and adds a
+        'query(T)' atom to the body.
+
+        Args:
+            expr: AST statement.
+
+        Returns:
+            Rewritten AST statement.
+        """
+        ret = expr.transform(self._lib, self._rewrite_stm) or expr
+        if self._final and hasattr(ret, "body"):
+            loc = ret.location
+            sym = ast.TermSymbolic(self._lib, loc, self._param)
+            arg = ast.ArgumentTuple(self._lib, [sym])
+            fun = ast.TermFunction(self._lib, loc, "query", [arg], False)
+            lit = ast.LiteralSymbolic(self._lib, loc, ast.Sign.NoSign, fun)
+            bdy = list(ret.body)
+            bdy.append(ast.BodySimpleLiteral(self._lib, lit))
+            ret = ret.update(self._lib, body=bdy)
+        return ret
+
+    @_rewrite_stm.register
+    def _(self, expr: ast.LiteralSymbolic):
+        return expr.update(self._lib, atom=self._rewrite_term(expr.atom))
+
+    @_rewrite_stm.register
+    def _(self, expr: ast.StatementProgram):
+        args = list(expr.arguments)
+        name = expr.name
+        self._final = False
+        match expr.name:
+            case "final":
+                name = "check"
+                self._final = True
+            case "initial":
+                name = "base"
+            case "dynamic":
+                name = "step"
+            case "static":
+                name = "check"
+            case "base":
+                name = "check"
+        self._current = name
+        if name != "base":
+            args.append(self._param.name)
+
+        return expr.update(self._lib, name=name, arguments=args)
+
+    @_rewrite_stm.register
+    def _(self, expr: ast.StatementShowSignature):
+        return expr.update(self._lib, arity=expr.arity + 1)
+
+    @_rewrite_stm.register
+    def _(self, expr: ast.StatementProjectSignature):
+        return expr.update(self._lib, arity=expr.arity + 1)
+
+    def __call__(self, files: Sequence[str]) -> ast.Program:
+        """
+        Rewrite the given files and return the transformed AST program.
+
+        Args:
+            files: List of input file paths.
+
+        Returns:
+            The transformed program.
+        """
+        prg = ast.Program(self._lib)
+        ast.parse_files(
+            self._lib, files, lambda stm: prg.add(self._rewrite_stm(stm) or stm)
+        )
+        return prg
+
+
+class TModeApp(App):
+    """
+    Temporal mode application.
+    """
+
+    _lib: Library
+
+    def __init__(self, lib):
+        super().__init__("tmode", "1.0.0")
+        self._lib = lib
+
+    def register_options(self, options: AppOptions) -> None:
+        """
+        Command-line application for temporal mode transformation.
+
+        Integrates the Transformer into a clingo.App for use with clingo_main.
+        """
+        # TODO:
+        # - step -> state
+        # - hide initially and query
+        options.set_default_value("out-pred-sep", "\n")
+        options.set_default_value("out-step", "last")
+
+    def main(self, control: Control, files: Sequence[str]) -> None:
+        """
+        Run the temporal mode application.
+
+        Args:
+            control: clingo control object.
+            files: List of input file paths.
+        """
+        control.join(Transformer(self._lib)(files))
+        control.parse_string("#include <incmode>. #program base. initially(0).")
+        control.main()
+
+
+if __name__ == "__main__":
+    LIB = Library()
+    sys.exit(clingo_main(LIB, sys.argv[1:], TModeApp(LIB)))

--- a/lib/c-api/include/clingo/app.h
+++ b/lib/c-api/include/clingo/app.h
@@ -107,7 +107,7 @@ typedef bool (*clingo_option_parser_t)(char const *value, size_t size, void *dat
 //! @param[in] group options are grouped into sections as given by this string
 //! @param[in] group_size the size of the group
 //! @param[in] option specifies the command line option
-//! @param[in] option_size teh size of the option
+//! @param[in] option_size the size of the option
 //! @param[in] description the description of the option
 //! @param[in] description_size the size of the description
 //! @param[in] parser callback to parse the value of the option
@@ -129,7 +129,7 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_options_add(clingo_options_t *options, cha
 //! @param[in] group options are grouped into sections as given by this string
 //! @param[in] group_size the size of the group
 //! @param[in] option specifies the command line option
-//! @param[in] option_size teh size of the option
+//! @param[in] option_size the size of the option
 //! @param[in] description the description of the option
 //! @param[in] description_size the size of the description
 //! @param[in] target boolean set to true if the flag is given on the command-line
@@ -137,6 +137,21 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_options_add(clingo_options_t *options, cha
 CLINGO_VISIBILITY_DEFAULT bool clingo_options_add_flag(clingo_options_t *options, char const *group, size_t group_size,
                                                        char const *option, size_t option_size, char const *description,
                                                        size_t description_size, bool *target);
+
+//! Set the default value for an existing clingo option.
+//!
+//! This function can be used to adjust the default value of a clingo option,
+//! which will be used if no value is given on the command-line.
+//!
+//! @param[in] options object to set the default value for
+//! @param[in] option specifies the command line option
+//! @param[in] option_size the size of the option
+//! @param[in] value the default value to set
+//! @param[in] value_size the size of the value
+//! @return whether the call was successful
+CLINGO_VISIBILITY_DEFAULT bool clingo_options_set_default_value(clingo_options_t *options, char const *option,
+                                                                size_t option_size, char const *value,
+                                                                size_t value_size);
 
 //! Run an application with the given library and arguments.
 //!

--- a/lib/c-api/src/ast.cc
+++ b/lib/c-api/src/ast.cc
@@ -1279,7 +1279,8 @@ auto clingo_ast::get_number(clingo_ast_attribute_t attr) const -> std::optional<
             ATTR(optimize_type, type()))
         TYPE(statement_show_signature, StmShowSig,
             ATTR(sign, sign())
-            ATTR(arity, arity()))
+            ATTR(arity, arity())
+            ATTR(value, value()))
         TYPE(statement_project_signature, StmProjectSig,
             ATTR(sign, sign())
             ATTR(arity, arity()))
@@ -2322,9 +2323,10 @@ extern "C" auto clingo_ast_construct(clingo_lib_t *lib, clingo_ast_type_t type, 
                 auto name_size = va_arg(args, size_t);
                 auto arity = va_arg(args, int);
                 auto sign = va_arg(args, int);
+                auto value = va_arg(args, int);
                 va_end(args);
-                *ast = construct_ast<CppClingo::Input::StmShowSig>(type, convert(loc), sign != 0,
-                                                                   *lib->store->string({name, name_size}), arity);
+                *ast = construct_ast<CppClingo::Input::StmShowSig>(
+                    type, convert(loc), sign != 0, *lib->store->string({name, name_size}), arity, value != 0);
                 break;
             }
             case clingo_ast_type_statement_project: {

--- a/lib/c-api/src/ast_yaml.cc
+++ b/lib/c-api/src/ast_yaml.cc
@@ -1050,14 +1050,18 @@ statement_show_signature:
       doc: The location of the statement.
     name:
       type: string
-      doc: The name of the atom to show.
+      doc: The name of the predicate to show.
     arity:
       type: number
-      doc: The arity of the atom to show.
+      doc: The arity of the predicate to show.
     sign:
       type: bool
       default: false
       doc: The classical sign of the atom.
+    value:
+      type: bool
+      default: true
+      doc: Whether to show or hide the predicate.
 statement_project:
   type: record
   doc: A project statement.

--- a/lib/c-api/src/main.cc
+++ b/lib/c-api/src/main.cc
@@ -12,7 +12,6 @@
 
 #include <clasp/cli/clasp_app.h>
 
-#include <forward_list>
 #include <utility>
 
 using namespace CppClingo::CAPI;
@@ -21,10 +20,10 @@ namespace CppClingo::CAPI {
 namespace {
 
 using namespace CppClingo::Input;
-
 class AppOptions {
   public:
     using OptionParser = std::function<bool(std::string_view)>;
+    explicit AppOptions(Potassco::ProgramOptions::OptionContext &root) : root_(&root) {}
 
     void add_option(std::string_view group, std::string_view option, std::string_view description, OptionParser parser,
                     std::optional<std::string_view> argument, bool multi = false) {
@@ -46,31 +45,21 @@ class AppOptions {
         add_option_value_(group, option, std::move(value), description);
     }
 
-    void init(Potassco::ProgramOptions::OptionContext &root) {
-        for (auto const &group : groups_) {
-            root.add(group);
+    auto set_default_value(std::string_view option, std::string_view value) -> bool {
+        if (!root_->option(option).assignDefault(value)) {
+            throw std::invalid_argument(std::string("Invalid value for option '").append(option).append("'"));
         }
+        return true;
     }
 
   private:
     void add_option_value_(std::string_view group, std::string_view option, Potassco::ProgramOptions::ValueDesc value,
                            std::string_view description) {
-        auto init = add_option_group_(group).addOptions();
+        auto init = root_->addOptions(group);
         init(option, std::move(value), description);
     }
 
-    auto add_option_group_(std::string_view group) -> Potassco::ProgramOptions::OptionGroup & {
-        auto it = groups_.before_begin();
-        for (auto &option_group : groups_) {
-            if (option_group.caption() == group) {
-                return option_group;
-            }
-            ++it;
-        }
-        return *groups_.emplace_after(it, group);
-    }
-
-    std::forward_list<Potassco::ProgramOptions::OptionGroup> groups_;
+    Potassco::ProgramOptions::OptionContext *root_ = nullptr;
 };
 
 auto c_cast(AppOptions *opts) -> clingo_options_t * {
@@ -106,8 +95,8 @@ class AppAdapter {
 
     void register_options(Potassco::ProgramOptions::OptionContext &root) {
         if (app_ != nullptr && app_->register_options != nullptr) {
-            handle_error(app_->register_options(c_cast(&opts_), data_));
-            opts_.init(root);
+            AppOptions opts(root);
+            handle_error(app_->register_options(c_cast(&opts), data_));
         }
     }
 
@@ -142,7 +131,6 @@ class AppAdapter {
     }
 
   private:
-    AppOptions opts_;
     clingo_application_t const *app_;
     void *data_;
 };
@@ -305,6 +293,15 @@ extern "C" auto clingo_options_add_flag(clingo_options_t *options, char const *g
     CLINGO_TRY {
         auto *opts = cpp_cast(options);
         opts->add_flag({group, group_size}, {option, option_size}, {description, description_size}, *target);
+    }
+    CLINGO_CATCH;
+}
+
+extern "C" auto clingo_options_set_default_value(clingo_options_t *options, char const *option, size_t option_size,
+                                                 char const *value, size_t value_size) -> bool {
+    CLINGO_TRY {
+        auto *opts = cpp_cast(options);
+        opts->set_default_value({option, option_size}, {value, value_size});
     }
     CLINGO_CATCH;
 }

--- a/lib/c-api/src/opts.hh
+++ b/lib/c-api/src/opts.hh
@@ -55,6 +55,24 @@ class ClingoOptions {
             solver_opts_.imax = 0;
             return Potassco::stringTo(value, *solver_opts_.imax) == std::errc{};
         };
+        auto parse_iquery = [this](std::string_view value) {
+            bool is_id = false;
+            for (auto c : value) {
+                if ('a' <= c && c <= 'z') {
+                    is_id = true;
+                    continue;
+                }
+                if (c == '_' || c == '\'') {
+                    continue;
+                }
+                if (is_id && (('A' <= c && c <= 'Z') || ('0' <= c && c <= '9'))) {
+                    continue;
+                }
+                return false;
+            }
+            solver_opts_.iquery = value;
+            return is_id;
+        };
         auto parse_level = [this](std::string_view value) {
             if (auto lvl = LogLevel::info; values<LogLevel>({{"error", LogLevel::error},
                                                              {"warn", LogLevel::warn},
@@ -161,6 +179,7 @@ class ClingoOptions {
             ("parts", parse(parse_parts), "Parse comma-separated program parts to ground")       //
             ("imin", parse(parse_imin).arg("<n>"), "Minimum number of steps for incmode")        //
             ("imax", parse(parse_imax).arg("{none|<n>}"), "Maximum number of steps for incmode") //
+            ("@3,iquery", parse(parse_iquery), "The name of the query atom")                     //
             ("istop",
              storeTo(solver_opts_.istop, values<Control::IStop>({{"none", Control::IStop::none},
                                                                  {"sat", Control::IStop::sat},

--- a/lib/control/include/clingo/control/solver.hh
+++ b/lib/control/include/clingo/control/solver.hh
@@ -77,6 +77,8 @@ struct SolverOptions {
     std::optional<size_t> imax = std::nullopt;
     //! The stop condition for the incremental mode.
     IStop istop = IStop::sat;
+    //! The name of the query atom.
+    std::string iquery = "query";
     //! Restrict to single shot-solving.
     bool single_shot = false;
 };

--- a/lib/control/src/grounder.cc
+++ b/lib/control/src/grounder.cc
@@ -183,6 +183,7 @@ struct Grounder::Impl : CppClingo::SymbolOwner {
                 out->show_atom(atom, it.value().id);
             }
         };
+        auto hide = Util::unordered_set<Input::Sig>{};
         for (auto const &stm : prg.meta_stms()) {
             std::visit(
                 [&, this]<class T>(T const &stm) {
@@ -196,10 +197,14 @@ struct Grounder::Impl : CppClingo::SymbolOwner {
                     } else if constexpr (Util::matches<T, Input::StmShowNothing>) {
                         show_all = false;
                     } else if constexpr (Util::matches<T, Input::StmShowSig>) {
-                        show_all = false;
-                        if (auto *base = bases.get_base(Input::Sig{stm.name(), stm.arity(), stm.sign()});
-                            base != nullptr) {
-                            show_base(*base);
+                        if (stm.value()) {
+                            show_all = false;
+                            if (auto *base = bases.get_base(Input::Sig{stm.name(), stm.arity(), stm.sign()});
+                                base != nullptr) {
+                                show_base(*base);
+                            }
+                        } else {
+                            hide.emplace(Input::Sig{stm.name(), stm.arity(), stm.sign()});
                         }
                     }
                 },
@@ -207,7 +212,9 @@ struct Grounder::Impl : CppClingo::SymbolOwner {
         }
         if (show_all) {
             for (auto const &[sig, base] : bases.atoms()) {
-                show_base(*base);
+                if (!hide.contains(sig)) {
+                    show_base(*base);
+                }
             }
         }
         // handle classical negation
@@ -428,7 +435,7 @@ void Grounder::show(Input::SharedSig const &sig) {
     auto prg = Input::UnprocessedProgram{};
     auto pos = Position{*impl_->store->string("<cmd>"), 1, 1};
     auto loc = Location{pos, pos};
-    prg.add(*impl_->store, Input::StmShowSig{loc, get<2>(sig), *get<0>(sig), static_cast<int>(get<1>(sig))});
+    prg.add(*impl_->store, Input::StmShowSig{loc, get<2>(sig), *get<0>(sig), static_cast<int>(get<1>(sig)), true});
     impl_->prg.join(*impl_->log, *impl_->store, prg);
 }
 

--- a/lib/control/src/solver.cc
+++ b/lib/control/src/solver.cc
@@ -1031,7 +1031,7 @@ auto SymbolTable::output(CppClingo::Symbol const &sym) -> State & {
 Solver::Solver(Clasp::ClaspFacade &clasp, Clasp::Cli::ClaspCliConfig &clasp_config, Logger &log, SymbolStore &store,
                Scripts &scripts, Input::RewriteOptions ropts, SolverOptions sopts, FILE *out)
     : clasp_{&clasp}, config_{clasp_config}, buf_{out}, out_{make_output_(store, sopts.mode)},
-      grd_{log, store, ropts, *out_}, scripts_{&scripts}, opts_{sopts} {
+      grd_{log, store, ropts, *out_}, scripts_{&scripts}, opts_{std::move(sopts)} {
 }
 
 auto Solver::make_output_(SymbolStore &store, AppMode mode) -> UOutputStm {
@@ -1067,13 +1067,12 @@ void Solver::incmode_() {
     auto part_check = store.string("check");
     auto part_step = store.string("step");
     auto part_base = store.string("base");
-    auto part_query = store.string("query");
 
-    parse(R"(#program check(t).
-#external query(t). [true]
-#program step(t).
-#external query(t-1). [release]
-)");
+    parse(std::string{"#program check(t).\n#external "} + opts_.iquery +
+          "(t). [true]\n"
+          "#program step(t).\n"
+          "#external " +
+          opts_.iquery + "(t-1). [release]\n");
 
     size_t step = 0;
     auto ret = SolveResult::empty;

--- a/lib/control/src/solver.cc
+++ b/lib/control/src/solver.cc
@@ -368,6 +368,7 @@ class ModelExtend : public Clasp::OutputTable::Theory {
   public:
     auto first([[maybe_unused]] const Clasp::Model &m) -> char const * override {
         index_ = 0;
+        std::ranges::sort(syms_);
         return next();
     }
     auto next() -> char const * override {

--- a/lib/cxx-api/include/clingo/app.hh
+++ b/lib/cxx-api/include/clingo/app.hh
@@ -84,6 +84,12 @@ class Options {
                                                      description.data(), description.size(), &flag));
     }
 
+    //! Set `value` as default value for the option with the given name.
+    void set_default_value(std::string_view option, std::string_view value) {
+        Detail::handle_error(
+            clingo_options_set_default_value(opts_, option.data(), option.size(), value.data(), value.size()));
+    }
+
   private:
     clingo_options_t *opts_;
     ParserList *parsers_;

--- a/lib/cxx-api/include/clingo/detail/ast.hh
+++ b/lib/cxx-api/include/clingo/detail/ast.hh
@@ -183,7 +183,8 @@ constexpr auto cons_statement_show =
 constexpr auto cons_statement_show_nothing = std::array{Arg{clingo_ast_attribute_location, Arg::location}};
 constexpr auto cons_statement_show_signature =
     std::array{Arg{clingo_ast_attribute_location, Arg::location}, Arg{clingo_ast_attribute_name, Arg::string},
-               Arg{clingo_ast_attribute_arity, Arg::integer}, Arg{clingo_ast_attribute_sign, Arg::integer}};
+               Arg{clingo_ast_attribute_arity, Arg::integer}, Arg{clingo_ast_attribute_sign, Arg::integer},
+               Arg{clingo_ast_attribute_value, Arg::integer}};
 constexpr auto cons_statement_project =
     std::array{Arg{clingo_ast_attribute_location, Arg::location}, Arg{clingo_ast_attribute_atom, Arg::node},
                Arg{clingo_ast_attribute_body, Arg::node_array}};

--- a/lib/cxx-api/tests/app.cc
+++ b/lib/cxx-api/tests/app.cc
@@ -24,6 +24,9 @@ class AppTest : public App {
     auto do_version() noexcept -> std::string_view override { return "1.2.3"; }
     void do_main(Control const &control, std::span<std::string_view const> files) override {
         events.emplace_back("main");
+        if (auto val = control.config()["configuration"].value(); val == config.path().string()) {
+            events.emplace_back("default");
+        }
         control.parse_files(files);
         control.ground();
         std::ignore = control.solve({}, MCB{models});
@@ -33,6 +36,7 @@ class AppTest : public App {
         options.add("Clingo.Test", "test", "test description",
                     [this](std::string_view val) { return this->parse_test(val); });
         options.add_flag("Clingo.Test", "flag", "test description", flag);
+        options.set_default_value("configuration", config.path().string());
     }
 
     void do_validate_options() override {
@@ -41,6 +45,7 @@ class AppTest : public App {
     }
 
     MV models;
+    TempFile config{""};
     std::vector<std::string> events;
     bool flag = false;
 };
@@ -62,7 +67,7 @@ TEST_CASE("app", "[cxx][app]") {
     auto ret = Clingo::main(lib, arg, &app);
 
     REQUIRE(ret == 30);
-    REQUIRE(app.events == std::vector<std::string>{"register", "parse", "validate", "main", "logger"});
+    REQUIRE(app.events == std::vector<std::string>{"register", "parse", "validate", "main", "default", "logger"});
     REQUIRE(app.models == MV{{"a"}, {"a", "b"}, {"b"}});
 }
 

--- a/lib/cxx-api/tests/ast.cc
+++ b/lib/cxx-api/tests/ast.cc
@@ -646,18 +646,23 @@ TEST_CASE_METHOD(Fixture, "ast statement show", "[cxx][ast][statement_show]") {
     REQUIRE(std::ranges::equal(s1.nodes(A::body), std::vector{l1, l2}));
     REQUIRE(s1.to_string() == "#show -p(X): q(X); p(X).");
 
-    auto s2 = node<T::statement_show_signature>(loc, "p", 2, false);
-    auto s3 = node<T::statement_show_signature>(loc, "q", 2, true);
+    auto s2 = node<T::statement_show_signature>(loc, "p", 2, false, true);
+    auto s3 = node<T::statement_show_signature>(loc, "q", 2, true, true);
+    auto s4 = node<T::statement_show_signature>(loc, "p", 2, false, false);
     REQUIRE((s2.location(A::location) == loc));
     REQUIRE(s2.string(A::name) == "p");
     REQUIRE(s2.number(A::arity) == 2);
     REQUIRE(s2.number(A::sign) == 0);
+    REQUIRE(s2.number(A::value) == 1);
     REQUIRE(s3.number(A::sign) == 1);
-    REQUIRE(s2.to_string() == "#show p/2.");
-    REQUIRE(s3.to_string() == "#show -q/2.");
+    REQUIRE(s3.number(A::value) == 1);
+    REQUIRE(s4.number(A::value) == 0);
+    REQUIRE(s2.to_string() == "#show p/2. [true]");
+    REQUIRE(s3.to_string() == "#show -q/2. [true]");
+    REQUIRE(s4.to_string() == "#show p/2. [false]");
 
-    auto s4 = node<T::statement_show_nothing>(loc);
-    REQUIRE(s4.to_string() == "#show.");
+    auto s5 = node<T::statement_show_nothing>(loc);
+    REQUIRE(s5.to_string() == "#show.");
 }
 
 TEST_CASE_METHOD(Fixture, "ast statement project", "[cxx][ast][statement_project]") {

--- a/lib/input/include/clingo/input/statement.hh
+++ b/lib/input/include/clingo/input/statement.hh
@@ -363,12 +363,12 @@ class StmShowSig : public Expression<StmShowSig> {
     //! The record attributes.
     static constexpr auto attributes() {
         return std::tuple{a_loc = &StmShowSig::loc_, a_name = &StmShowSig::name, a_sign = &StmShowSig::sign_,
-                          a_arity = &StmShowSig::arity_};
+                          a_arity = &StmShowSig::arity_, a_value = &StmShowSig::value_};
     }
 
     //! Construct a show signature statement.
-    explicit StmShowSig(Location loc, bool sign, String name, int arity)
-        : loc_{std::move(loc)}, name_{name}, arity_{arity}, sign_{sign} {}
+    explicit StmShowSig(Location loc, bool sign, String name, int arity, bool value)
+        : loc_{std::move(loc)}, name_{name}, arity_{arity}, sign_{sign}, value_{value} {}
 
     //! The location of the statement.
     [[nodiscard]] auto loc() const -> Location const & { return loc_; }
@@ -378,12 +378,15 @@ class StmShowSig : public Expression<StmShowSig> {
     [[nodiscard]] auto name() const -> String const & { return *name_; }
     //! The arity.
     [[nodiscard]] auto arity() const -> int { return arity_; }
+    //! The value.
+    [[nodiscard]] auto value() const -> bool { return value_; }
 
   private:
     Location loc_;
     SharedString name_;
     int arity_;
     bool sign_;
+    bool value_;
 };
 
 //! A show signature statement.

--- a/lib/input/src/parse/statement.cc
+++ b/lib/input/src/parse/statement.cc
@@ -148,7 +148,26 @@ auto parse_show(ParserState &state) -> std::optional<Stm> {
             state.consume();
             if (auto res = check_term_sig(*term)) {
                 auto [sign, name, arity] = *std::move(res);
-                return StmShowSig{std::move(loc), sign, name, arity};
+                auto value = true;
+                if (state.branch(TokenType::lbrack)) {
+                    if (!state.expect(TokenType::id)) {
+                        return std::nullopt;
+                    }
+                    auto id = state.str();
+                    if (id == "false") {
+                        value = false;
+                    } else if (id != "true") {
+                        return state.expected<std::nullopt>("true", "false");
+                    }
+                    state.consume();
+                    if (!state.expect(TokenType::rbrack)) {
+                        return std::nullopt;
+                    }
+                    loc += state.cursor_pos();
+                    state.mark_stms();
+                    state.consume();
+                }
+                return StmShowSig{std::move(loc), sign, name, arity, value};
             }
             return StmShow{state.loc(), *std::move(term), {}};
         }

--- a/lib/input/src/print.cc
+++ b/lib/input/src/print.cc
@@ -630,7 +630,8 @@ template <class O> class Print {
     void operator()([[maybe_unused]] StmShowNothing const &stm) const { *out_ << "#show."; }
 
     void operator()(StmShowSig const &stm) const {
-        *out_ << "#show " << (stm.sign() ? "-" : "") << stm.name() << "/" << stm.arity() << ".";
+        *out_ << "#show " << (stm.sign() ? "-" : "") << stm.name() << "/" << stm.arity() << "." << " ["
+              << (stm.value() ? "true" : "false") << "]";
     }
 
     void operator()(StmProject const &stm) const {

--- a/lib/input/tests/dependency.cc
+++ b/lib/input/tests/dependency.cc
@@ -204,7 +204,7 @@ TEST_CASE("dependency") {
         auto prg = Program{ph.ctx().options()};
         prg.join(ph, ph, uprg);
         std::ignore = prg.analyze(ph, {ProgramParam{ph.store().string("p"), {ph.store().num(Number(1))}}}, bld);
-        REQUIRE(bld.res == std::vector<std::string>{"#show p/2.", "p(b).", "#program_p(1).", "% component",
+        REQUIRE(bld.res == std::vector<std::string>{"#show p/2. [true]", "p(b).", "#program_p(1).", "% component",
                                                     "% refined component", "p($0) :- #program_p($0).", "% component",
                                                     "% refined component", "p(X,$0) :- #program_p($0); f(X)."});
     }

--- a/lib/input/tests/parser.cc
+++ b/lib/input/tests/parser.cc
@@ -356,8 +356,10 @@ TEST_CASE("parsev2") {
         REQUIRE(parse("#minimize {1@2;3@4}.") == "#minimize { 1@2; 3@4 }.");
 
         // show
-        REQUIRE(parse("#show a/2.") == "#show a/2.");
-        REQUIRE(parse("#show -a/2.") == "#show -a/2.");
+        REQUIRE(parse("#show a/2.") == "#show a/2. [true]");
+        REQUIRE(parse("#show -a/2.") == "#show -a/2. [true]");
+        REQUIRE(parse("#show -a/2. [true]") == "#show -a/2. [true]");
+        REQUIRE(parse("#show -a/2. [false]") == "#show -a/2. [false]");
         // Note: the print function could be refined to omit the parenthesis
         REQUIRE(parse("#show a()/2.") == "#show (a/2): .");
         REQUIRE(parse("#show -a()/2.") == "#show (-a/2): .");

--- a/lib/input/tests/project.cc
+++ b/lib/input/tests/project.cc
@@ -96,7 +96,8 @@ TEST_CASE("project_statement") {
     REQUIRE(project_statement("#minimize { X,Y: p(X), p(Z) }.") == "#minimize { X,Y: p(X), p(*) }.");
     REQUIRE(project_statement(":~ p(X), p(Z). [X,Y]") == " :~ p(X); p(*). [X,Y]");
     REQUIRE(project_statement("#show p(X,Y): q(X,Z).") == "#show p(X,Y): q(X,*).");
-    REQUIRE(project_statement("#show p/2.") == "#show p/2.");
+    REQUIRE(project_statement("#show p/2. [true]") == "#show p/2. [true]");
+    REQUIRE(project_statement("#show p/2. [false]") == "#show p/2. [false]");
     REQUIRE(project_statement("#project p(X,Y): q(X,Z).") == "#project p(X,Y): q(X,*).");
     REQUIRE(project_statement("#project p/2.") == "#project p/2.");
     REQUIRE(project_statement("#defined p/2.") == "#defined p/2.");

--- a/lib/input/tests/project_anonymous.cc
+++ b/lib/input/tests/project_anonymous.cc
@@ -77,7 +77,7 @@ TEST_CASE("project_anonymous_statement") {
     REQUIRE(project_statement("#minimize { Y@Z: not p(X), not p(_) }.") == "#minimize { Y@Z: not p(X), not p(*) }.");
     REQUIRE(project_statement(":~ not p(X); not p(_). [Y]") == " :~ not p(X); not p(*). [Y]");
     REQUIRE(project_statement("#show p(X,Y): not p(X), not q(_).") == "#show p(X,Y): not p(X); not q(*).");
-    REQUIRE(project_statement("#show p/2.") == "#show p/2.");
+    REQUIRE(project_statement("#show p/2.") == "#show p/2. [true]");
     REQUIRE(project_statement("#project p(X): not q(Y), not q(_).") == "#project p(X): not q(Y); not q(*).");
     REQUIRE(project_statement("#project p/2.") == "#project p/2.");
     REQUIRE(project_statement("#defined p/2.") == "#defined p/2.");

--- a/lib/input/tests/rewrite_anonymous.cc
+++ b/lib/input/tests/rewrite_anonymous.cc
@@ -78,7 +78,7 @@ TEST_CASE("rewrite_anonymous_statement") {
             "#minimize { Y@Z: not p(X), not p(__A_0) }.");
     REQUIRE(rewrite_statement(":~ not p(X), not p(_). [Y]") == " :~ not p(X); not p(__A_0). [Y]");
     REQUIRE(rewrite_statement("#show p(X,Y): not p(X); not q(_).") == "#show p(X,Y): not p(X); not q(__A_0).");
-    REQUIRE(rewrite_statement("#show p/2.") == "#show p/2.");
+    REQUIRE(rewrite_statement("#show p/2.") == "#show p/2. [true]");
     REQUIRE(rewrite_statement("#project p(X): not q(Y), not q(_).") == "#project p(X): not q(Y); not q(__A_0).");
     REQUIRE(rewrite_statement("#project p/2.") == "#project p/2.");
     REQUIRE(rewrite_statement("#defined p/2.") == "#defined p/2.");

--- a/lib/python-api/src/app.cc
+++ b/lib/python-api/src/app.cc
@@ -41,6 +41,10 @@ class Options {
                                              description.data(), description.size(), &cflag.value));
     }
 
+    void set_default_value(std::string_view option, std::string_view value) {
+        handle_error(clingo_options_set_default_value(opts_, option.data(), option.size(), value.data(), value.size()));
+    }
+
     auto c_ptr() -> clingo_options_t * { return opts_; }
 
   private:
@@ -342,6 +346,18 @@ Args:
         A brief description of the flag option.
     flag:
         A Flag object that holds the value of the flag.
+)"_d)
+        .def("set_default_value", &Options::set_default_value, py::arg("option"), py::arg("value"), R"(
+Set the default value for an existing clingo option.
+
+This function can be used to adjust the default value of a clingo option, which
+will be used if no value is given on the command-line.
+
+Args:
+    option:
+        The name of the option for which a default value should be set.
+    value:
+        The new default value to set.
 )"_d);
 
     py::class_<App>(app, "App", py::custom_type_setup(&App::setup), R"(

--- a/lib/python-api/src/ast.cc
+++ b/lib/python-api/src/ast.cc
@@ -2048,14 +2048,15 @@ class StatementShowSignature : public ASTBase {
     auto name() -> std::string_view;
     auto arity() -> int;
     auto sign() -> bool;
+    auto value() -> bool;
 
     void visit(py::handle visitor, py::args const &args, py::kwargs const &kwargs);
     auto transform(Library &lib, py::handle transform, py::args const &args, py::kwargs const &kwargs)
         -> std::optional<StatementShowSignature>;
     auto update(Library &lib, py::kwargs const &kwargs) -> StatementShowSignature;
 
-    static auto construct(Library &lib, Location const &location, std::string_view name, int arity, bool sign)
-        -> StatementShowSignature;
+    static auto construct(Library &lib, Location const &location, std::string_view name, int arity, bool sign,
+                          bool value) -> StatementShowSignature;
     static auto acquire(clingo_ast_t *ast) -> StatementShowSignature { return {ast}; }
 
     friend auto operator==(StatementShowSignature const &a, StatementShowSignature const &b) -> bool = default;
@@ -5795,12 +5796,18 @@ auto StatementShowSignature::sign() -> bool {
     return ret != 0;
 }
 
+auto StatementShowSignature::value() -> bool {
+    int ret = 0;
+    handle_error(clingo_ast_attribute_get_number(ast_, clingo_ast_attribute_value, &ret));
+    return ret != 0;
+}
+
 auto StatementShowSignature::construct(Library &lib, Location const &location, std::string_view name, int arity,
-                                       bool sign) -> StatementShowSignature {
+                                       bool sign, bool value) -> StatementShowSignature {
     clingo_ast_t *res_ = nullptr;
     handle_error(clingo_ast_construct(lib, clingo_ast_type_statement_show_signature, &res_,
                                       static_cast<clingo_location_t const *>(location), name.data(), name.size(), arity,
-                                      static_cast<int>(sign)));
+                                      static_cast<int>(sign), static_cast<int>(value)));
     return StatementShowSignature::acquire(res_);
 }
 
@@ -5819,7 +5826,8 @@ auto StatementShowSignature::update(Library &lib, py::kwargs const &kwargs) -> S
         lib, update_value<Location>(this, &StatementShowSignature::location, kwargs, "location"),
         update_value<std::string_view>(this, &StatementShowSignature::name, kwargs, "name"),
         update_value<int>(this, &StatementShowSignature::arity, kwargs, "arity"),
-        update_value<bool>(this, &StatementShowSignature::sign, kwargs, "sign"));
+        update_value<bool>(this, &StatementShowSignature::sign, kwargs, "sign"),
+        update_value<bool>(this, &StatementShowSignature::value, kwargs, "value"));
 }
 
 auto StatementProject::location() -> Location {
@@ -9196,19 +9204,23 @@ Returns:
 
     make_comparable_base<Statement>(py_statement_show_signature)
         .def(py::init(&StatementShowSignature::construct), py::arg("lib"), py::arg("location"), py::arg("name"),
-             py::arg("arity"), py::arg("sign") = false, R"doc(Construct a StatementShowSignature object.
+             py::arg("arity"), py::arg("sign") = false, py::arg("value") = true,
+             R"doc(Construct a StatementShowSignature object.
 
 Args:
     lib: The library object for storing symbols.
     location: The location of the statement.
-    name: The name of the atom to show.
-    arity: The arity of the atom to show.
-    sign: The classical sign of the atom.)doc")
+    name: The name of the predicate to show.
+    arity: The arity of the predicate to show.
+    sign: The classical sign of the atom.
+    value: Whether to show or hide the predicate.)doc")
         .def("__str__", &StatementShowSignature::to_string)
         .def_property_readonly("location", &StatementShowSignature::location, R"doc(The location of the statement.)doc")
-        .def_property_readonly("name", &StatementShowSignature::name, R"doc(The name of the atom to show.)doc")
-        .def_property_readonly("arity", &StatementShowSignature::arity, R"doc(The arity of the atom to show.)doc")
+        .def_property_readonly("name", &StatementShowSignature::name, R"doc(The name of the predicate to show.)doc")
+        .def_property_readonly("arity", &StatementShowSignature::arity, R"doc(The arity of the predicate to show.)doc")
         .def_property_readonly("sign", &StatementShowSignature::sign, R"doc(The classical sign of the atom.)doc")
+        .def_property_readonly("value", &StatementShowSignature::value,
+                               R"doc(Whether to show or hide the predicate.)doc")
         .def("visit", &StatementShowSignature::visit, py::arg("visitor"), R"doc(Visit the children of the expression.
 
 Args:

--- a/lib/python-api/stubs/app.pyi
+++ b/lib/python-api/stubs/app.pyi
@@ -235,6 +235,20 @@ class AppOptions:
                 A Flag object that holds the value of the flag.
         """
 
+    def set_default_value(self, option: str, value: str) -> None:
+        """
+        Set the default value for an existing clingo option.
+
+        This function can be used to adjust the default value of a clingo option, which
+        will be used if no value is given on the command-line.
+
+        Args:
+            option:
+                The name of the option for which a default value should be set.
+            value:
+                The new default value to set.
+        """
+
 class Flag:
     """
     Boolean flag with value management.

--- a/lib/python-api/tests/resources/show-02.lp
+++ b/lib/python-api/tests/resources/show-02.lp
@@ -1,0 +1,5 @@
+a.
+b.
+#show b/0. [false]
+%% { "options": ["0"]
+%% , "solutions": [ ["a"] ] }

--- a/lib/python-api/tests/test_app.py
+++ b/lib/python-api/tests/test_app.py
@@ -22,19 +22,20 @@ class AppTest(App):
     Note that I did not find a nice way to test model printing.
     """
 
+    _df: str
     _queue: Queue
     program_name = "test"
     version = "1.2.3"
     message_limit = 17
 
-    def __init__(self, queue: Queue):
+    def __init__(self, df: str, queue: Queue):
         super().__init__(AppTest.program_name, AppTest.version)
+        self._df = df
         self._queue = queue
         self._flag = Flag()
 
-    def _parse_test(self, value):
+    def _parse_test(self, value) -> None:
         self._queue.put(("parse", value))
-        return True
 
     def register_options(self, options: AppOptions) -> None:
         """
@@ -44,6 +45,8 @@ class AppTest(App):
         group = "Clingo.Test"
         options.add(group, "test", "test description", self._parse_test)
         options.add_flag(group, "flag", "test description", self._flag)
+        # Apply default value
+        options.set_default_value("configuration", self._df)
 
     def validate_options(self) -> None:
         """
@@ -61,6 +64,7 @@ class AppTest(App):
         Run the main loop.
         """
         self._queue.put("main")
+        self._queue.put(("configuration", control.config.configuration.value))
         control.parse_files(files)
         control.ground(control.parts)
         mcb = MCB()
@@ -69,7 +73,11 @@ class AppTest(App):
 
 
 def _run_process(
-    app: Callable[[Queue], App], program: str, queue: Queue, args: Sequence[str]
+    app: Callable[[str, Queue], App],
+    df: str,
+    program: str,
+    queue: Queue,
+    args: Sequence[str],
 ) -> None:
     """
     Run clingo application with given program and intercept results.
@@ -85,7 +93,7 @@ def _run_process(
             queue.put((code, re.sub("^.*:(?=[0-9]+:)", "", msg)))
 
         with Library(logger=logger) as lib:
-            ret = clingo_main(lib, [name, "--outf=3"] + list(args), app(queue))
+            ret = clingo_main(lib, [name, "--outf=3"] + list(args), app(df, queue))
             queue.put(int(ret))
             queue.close()
     finally:
@@ -96,14 +104,14 @@ AppResult = Tuple[int, List[Any]]
 
 
 def run_app(
-    app: Callable[[Queue], App], program: str, *args: Sequence[str]
+    app: Callable[[str, Queue], App], df: str, program: str, *args: Sequence[str]
 ) -> AppResult:
     """
     Run clingo application in subprocess via multiprocessing module.
     """
     q: Queue
     q = Queue()
-    p = Process(target=_run_process, args=(app, program, q, tuple(args)))
+    p = Process(target=_run_process, args=(app, df, program, q, tuple(args)))
 
     p.start()
     seq: List[Any]
@@ -131,17 +139,25 @@ class TestApplication:
         """
         Test application.
         """
-        ret, seq = run_app(AppTest, "1 {a; b; c(1/0)}.", "0", "--test=x", "--flag")
-        assert ret == 30
-        assert seq == [
-            "register",
-            ("parse", "x"),
-            "validate",
-            ("flag", True),
-            "main",
-            (
-                MessageType.OperationUndefined,
-                "1:12-15: info: operation undefined:\n  1/0\n",
-            ),
-            ("models", [["a"], ["a", "b"], ["b"]]),
-        ]
+        with NamedTemporaryFile(mode="wt", delete=False) as fp:
+            name = fp.name
+        try:
+            ret, seq = run_app(
+                AppTest, name, "1 {a; b; c(1/0)}.", "0", "--test=x", "--flag"
+            )
+            assert ret == 30
+            assert seq == [
+                "register",
+                ("parse", "x"),
+                "validate",
+                ("flag", True),
+                "main",
+                ("configuration", name),
+                (
+                    MessageType.OperationUndefined,
+                    "1:12-15: info: operation undefined:\n  1/0\n",
+                ),
+                ("models", [["a"], ["a", "b"], ["b"]]),
+            ]
+        finally:
+            os.unlink(name)

--- a/lib/python-api/tests/test_ast.py
+++ b/lib/python-api/tests/test_ast.py
@@ -762,16 +762,21 @@ class TestAST:
 
         s2 = ast.StatementShowSignature(self.lib, self.loc, "p", 2)
         s3 = ast.StatementShowSignature(self.lib, self.loc, "q", 2, True)
+        s4 = ast.StatementShowSignature(self.lib, self.loc, "p", 2, False, False)
         assert s2.location == self.loc
         assert s2.name == "p"
         assert s2.arity == 2
         assert not s2.sign
+        assert s2.value
         assert s3.sign
-        assert str(s2) == "#show p/2."
-        assert str(s3) == "#show -q/2."
+        assert s3.value
+        assert not s4.value
+        assert str(s2) == "#show p/2. [true]"
+        assert str(s3) == "#show -q/2. [true]"
+        assert str(s4) == "#show p/2. [false]"
 
-        s4 = ast.StatementShowNothing(self.lib, self.loc)
-        assert str(s4) == "#show."
+        s5 = ast.StatementShowNothing(self.lib, self.loc)
+        assert str(s5) == "#show."
 
     def test_statement_project(self):
         """


### PR DESCRIPTION
* add colored help output and fix regression in option parser
* extend text output

@rkaminsk  This update is also a first step towards custom text output. 
For example, the output of `clingcon` could now be achieved by:

- Adding options  `--out-assign=__csp/2` and `--out-cost=__csp_cost/1:%0`
- Adjusting `Clingcon::Propagator::on_model() ` so that it adds the cost as a `Clingo::Number(lib_, std::to_string(bound));` instead of a `Clingo::String`.

For `clingo-lpx`, it would be:
- `--out-assign=__lpx/2` and `--out-cost=__lpx_objective/2:%0 [%1]`
- Adjusting `LPXPropagatorFacade::extend_model()`  so that it adds `Clingo::Number`s instead of strings. 

**TODO/RFC**

- There is an API missing for properly setting output options like `--out-assign`.
- The theory assignment extracted from the theory atoms is not yet sorted.
- Atom arguments are always printed verbatim (including quotes). E.g. for a theory atom `__lpx_objective(-132, "bounded")` and `--out-cost=__lpx_objective/2:%0 [%1]`, `clasp` currently prints `Costs: -132 ["bounded"]`. Hence, maybe it should be possible to extend the argument references with a type/print-hint (e.g. `%1s`).