### PR TITLE
Update RE2C version requirement to 3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,7 +108,7 @@ if(MSVC)
     add_compile_options(/bigobj)
 endif()
 
-find_package(RE2C "2.0" REQUIRED)
+find_package(RE2C "3.0" REQUIRED)
 
 add_subdirectory(third_party)
 add_subdirectory(lib libclingo)


### PR DESCRIPTION
The short `--header` flag is RE2C v3+ only: https://github.com/skvadrik/re2c/commit/886b73af33335644f0d3909b54c12c6d6f478356