### PR TITLE
update clasp

### DIFF
--- a/lib/control/src/solver.cc
+++ b/lib/control/src/solver.cc
@@ -367,8 +367,10 @@ class TheoryBackendAdapter : public TheoryBackend {
 class ModelExtend : public Clasp::OutputTable::Theory {
   public:
     auto first([[maybe_unused]] const Clasp::Model &m) -> char const * override {
+        if (!std::exchange(sorted_, true)) {
+            std::ranges::sort(syms_);
+        }
         index_ = 0;
-        std::ranges::sort(syms_);
         return next();
     }
     auto next() -> char const * override {
@@ -379,14 +381,21 @@ class ModelExtend : public Clasp::OutputTable::Theory {
         }
         return nullptr;
     }
-    void clear() { syms_.clear(); }
-    void add(SymbolSpan symbols) { syms_.insert(syms_.end(), symbols.begin(), symbols.end()); }
+    void clear() {
+        syms_.clear();
+        sorted_ = true;
+    }
+    void add(SymbolSpan symbols) {
+        syms_.insert(syms_.end(), symbols.begin(), symbols.end());
+        sorted_ = sorted_ && std::ranges::is_sorted(syms_);
+    }
     [[nodiscard]] auto symbols() const -> SymbolSpan { return syms_; }
 
   private:
     Util::OutputBuffer buf_;
     SymbolVec syms_;
     size_t index_ = 0;
+    bool sorted_ = true;
 };
 
 //! Implementation of the model interface.


### PR DESCRIPTION
* apply `--out-{assign,cost}` to all atoms and make section string customizable

* avoid re-sorting of symbols in ModelExtend

@rkaminsk I also adjusted the [clingo-lpx](https://github.com/potassco/clingo-lpx/pulls) PR so that it now uses "Objective:" instead of "Cost:"