### PR TITLE
Statistics

### DIFF
--- a/lib/c-api/include/clingo/stats.h
+++ b/lib/c-api/include/clingo/stats.h
@@ -58,6 +58,11 @@ typedef int clingo_stats_type_t;
 //! Handle for the solver stats.
 typedef struct clingo_statistic clingo_stats_t;
 
+//! Well-known key name intended to be used for user-specific step statistics.
+CLINGO_VISIBILITY_DEFAULT extern clingo_string_t const clingo_user_stats_step;
+//! Well-known key name intended to be used for user-specific accu statistics.
+CLINGO_VISIBILITY_DEFAULT extern clingo_string_t const clingo_user_stats_accu;
+
 //! Get the root key of the stats.
 //!
 //! @param[in] stats the target stats

--- a/lib/c-api/include/clingo/stats.h
+++ b/lib/c-api/include/clingo/stats.h
@@ -166,6 +166,20 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_stats_map_subkey_name(clingo_stats_t const
 //! @return whether the call was successful
 CLINGO_VISIBILITY_DEFAULT bool clingo_stats_map_at(clingo_stats_t const *stats, uint64_t key, char const *name,
                                                    size_t size, uint64_t *subkey);
+
+//! Try to get the subkey under the given name or return the given default key if it does not exist.
+//!
+//! @pre The @link clingo_stats_type() type@endlink of the entry must be @ref ::clingo_stats_type_map.
+//! @param[in] stats the target stats
+//! @param[in] key the key
+//! @param[in] name the name to look up the subkey
+//! @param[in] size the size of the name
+//! @param[in] defkey the key to return if name is not found
+//! @param[out] subkey the resulting subkey
+//! @return whether the call was successful
+CLINGO_VISIBILITY_DEFAULT bool clingo_stats_map_try_at(clingo_stats_t const *stats, uint64_t key, char const *name,
+                                                       size_t size, uint64_t defkey, uint64_t *subkey);
+
 //! Add a subkey with the given name.
 //!
 //! @pre The @link clingo_stats_type() type@endlink of the entry must be @ref ::clingo_stats_type_map.

--- a/lib/c-api/src/stats.cc
+++ b/lib/c-api/src/stats.cc
@@ -161,6 +161,19 @@ extern "C" auto clingo_stats_map_at(clingo_stats_t const *stats, uint64_t key, c
     CLINGO_CATCH;
 }
 
+extern "C" auto clingo_stats_map_try_at(clingo_stats_t const *stats, uint64_t key, char const *name, size_t size,
+                                        uint64_t defkey, uint64_t *subkey) -> bool {
+    CLINGO_TRY {
+        if (stats == nullptr || (name == nullptr && size > 0) || subkey == nullptr) {
+            return fail_arguments();
+        }
+        if (!cpp_cast(stats)->find(key, std::string_view{name, size}, subkey)) {
+            *subkey = defkey;
+        }
+    }
+    CLINGO_CATCH;
+}
+
 extern "C" auto clingo_stats_map_add_subkey(clingo_stats_t *stats, uint64_t key, char const *name, size_t size,
                                             clingo_stats_type_t type, uint64_t *subkey) -> bool {
     CLINGO_TRY {

--- a/lib/c-api/src/stats.cc
+++ b/lib/c-api/src/stats.cc
@@ -59,6 +59,11 @@ inline auto c_cast(Potassco::StatisticsType type) -> clingo_stats_type_e {
 } // namespace
 } // namespace CppClingo::CAPI
 
+clingo_string_t const clingo_user_stats_step = {.data = Clasp::ClaspFacade::user_step_stats.data(),
+                                                .size = Clasp::ClaspFacade::user_step_stats.size()};
+clingo_string_t const clingo_user_stats_accu = {.data = Clasp::ClaspFacade::user_accu_stats.data(),
+                                                .size = Clasp::ClaspFacade::user_accu_stats.size()};
+
 extern "C" auto clingo_stats_root(clingo_stats_t const *stats, uint64_t *key) -> bool {
     CLINGO_TRY {
         if (stats == nullptr || key == nullptr) {

--- a/lib/control/include/clingo/control/solver.hh
+++ b/lib/control/include/clingo/control/solver.hh
@@ -396,7 +396,7 @@ class SolveEventHandler {
     //! Callback to update statistics.
     //!
     //! Applications can add user defined statistics here. Statistics should be
-    //! added under keys "user_step" and "user_accu" to appear in the text
+    //! added under keys \ref clingo_user_stats_step and \ref clingo_user_stats_accu to appear in the text
     //! output.
     //!
     //! @param stats a handle to the statistics

--- a/lib/control/include/clingo/control/solver.hh
+++ b/lib/control/include/clingo/control/solver.hh
@@ -396,8 +396,8 @@ class SolveEventHandler {
     //! Callback to update statistics.
     //!
     //! Applications can add user defined statistics here. Statistics should be
-    //! added under keys \ref clingo_user_stats_step and \ref clingo_user_stats_accu to appear in the text
-    //! output.
+    //! added under keys \ref clingo_user_stats_step and \ref
+    //! clingo_user_stats_accu to appear in the text output.
     //!
     //! @param stats a handle to the statistics
     void on_stats(Potassco::AbstractStatistics &stats) { do_on_stats(stats); }

--- a/lib/cxx-api/include/clingo/control.hh
+++ b/lib/cxx-api/include/clingo/control.hh
@@ -674,13 +674,13 @@ class Control {
                         CLINGO_TRY {
                             auto *hnd = UserData::cast(data);
                             assert(hnd != nullptr);
-                            std::string_view user_step = "user_step";
-                            std::string_view user_accu = "user_accu";
                             uint64_t root = Detail::call<clingo_stats_root>(stats);
                             uint64_t step = Detail::call<clingo_stats_map_add_subkey>(
-                                stats, root, user_step.data(), user_step.size(), clingo_stats_type_map);
+                                stats, root, clingo_user_stats_step.data, clingo_user_stats_step.size,
+                                clingo_stats_type_map);
                             uint64_t accu = Detail::call<clingo_stats_map_add_subkey>(
-                                stats, root, user_accu.data(), user_accu.size(), clingo_stats_type_map);
+                                stats, root, clingo_user_stats_accu.data, clingo_user_stats_accu.size,
+                                clingo_stats_type_map);
                             hnd->stats(Stats{stats, step}, Stats{stats, accu});
                         }
                         CLINGO_CATCH;

--- a/lib/cxx-api/include/clingo/solve.hh
+++ b/lib/cxx-api/include/clingo/solve.hh
@@ -542,13 +542,11 @@ static constexpr clingo_solve_event_handler_t c_solve_event_handler{
         CLINGO_TRY {
             auto *hnd = static_cast<SolveEventHandler *>(data);
             assert(hnd != nullptr);
-            std::string_view user_step = "user_step";
-            std::string_view user_accu = "user_accu";
             uint64_t root = Detail::call<clingo_stats_root>(stats);
-            uint64_t step = Detail::call<clingo_stats_map_add_subkey>(stats, root, user_step.data(), user_step.size(),
-                                                                      clingo_stats_type_map);
-            uint64_t accu = Detail::call<clingo_stats_map_add_subkey>(stats, root, user_accu.data(), user_accu.size(),
-                                                                      clingo_stats_type_map);
+            uint64_t step = Detail::call<clingo_stats_map_add_subkey>(
+                stats, root, clingo_user_stats_step.data, clingo_user_stats_step.size, clingo_stats_type_map);
+            uint64_t accu = Detail::call<clingo_stats_map_add_subkey>(
+                stats, root, clingo_user_stats_accu.data, clingo_user_stats_accu.size, clingo_stats_type_map);
             hnd->stats(Stats{stats, step}, Stats{stats, accu});
         }
         CLINGO_CATCH;

--- a/lib/cxx-api/include/clingo/stats.hh
+++ b/lib/cxx-api/include/clingo/stats.hh
@@ -470,6 +470,16 @@ inline auto Stats::get(std::string_view name) const -> Stats {
     return map().get(name);
 }
 
+//! Get the root statistics entry for user step stats.
+inline auto stats_step_root() -> std::string_view {
+    return {clingo_user_stats_step.data, clingo_user_stats_step.size};
+}
+
+//! Get the root statistics entry for user accumulated stats.
+inline auto stats_accu_root() -> std::string_view {
+    return {clingo_user_stats_accu.data, clingo_user_stats_accu.size};
+}
+
 //! @}
 
 } // namespace Clingo

--- a/lib/cxx-api/include/clingo/stats.hh
+++ b/lib/cxx-api/include/clingo/stats.hh
@@ -86,7 +86,7 @@ class ConstStats {
 
     //! Get a string representation of the statistics entry.
     //!
-    //! The represention is YAML-like and can be used for debugging purposes.
+    //! The representation is YAML-like and can be used for debugging purposes.
     //!
     //! @return a string representation of the statistics entry
     [[nodiscard]] auto to_string() const -> std::string {

--- a/lib/cxx-api/tests/propagate.cc
+++ b/lib/cxx-api/tests/propagate.cc
@@ -43,8 +43,8 @@ class AIFFBPropagator : public Propagator {
     }
     void do_attach([[maybe_unused]] Assignment assignment, [[maybe_unused]] PropagateControl ctl) override {
         auto thread_id = assignment.thread_id();
-        REQUIRE(thread_id < n_threads);
         auto lock = std::scoped_lock{mut};
+        REQUIRE(thread_id < n_threads);
         REQUIRE(attached.insert(thread_id).second);
     }
 

--- a/lib/cxx-api/tests/stats.cc
+++ b/lib/cxx-api/tests/stats.cc
@@ -72,15 +72,17 @@ TEST_CASE_METHOD(Fixture, "stats user", "[cxx][stats][user]") {
     REQUIRE(models == MV{{"a"}, {"b"}, {"c"}, {"d"}});
 
     auto stats = ctl.stats();
+    auto user_step = std::string_view{clingo_user_stats_step.data, clingo_user_stats_step.size};
+    auto user_accu = std::string_view{clingo_user_stats_accu.data, clingo_user_stats_accu.size};
 
-    REQUIRE(*stats["user_step"]["a"] == 10.0);
-    REQUIRE(*stats["user_step"]["b"][0] == 10.0);
-    REQUIRE(*stats["user_step"]["c"]["x"] == 1.0);
+    REQUIRE(*stats[user_step]["a"] == 10.0);
+    REQUIRE(*stats[user_step]["b"][0] == 10.0);
+    REQUIRE(*stats[user_step]["c"]["x"] == 1.0);
 
-    REQUIRE(*stats["user_accu"]["Test"]["x"] == 12.0);
-    REQUIRE(*stats["user_accu"]["Test"]["y"][0] == 2.0);
-    REQUIRE(*stats["user_accu"]["Test"]["y"][1] == 3.0);
-    REQUIRE(*stats["user_accu"]["Test"]["y"][2] == 4.0);
+    REQUIRE(*stats[user_accu]["Test"]["x"] == 12.0);
+    REQUIRE(*stats[user_accu]["Test"]["y"][0] == 2.0);
+    REQUIRE(*stats[user_accu]["Test"]["y"][1] == 3.0);
+    REQUIRE(*stats[user_accu]["Test"]["y"][2] == 4.0);
 }
 
 } // namespace Clingo::Test

--- a/lib/cxx-api/tests/theory.cc
+++ b/lib/cxx-api/tests/theory.cc
@@ -65,7 +65,7 @@ struct TestTheory {
             uint64_t root = 0;
             Detail::handle_error(clingo_stats_root(stats, &root));
             auto st = Stats{stats, root};
-            auto step = st.map().insert(theory_stats_root(), StatsType::map).map();
+            auto step = st.map().insert(Clingo::stats_step_root(), StatsType::map).map();
             step.insert("test_key", StatsType::value).value(3.14);
         }
         CLINGO_CATCH;
@@ -143,9 +143,6 @@ struct TestTheory {
         }
         CLINGO_CATCH;
     }
-    static auto theory_stats_root() -> std::string_view {
-        return std::string_view{clingo_user_stats_step.data, clingo_user_stats_step.size};
-    }
 };
 
 struct Fixture : SolveEventHandler {
@@ -201,7 +198,7 @@ TEST_CASE_METHOD(Fixture, "theory", "[cxx][theory]") {
     REQUIRE(dta->prepared);
     REQUIRE(ctl.solve({}, std::ref(*this)).satisfiable());
     REQUIRE(dta->models == 1);
-    REQUIRE(ctl.stats()[TestTheory::theory_stats_root()]["test_key"].value() == 3.14);
+    REQUIRE(ctl.stats()[Clingo::stats_step_root()]["test_key"].value() == 3.14);
 }
 
 } // namespace Clingo::Test

--- a/lib/cxx-api/tests/theory.cc
+++ b/lib/cxx-api/tests/theory.cc
@@ -65,7 +65,7 @@ struct TestTheory {
             uint64_t root = 0;
             Detail::handle_error(clingo_stats_root(stats, &root));
             auto st = Stats{stats, root};
-            auto step = st.map().insert("user_step", StatsType::map).map();
+            auto step = st.map().insert(theory_stats_root(), StatsType::map).map();
             step.insert("test_key", StatsType::value).value(3.14);
         }
         CLINGO_CATCH;
@@ -143,6 +143,9 @@ struct TestTheory {
         }
         CLINGO_CATCH;
     }
+    static auto theory_stats_root() -> std::string_view {
+        return std::string_view{clingo_user_stats_step.data, clingo_user_stats_step.size};
+    }
 };
 
 struct Fixture : SolveEventHandler {
@@ -198,7 +201,7 @@ TEST_CASE_METHOD(Fixture, "theory", "[cxx][theory]") {
     REQUIRE(dta->prepared);
     REQUIRE(ctl.solve({}, std::ref(*this)).satisfiable());
     REQUIRE(dta->models == 1);
-    REQUIRE(ctl.stats()["user_step"]["test_key"].value() == 3.14);
+    REQUIRE(ctl.stats()[TestTheory::theory_stats_root()]["test_key"].value() == 3.14);
 }
 
 } // namespace Clingo::Test

--- a/lib/python-api/src/control.cc
+++ b/lib/python-api/src/control.cc
@@ -213,13 +213,13 @@ auto Control::config() -> Config {
     return Config{*this, config, key};
 }
 
-auto Control::stats() -> py::dict {
+auto Control::stats() -> ConstStats {
     clingo_stats_t const *stats = nullptr;
     handle_error(clingo_control_stats(get(), &stats));
     uint64_t key = 0;
     handle_error(clingo_stats_root(stats, &key));
     // NOLINTNEXTLINE
-    return Stats{const_cast<clingo_stats_t *>(stats), key}.nestify();
+    return ConstStats{const_cast<clingo_stats_t *>(stats), key};
 }
 
 auto Control::profile() -> py::list {

--- a/lib/python-api/src/control.cc
+++ b/lib/python-api/src/control.cc
@@ -331,12 +331,10 @@ auto Control::start_solve(MixedLitSpan const &assumptions, Annotation<std::optio
                 uint64_t root = 0;
                 handle_error(clingo_stats_root(stats, &root));
                 uint64_t step = 0;
-                std::string_view user_step = "user_step";
-                std::string_view user_accu = "user_accu";
-                handle_error(clingo_stats_map_add_subkey(stats, root, user_step.data(), user_step.size(),
+                handle_error(clingo_stats_map_add_subkey(stats, root, clingo_user_stats_step.data, clingo_user_stats_step.size,
                                                          clingo_stats_type_map, &step));
                 uint64_t accu = 0;
-                handle_error(clingo_stats_map_add_subkey(stats, root, user_accu.data(), user_accu.size(),
+                handle_error(clingo_stats_map_add_subkey(stats, root, clingo_user_stats_accu.data, clingo_user_stats_accu.size,
                                                          clingo_stats_type_map, &accu));
                 (*hnd->stats_)(Stats{stats, step}, Stats{stats, accu});
             }

--- a/lib/python-api/src/control.hh
+++ b/lib/python-api/src/control.hh
@@ -65,7 +65,7 @@ class Control : public registered_handle<Control, clingo_control_t>, public refe
     void observe(Observer &obs, bool preprocess);
     auto backend() -> BackendManager;
     auto config() -> Config;
-    auto stats() -> py::dict;
+    auto stats() -> ConstStats;
     auto profile() -> py::list;
     void main();
     auto buffer() -> std::string_view;

--- a/lib/python-api/src/stats.cc
+++ b/lib/python-api/src/stats.cc
@@ -6,7 +6,58 @@
 namespace PyClingo {
 
 namespace {
+class StatsIterBase {
+  public:
+    StatsIterBase(clingo_stats_t *stats, uint64_t key, std::size_t len) : stats_(stats), key_(key), end_(len) {}
+    auto operator==(const StatsIterBase &) const -> bool = default;
+    friend auto operator==(const StatsIterBase &iter, [[maybe_unused]] std::default_sentinel_t s) -> bool {
+        return iter.pos_ == iter.end_;
+    }
+    void next() { ++pos_; }
+    [[nodiscard]] auto map_key() const -> std::string_view {
+        clingo_string_t name;
+        handle_error(clingo_stats_map_subkey_name(stats_, key_, pos_, &name));
+        return {name.data, name.size};
+    }
+    [[nodiscard]] auto map_value() const -> ConstStats { return map_item().second; }
+    [[nodiscard]] auto map_item() const -> std::pair<std::string_view, ConstStats> {
+        auto name = this->map_key();
+        auto value = ConstStatsMap{stats_, key_}.get(name);
+        return {name, value};
+    }
+    [[nodiscard]] auto array_item() const -> ConstStats { return ConstStatsArray{stats_, key_}.get(pos_); }
 
+  private:
+    clingo_stats_t *stats_;
+    uint64_t key_;
+    std::size_t pos_{0};
+    std::size_t end_;
+};
+template <auto Pmf>
+    requires(std::is_invocable_v<decltype(Pmf), StatsIterBase const &>)
+class StatsIter : public StatsIterBase {
+  public:
+    using StatsIterBase::operator==;
+    using StatsIterBase::StatsIterBase;
+    auto operator*() const -> std::invoke_result_t<decltype(Pmf), StatsIterBase const &> {
+        return (static_cast<StatsIterBase const &>(*this).*Pmf)();
+    }
+    auto operator->() const -> std::invoke_result_t<decltype(Pmf), StatsIterBase const &> {
+        return (static_cast<StatsIterBase const &>(*this).*Pmf)();
+    }
+    auto operator++() -> StatsIter & {
+        this->next();
+        return *this;
+    }
+    auto operator++(int) -> StatsIter {
+        StatsIter t(*this);
+        this->next();
+        return t;
+    }
+};
+template <auto Fun> auto make_py_iter(clingo_stats_t *stats, uint64_t key, std::size_t len) {
+    return py::make_iterator(StatsIter<Fun>(stats, key, len), std::default_sentinel);
+}
 auto get_type(py::handle value, std::optional<ConstStats> old_value) -> std::pair<StatsType, py::object> {
     py::object new_value = py::none{};
     if (PyCallable_Check(value.ptr()) == 1) {
@@ -30,7 +81,6 @@ auto get_type(py::handle value, std::optional<ConstStats> old_value) -> std::pai
 }
 
 } // namespace
-
 auto ConstStatsArray::len() const -> size_t {
     size_t size = 0;
     handle_error(clingo_stats_array_size(stats_, key_, &size));
@@ -43,6 +93,9 @@ auto ConstStatsArray::get(size_t index) const -> ConstStats {
         return {stats_, subkey};
     }
     throw py::index_error{"array index out of bounds"};
+}
+auto ConstStatsArray::items() const -> py::iterator {
+    return make_py_iter<&StatsIterBase::array_item>(stats_, key_, len());
 }
 ConstStatsArray::operator StatsArray() const {
     return StatsArray{stats_, key_};
@@ -61,15 +114,6 @@ void StatsArray::append(py::handle value) {
     auto [subtype, subval] = get_type(value, std::nullopt);
     handle_error(clingo_stats_array_push(stats_, key_, static_cast<clingo_stats_type_t>(subtype), &subkey));
     Stats{stats_, subkey}.update_(std::move(subval), true);
-}
-
-ConstStatsMap::KeyIter::KeyIter(clingo_stats_t *stats, uint64_t key, std::size_t len)
-    : stats_(stats), key_(key), pos_(0), end_(len) {
-}
-auto ConstStatsMap::KeyIter::operator*() const -> std::string_view {
-    clingo_string_t name;
-    handle_error(clingo_stats_map_subkey_name(stats_, key_, pos_, &name));
-    return {name.data, name.size};
 }
 
 auto ConstStatsMap::len() const -> size_t {
@@ -97,8 +141,14 @@ auto ConstStatsMap::try_get(std::string_view name) const -> std::optional<ConstS
     }
     return res;
 }
-auto ConstStatsMap::keys() const -> KeyIter {
-    return {stats_, key_, len()};
+auto ConstStatsMap::keys() const -> py::iterator {
+    return make_py_iter<&StatsIterBase::map_key>(stats_, key_, len());
+}
+auto ConstStatsMap::values() const -> py::iterator {
+    return make_py_iter<&StatsIterBase::map_value>(stats_, key_, len());
+}
+auto ConstStatsMap::items() const -> py::iterator {
+    return make_py_iter<&StatsIterBase::map_item>(stats_, key_, len());
 }
 ConstStatsMap::operator StatsMap() const {
     return StatsMap{stats_, key_};
@@ -186,14 +236,26 @@ auto ConstStats::nestify() const -> py::object {
             return res;
         }
         case StatsType::map: {
-            auto x = ConstStatsMap{stats_, key_};
+            auto map = ConstStatsMap{stats_, key_};
             auto res = py::dict{};
-            for (auto k = x.keys(); k != std::default_sentinel; ++k) {
-                auto name = *k;
-                res[py::str{name}] = x.get(name).nestify();
+            for (auto it = StatsIter<&StatsIterBase::map_item>{stats_, key_, map.len()}; it != std::default_sentinel;
+                 ++it) {
+                auto [name, object] = *it;
+                res[py::str{name}] = object.nestify();
             }
             return res;
         }
+    }
+    unreachable();
+}
+auto ConstStats::iter() const -> py::iterator {
+    switch (type()) {
+        case StatsType::map:
+            return map().keys();
+        case StatsType::array:
+            return array().items();
+        case StatsType::value:
+            throw py::type_error{"'StatsType::value' is not iterable"};
     }
     unreachable();
 }
@@ -241,10 +303,10 @@ void Stats::update_(py::handle value, bool init) {
         }
     }
 }
-auto Stats::array() const -> StatsArray {
+auto Stats::array() -> StatsArray {
     return static_cast<StatsArray>(ConstStats::array());
 }
-auto Stats::map() const -> StatsMap {
+auto Stats::map() -> StatsMap {
     return static_cast<StatsMap>(ConstStats::map());
 }
 auto Stats::get(std::size_t key) -> Stats {
@@ -308,6 +370,7 @@ option only basic stats are reported.
             .def("__len__", &ConstStats::len, "Get the length of this element.")
             .def("__contains__", &ConstStats::contains,
                  "Checks whether the given key is in the element, which must be a map.")
+            .def("__iter__", &ConstStats::iter, "Get an iterator over the keys of the map.")
             .def("__float__", &ConstStats::get_value, "Get the value of the element.")
             .def("__eq__",
                  [](const ConstStats &lhs, const py::object &rhs) {
@@ -332,6 +395,7 @@ Class representing a read-only array of stats.
 This class partially implements the mutable sequence protocol.
 )"_d)
         .def("__len__", &ConstStatsArray::len, "Get the length of the array.")
+        .def("__iter__", &ConstStatsArray::items, "Get an iterator over the elements of the array.")
         .def("__getitem__", &ConstStatsArray::get, "Get the element at the given index.");
 
     py::class_<StatsArray, ConstStatsArray>(module, "StatsArray", R"(
@@ -359,9 +423,10 @@ Class representing a read-only map of stats.
 This class partially implements the mutable mapping protocol.
 )"_d)
         .def("__len__", &ConstStatsMap::len, "Get the length of the map.")
-        .def(
-            "__iter__", [](const ConstStatsMap &map) { return py::make_iterator(map.keys(), std::default_sentinel); },
-            "Get an iterator over the keys of the map.")
+        .def("__iter__", &ConstStatsMap::keys, "Get an iterator over the keys of the map.")
+        .def("keys", &ConstStatsMap::keys, "Get an iterator over the keys of the map.")
+        .def("values", &ConstStatsMap::values, "Get an iterator over the values of the map.")
+        .def("items", &ConstStatsMap::items, "Get an iterator over the items of the map.")
         .def("__getitem__", &ConstStatsMap::get, py::arg("key"), "Lookup the value with the given key.");
 
     py::class_<StatsMap, ConstStatsMap>(module, "StatsMap", R"(

--- a/lib/python-api/src/stats.cc
+++ b/lib/python-api/src/stats.cc
@@ -7,7 +7,7 @@ namespace PyClingo {
 
 namespace {
 
-auto get_type(py::handle value, std::optional<Stats> old_value) -> std::pair<StatsType, py::object> {
+auto get_type(py::handle value, std::optional<ConstStats> old_value) -> std::pair<StatsType, py::object> {
     py::object new_value = py::none{};
     if (PyCallable_Check(value.ptr()) == 1) {
         new_value = value(old_value ? old_value->nestify() : py::none{});
@@ -83,12 +83,19 @@ auto ConstStatsMap::contains(std::string_view name) const -> bool {
     return res;
 }
 auto ConstStatsMap::get(std::string_view name) const -> ConstStats {
-    if (contains(name)) {
-        uint64_t subkey = 0;
-        handle_error(clingo_stats_map_at(stats_, key_, name.data(), name.size(), &subkey));
-        return {stats_, subkey};
+    if (auto stats = try_get(name); stats) {
+        return *stats;
     }
     throw py::index_error{"invalid key"};
+}
+auto ConstStatsMap::try_get(std::string_view name) const -> std::optional<ConstStats> {
+    uint64_t subkey = 0;
+    handle_error(clingo_stats_map_try_at(stats_, key_, name.data(), name.size(), key_, &subkey));
+    std::optional<ConstStats> res;
+    if (subkey != key_) {
+        res.emplace(stats_, subkey);
+    }
+    return res;
 }
 auto ConstStatsMap::keys() const -> KeyIter {
     return {stats_, key_, len()};
@@ -102,7 +109,7 @@ auto StatsMap::get(std::string_view name) -> Stats {
 }
 
 void StatsMap::set(std::string_view name, py::handle value) {
-    auto old = contains(name) ? std::optional{get(name)} : std::nullopt;
+    auto old = try_get(name);
     auto [subtype, subval] = get_type(value, old);
     uint64_t subkey = 0;
     handle_error(clingo_stats_map_add_subkey(stats_, key_, name.data(), name.size(),

--- a/lib/python-api/src/stats.cc
+++ b/lib/python-api/src/stats.cc
@@ -31,24 +31,29 @@ auto get_type(py::handle value, std::optional<Stats> old_value) -> std::pair<Sta
 
 } // namespace
 
-auto StatsArray::get(size_t index) -> Stats {
-    uint64_t subkey = 0;
-    handle_error(clingo_stats_array_at(stats_, key_, index, &subkey));
-    return {stats_, subkey};
-}
-
-auto StatsArray::len() -> size_t {
+auto ConstStatsArray::len() const -> size_t {
     size_t size = 0;
     handle_error(clingo_stats_array_size(stats_, key_, &size));
     return size;
 }
+auto ConstStatsArray::get(size_t index) const -> ConstStats {
+    if (index < len()) {
+        uint64_t subkey = 0;
+        handle_error(clingo_stats_array_at(stats_, key_, index, &subkey));
+        return {stats_, subkey};
+    }
+    throw py::index_error{"array index out of bounds"};
+}
+ConstStatsArray::operator StatsArray() const {
+    return StatsArray{stats_, key_};
+}
+
+auto StatsArray::get(size_t index) -> Stats {
+    return static_cast<Stats>(ConstStatsArray::get(index));
+}
 
 void StatsArray::set(size_t index, py::handle value) {
-    if (index < len()) {
-        get(index).update_(value, false);
-    } else {
-        throw py::index_error{"array index out of bounds"};
-    }
+    get(index).update_(value, false);
 }
 
 void StatsArray::append(py::handle value) {
@@ -58,13 +63,26 @@ void StatsArray::append(py::handle value) {
     Stats{stats_, subkey}.update_(std::move(subval), true);
 }
 
-auto StatsMap::len() -> size_t {
+ConstStatsMap::KeyIter::KeyIter(clingo_stats_t *stats, uint64_t key, std::size_t len)
+    : stats_(stats), key_(key), pos_(0), end_(len) {
+}
+auto ConstStatsMap::KeyIter::operator*() const -> std::string_view {
+    clingo_string_t name;
+    handle_error(clingo_stats_map_subkey_name(stats_, key_, pos_, &name));
+    return {name.data, name.size};
+}
+
+auto ConstStatsMap::len() const -> size_t {
     size_t size = 0;
     handle_error(clingo_stats_map_size(stats_, key_, &size));
     return size;
 }
-
-auto StatsMap::get(std::string_view name) -> Stats {
+auto ConstStatsMap::contains(std::string_view name) const -> bool {
+    auto res = false;
+    handle_error(clingo_stats_map_has_subkey(stats_, key_, name.data(), name.size(), &res));
+    return res;
+}
+auto ConstStatsMap::get(std::string_view name) const -> ConstStats {
     if (contains(name)) {
         uint64_t subkey = 0;
         handle_error(clingo_stats_map_at(stats_, key_, name.data(), name.size(), &subkey));
@@ -72,11 +90,15 @@ auto StatsMap::get(std::string_view name) -> Stats {
     }
     throw py::index_error{"invalid key"};
 }
+auto ConstStatsMap::keys() const -> KeyIter {
+    return {stats_, key_, len()};
+}
+ConstStatsMap::operator StatsMap() const {
+    return StatsMap{stats_, key_};
+}
 
-auto StatsMap::contains(std::string_view name) -> bool {
-    auto res = false;
-    handle_error(clingo_stats_map_has_subkey(stats_, key_, name.data(), name.size(), &res));
-    return res;
+auto StatsMap::get(std::string_view name) -> Stats {
+    return static_cast<Stats>(ConstStatsMap::get(name));
 }
 
 void StatsMap::set(std::string_view name, py::handle value) {
@@ -88,27 +110,24 @@ void StatsMap::set(std::string_view name, py::handle value) {
     Stats{stats_, subkey}.update_(std::move(subval), !old.has_value());
 }
 
-auto Stats::type() -> StatsType {
+auto ConstStats::type() const -> StatsType {
     clingo_stats_type_t type = 0;
     handle_error(clingo_stats_type(stats_, key_, &type));
     return static_cast<StatsType>(type);
 }
-
-auto Stats::array() -> StatsArray {
+auto ConstStats::array() const -> ConstStatsArray {
     if (type() == StatsType::array) {
         return {stats_, key_};
     }
     throw py::type_error{"not an array"};
 }
-
-auto Stats::map() -> StatsMap {
+auto ConstStats::map() const -> ConstStatsMap {
     if (type() == StatsType::map) {
         return {stats_, key_};
     }
     throw py::type_error{"not a map"};
 }
-
-auto Stats::get_value() -> double {
+auto ConstStats::get_value() const -> double {
     if (type() == StatsType::value) {
         double value = 0;
         handle_error(clingo_stats_value_get(stats_, key_, &value));
@@ -116,30 +135,42 @@ auto Stats::get_value() -> double {
     }
     throw py::type_error{"not a value"};
 }
-
-void Stats::set_value(double value) {
-    if (type() == StatsType::value) {
-        handle_error(clingo_stats_value_set(stats_, key_, value));
-    } else {
-        throw py::type_error{"not a value"};
-    }
-}
-
-auto Stats::str() -> std::string_view {
+auto ConstStats::str() const -> std::string_view {
     auto *bld = string_builder();
     handle_error(clingo_stats_to_string(stats_, key_, bld));
     clingo_string_t res;
     handle_error(clingo_string_builder_string(bld, &res));
     return {res.data, res.size};
 }
-
-auto Stats::nestify() -> py::object {
+auto ConstStats::get(std::size_t key) const -> ConstStats {
+    return array().get(key);
+}
+auto ConstStats::at(std::string_view key) const -> ConstStats {
+    return map().get(key);
+}
+auto ConstStats::len() const -> size_t {
+    switch (type()) {
+        case StatsType::array:
+            return ConstStatsArray{stats_, key_}.len();
+        case StatsType::map:
+            return ConstStatsMap{stats_, key_}.len();
+        default:
+            return 0;
+    }
+}
+auto ConstStats::contains(std::string_view key) const -> bool {
+    return map().contains(key);
+}
+ConstStats::operator Stats() const {
+    return Stats{stats_, key_};
+}
+auto ConstStats::nestify() const -> py::object {
     switch (type()) {
         case StatsType::value: {
             return py::float_{get_value()};
         }
         case StatsType::array: {
-            auto x = array();
+            auto x = ConstStatsArray{stats_, key_};
             auto n = x.len();
             auto res = py::list{n};
             for (size_t i = 0; i < n; ++i) {
@@ -148,18 +179,24 @@ auto Stats::nestify() -> py::object {
             return res;
         }
         case StatsType::map: {
-            auto x = map();
-            auto n = x.len();
+            auto x = ConstStatsMap{stats_, key_};
             auto res = py::dict{};
-            for (size_t i = 0; i < n; ++i) {
-                clingo_string_t name;
-                handle_error(clingo_stats_map_subkey_name(stats_, key_, i, &name));
-                res[py::str{name.data, name.size}] = x.get(std::string_view{name.data, name.size}).nestify();
+            for (auto k = x.keys(); k != std::default_sentinel; ++k) {
+                auto name = *k;
+                res[py::str{name}] = x.get(name).nestify();
             }
             return res;
         }
     }
     unreachable();
+}
+
+void Stats::set_value(double value) {
+    if (type() == StatsType::value) {
+        handle_error(clingo_stats_value_set(c_ptr(), key(), value));
+    } else {
+        throw py::type_error{"not a value"};
+    }
 }
 
 void Stats::update_(py::handle value, bool init) {
@@ -196,6 +233,18 @@ void Stats::update_(py::handle value, bool init) {
             break;
         }
     }
+}
+auto Stats::array() const -> StatsArray {
+    return static_cast<StatsArray>(ConstStats::array());
+}
+auto Stats::map() const -> StatsMap {
+    return static_cast<StatsMap>(ConstStats::map());
+}
+auto Stats::get(std::size_t key) -> Stats {
+    return static_cast<Stats>(ConstStats::get(key));
+}
+auto Stats::at(std::string_view key) -> Stats {
+    return static_cast<Stats>(ConstStats::at(key));
 }
 
 void register_stats(pybind11::module &m) {
@@ -244,9 +293,41 @@ option only basic stats are reported.
         .value("Value", StatsType::value, R"(Indicate a value of stats.)")
         .finalize();
 
-    auto stats = py::class_<Stats>(module, "Stats", R"(Class representing solver stats.)");
+    auto stats_view =
+        py::class_<ConstStats>(module, "StatsView", R"(Class representing read-only solver stats.)")
+            .def("__str__", &ConstStats::str, R"(A readable representation to inspect the statistics.)")
+            .def("__getitem__", &ConstStats::get, "Get the element at the given index.")
+            .def("__getitem__", &ConstStats::at, py::arg("key"), "Lookup the value with the given key.")
+            .def("__len__", &ConstStats::len, "Get the length of this element.")
+            .def("__contains__", &ConstStats::contains,
+                 "Checks whether the given key is in the element, which must be a map.")
+            .def("__float__", &ConstStats::get_value, "Get the value of the element.")
+            .def("__eq__",
+                 [](const ConstStats &lhs, const py::object &rhs) {
+                     if (!py::isinstance<ConstStats>(rhs)) {
+                         return lhs.nestify().equal(rhs);
+                     }
+                     return lhs == rhs.cast<ConstStats>();
+                 })
+            .def("nestify", &ConstStats::nestify, R"(
+Convert the statistics object into a nested structure consisting of sequencens,
+mappings with string keys, and floats.
+)"_d)
+            .def_property_readonly("type", &ConstStats::type, R"(Get the type of the stats object.)")
+            .def_property_readonly("array", &ConstStats::array, R"(Get an array of stats objects.)")
+            .def_property_readonly("map", &ConstStats::map, R"(Get a map of stats objects.)")
+            .def_property_readonly("value", &ConstStats::get_value, R"(Get the value of the stats object.)");
+    auto stats = py::class_<Stats, ConstStats>(module, "Stats", R"(Class representing solver stats.)");
 
-    py::class_<StatsArray>(module, "StatsArray", R"(
+    py::class_<ConstStatsArray>(module, "StatsArrayView", R"(
+Class representing a read-only array of stats.
+
+This class partially implements the mutable sequence protocol.
+)"_d)
+        .def("__len__", &ConstStatsArray::len, "Get the length of the array.")
+        .def("__getitem__", &ConstStatsArray::get, "Get the element at the given index.");
+
+    py::class_<StatsArray, ConstStatsArray>(module, "StatsArray", R"(
 Class representing an array of stats.
 
 This class partially implements the mutable sequence protocol - elements of
@@ -256,7 +337,6 @@ implemented via `Stats.update`.
 Most use cases should be implementable just using the update function of the
 top-level statistics object.
 )"_d)
-        .def("__len__", &StatsArray::len, "Get the length of the array.")
         .def("__setitem__", &StatsArray::set, "Set the element at the given index to the given value.")
         .def("__getitem__", &StatsArray::get, "Get the element at the given index.")
         .def("append", &StatsArray::append, py::arg("value"), R"(
@@ -266,7 +346,18 @@ Args:
 	value: The value to append.
 )"_d);
 
-    py::class_<StatsMap>(module, "StatsMap", R"(
+    py::class_<ConstStatsMap>(module, "StatsMapView", R"(
+Class representing a read-only map of stats.
+
+This class partially implements the mutable mapping protocol.
+)"_d)
+        .def("__len__", &ConstStatsMap::len, "Get the length of the map.")
+        .def(
+            "__iter__", [](const ConstStatsMap &map) { return py::make_iterator(map.keys(), std::default_sentinel); },
+            "Get an iterator over the keys of the map.")
+        .def("__getitem__", &ConstStatsMap::get, py::arg("key"), "Lookup the value with the given key.");
+
+    py::class_<StatsMap, ConstStatsMap>(module, "StatsMap", R"(
 Class representing a map of stats.
 
 This class partially implements the mutable mapping protocol - value of keys
@@ -276,15 +367,10 @@ can be modified but they cannot be deleted. Modifications are implemented via
 Most use cases should be implementable just using the update function of the
 top-level statistics object.
 )"_d)
-        .def("__len__", &StatsMap::len, "Get the length of the map.")
         .def("__setitem__", &StatsMap::set, py::arg("key"), py::arg("value"), "Set the value at the given key.")
         .def("__getitem__", &StatsMap::get, py::arg("key"), "Lookup the value with the given key.");
 
     stats
-        .def("nestify", &Stats::nestify, R"(
-Convert the statistics object into a nested structure consisting of sequencens,
-mappings with string keys, and floats.
-)"_d)
         .def("update", &Stats::update, py::arg("values"), R"(
 Update the statistics with the given values.
 
@@ -298,8 +384,8 @@ Args:
         return an updated value. If there is no previous value, `None` is
         passed as argument.
 )"_d)
-        .def("__str__", &Stats::str, R"(A readable representation to inspect the statistics.)")
-        .def_property_readonly("type", &Stats::type, R"(Get the type of the stats object.)")
+        .def("__getitem__", &Stats::get, "Get the element at the given index.")
+        .def("__getitem__", &Stats::at, py::arg("key"), "Lookup the value with the given key.")
         .def_property_readonly("array", &Stats::array, R"(Get an array of stats objects.)")
         .def_property_readonly("map", &Stats::map, R"(Get a map of stats objects.)")
         .def_property("value", &Stats::get_value, &Stats::set_value, R"(Get/set the value of the stats object.)");

--- a/lib/python-api/src/stats.cc
+++ b/lib/python-api/src/stats.cc
@@ -97,7 +97,7 @@ auto ConstStatsArray::get(size_t index) const -> ConstStats {
     throw py::index_error{"array index out of bounds"};
 }
 
-auto ConstStatsArray::items() const -> py::iterator {
+auto ConstStatsArray::items() const -> TypeHint<"Iterator[StatsView]"> {
     return make_py_iter<&StatsIterBase::array_item>(stats_, key_, len());
 }
 
@@ -149,15 +149,15 @@ auto ConstStatsMap::try_get(std::string_view name) const -> std::optional<ConstS
     return res;
 }
 
-auto ConstStatsMap::keys() const -> py::iterator {
+auto ConstStatsMap::keys() const -> TypeHint<"Iterator[str]"> {
     return make_py_iter<&StatsIterBase::map_key>(stats_, key_, len());
 }
 
-auto ConstStatsMap::values() const -> py::iterator {
+auto ConstStatsMap::values() const -> TypeHint<"Iterator[StatsView]"> {
     return make_py_iter<&StatsIterBase::map_value>(stats_, key_, len());
 }
 
-auto ConstStatsMap::items() const -> py::iterator {
+auto ConstStatsMap::items() const -> TypeHint<"Iterator[tuple[str,StatsView]]"> {
     return make_py_iter<&StatsIterBase::map_item>(stats_, key_, len());
 }
 
@@ -270,7 +270,7 @@ auto ConstStats::nestify() const -> py::object {
     unreachable();
 }
 
-auto ConstStats::iter() const -> py::iterator {
+auto ConstStats::iter() const -> TypeHint<"Iterator[str|StatsView]"> {
     switch (type()) {
         case StatsType::map:
             return map().keys();

--- a/lib/python-api/src/stats.cc
+++ b/lib/python-api/src/stats.cc
@@ -81,11 +81,13 @@ auto get_type(py::handle value, std::optional<ConstStats> old_value) -> std::pai
 }
 
 } // namespace
+
 auto ConstStatsArray::len() const -> size_t {
     size_t size = 0;
     handle_error(clingo_stats_array_size(stats_, key_, &size));
     return size;
 }
+
 auto ConstStatsArray::get(size_t index) const -> ConstStats {
     if (index < len()) {
         uint64_t subkey = 0;
@@ -94,9 +96,11 @@ auto ConstStatsArray::get(size_t index) const -> ConstStats {
     }
     throw py::index_error{"array index out of bounds"};
 }
+
 auto ConstStatsArray::items() const -> py::iterator {
     return make_py_iter<&StatsIterBase::array_item>(stats_, key_, len());
 }
+
 ConstStatsArray::operator StatsArray() const {
     return StatsArray{stats_, key_};
 }
@@ -121,17 +125,20 @@ auto ConstStatsMap::len() const -> size_t {
     handle_error(clingo_stats_map_size(stats_, key_, &size));
     return size;
 }
+
 auto ConstStatsMap::contains(std::string_view name) const -> bool {
     auto res = false;
     handle_error(clingo_stats_map_has_subkey(stats_, key_, name.data(), name.size(), &res));
     return res;
 }
+
 auto ConstStatsMap::get(std::string_view name) const -> ConstStats {
     if (auto stats = try_get(name); stats) {
         return *stats;
     }
     throw py::index_error{"invalid key"};
 }
+
 auto ConstStatsMap::try_get(std::string_view name) const -> std::optional<ConstStats> {
     uint64_t subkey = 0;
     handle_error(clingo_stats_map_try_at(stats_, key_, name.data(), name.size(), key_, &subkey));
@@ -141,15 +148,19 @@ auto ConstStatsMap::try_get(std::string_view name) const -> std::optional<ConstS
     }
     return res;
 }
+
 auto ConstStatsMap::keys() const -> py::iterator {
     return make_py_iter<&StatsIterBase::map_key>(stats_, key_, len());
 }
+
 auto ConstStatsMap::values() const -> py::iterator {
     return make_py_iter<&StatsIterBase::map_value>(stats_, key_, len());
 }
+
 auto ConstStatsMap::items() const -> py::iterator {
     return make_py_iter<&StatsIterBase::map_item>(stats_, key_, len());
 }
+
 ConstStatsMap::operator StatsMap() const {
     return StatsMap{stats_, key_};
 }
@@ -172,18 +183,21 @@ auto ConstStats::type() const -> StatsType {
     handle_error(clingo_stats_type(stats_, key_, &type));
     return static_cast<StatsType>(type);
 }
+
 auto ConstStats::array() const -> ConstStatsArray {
     if (type() == StatsType::array) {
         return {stats_, key_};
     }
     throw py::type_error{"not an array"};
 }
+
 auto ConstStats::map() const -> ConstStatsMap {
     if (type() == StatsType::map) {
         return {stats_, key_};
     }
     throw py::type_error{"not a map"};
 }
+
 auto ConstStats::get_value() const -> double {
     if (type() == StatsType::value) {
         double value = 0;
@@ -192,6 +206,7 @@ auto ConstStats::get_value() const -> double {
     }
     throw py::type_error{"not a value"};
 }
+
 auto ConstStats::str() const -> std::string_view {
     auto *bld = string_builder();
     handle_error(clingo_stats_to_string(stats_, key_, bld));
@@ -199,12 +214,15 @@ auto ConstStats::str() const -> std::string_view {
     handle_error(clingo_string_builder_string(bld, &res));
     return {res.data, res.size};
 }
+
 auto ConstStats::get(std::size_t key) const -> ConstStats {
     return array().get(key);
 }
+
 auto ConstStats::at(std::string_view key) const -> ConstStats {
     return map().get(key);
 }
+
 auto ConstStats::len() const -> size_t {
     switch (type()) {
         case StatsType::array:
@@ -215,12 +233,15 @@ auto ConstStats::len() const -> size_t {
             return 0;
     }
 }
+
 auto ConstStats::contains(std::string_view key) const -> bool {
     return map().contains(key);
 }
+
 ConstStats::operator Stats() const {
     return Stats{stats_, key_};
 }
+
 auto ConstStats::nestify() const -> py::object {
     switch (type()) {
         case StatsType::value: {
@@ -248,6 +269,7 @@ auto ConstStats::nestify() const -> py::object {
     }
     unreachable();
 }
+
 auto ConstStats::iter() const -> py::iterator {
     switch (type()) {
         case StatsType::map:
@@ -303,15 +325,19 @@ void Stats::update_(py::handle value, bool init) {
         }
     }
 }
+
 auto Stats::array() -> StatsArray {
     return static_cast<StatsArray>(ConstStats::array());
 }
+
 auto Stats::map() -> StatsMap {
     return static_cast<StatsMap>(ConstStats::map());
 }
+
 auto Stats::get(std::size_t key) -> Stats {
     return static_cast<Stats>(ConstStats::get(key));
 }
+
 auto Stats::at(std::string_view key) -> Stats {
     return static_cast<Stats>(ConstStats::at(key));
 }
@@ -356,49 +382,20 @@ Note that the control object is created passing options `--stats`; without this
 option only basic stats are reported.
 )"_d);
 
-    py::native_enum<StatsType>(module, "StatsType", "enum.IntEnum", "The type of a stats object.")
+    py::native_enum<StatsType>{module, "StatsType", "enum.IntEnum", "The type of a stats object."}
         .value("Map", StatsType::map, R"(Indicate a map of stats.)")
         .value("Array", StatsType::array, R"(Indicate an array of stats.)")
         .value("Value", StatsType::value, R"(Indicate a value of stats.)")
         .finalize();
 
-    auto stats_view =
-        py::class_<ConstStats>(module, "StatsView", R"(Class representing read-only solver stats.)")
-            .def("__str__", &ConstStats::str, R"(A readable representation to inspect the statistics.)")
-            .def("__getitem__", &ConstStats::get, "Get the element at the given index.")
-            .def("__getitem__", &ConstStats::at, py::arg("key"), "Lookup the value with the given key.")
-            .def("__len__", &ConstStats::len, "Get the length of this element.")
-            .def("__contains__", &ConstStats::contains,
-                 "Checks whether the given key is in the element, which must be a map.")
-            .def("__iter__", &ConstStats::iter, "Get an iterator over the keys of the map.")
-            .def("__float__", &ConstStats::get_value, "Get the value of the element.")
-            .def("__eq__",
-                 [](const ConstStats &lhs, const py::object &rhs) {
-                     if (!py::isinstance<ConstStats>(rhs)) {
-                         return lhs.nestify().equal(rhs);
-                     }
-                     return lhs == rhs.cast<ConstStats>();
-                 })
-            .def("nestify", &ConstStats::nestify, R"(
-Convert the statistics object into a nested structure consisting of sequencens,
-mappings with string keys, and floats.
-)"_d)
-            .def_property_readonly("type", &ConstStats::type, R"(Get the type of the stats object.)")
-            .def_property_readonly("array", &ConstStats::array, R"(Get an array of stats objects.)")
-            .def_property_readonly("map", &ConstStats::map, R"(Get a map of stats objects.)")
-            .def_property_readonly("value", &ConstStats::get_value, R"(Get the value of the stats object.)");
-    auto stats = py::class_<Stats, ConstStats>(module, "Stats", R"(Class representing solver stats.)");
-
-    py::class_<ConstStatsArray>(module, "StatsArrayView", R"(
+    auto stats_view = py::class_<ConstStats>{module, "StatsView", R"(Class representing read-only solver stats.)"};
+    auto stats = py::class_<Stats, ConstStats>{module, "Stats", R"(Class representing solver stats.)"};
+    auto stats_array_view = py::class_<ConstStatsArray>{module, "StatsArrayView", R"(
 Class representing a read-only array of stats.
 
 This class partially implements the mutable sequence protocol.
-)"_d)
-        .def("__len__", &ConstStatsArray::len, "Get the length of the array.")
-        .def("__iter__", &ConstStatsArray::items, "Get an iterator over the elements of the array.")
-        .def("__getitem__", &ConstStatsArray::get, "Get the element at the given index.");
-
-    py::class_<StatsArray, ConstStatsArray>(module, "StatsArray", R"(
+)"_d};
+    auto stats_array = py::class_<StatsArray, ConstStatsArray>{module, "StatsArray", R"(
 Class representing an array of stats.
 
 This class partially implements the mutable sequence protocol - elements of
@@ -407,7 +404,54 @@ implemented via `Stats.update`.
 
 Most use cases should be implementable just using the update function of the
 top-level statistics object.
+)"_d};
+    auto stats_map_view = py::class_<ConstStatsMap>{module, "StatsMapView", R"(
+Class representing a read-only map of stats.
+
+This class partially implements the mutable mapping protocol.
+)"_d};
+    auto stats_map = py::class_<StatsMap, ConstStatsMap>{module, "StatsMap", R"(
+Class representing a map of stats.
+
+This class partially implements the mutable mapping protocol - value of keys
+can be modified but they cannot be deleted. Modifications are implemented via
+`Stats.update`.
+
+Most use cases should be implementable just using the update function of the
+top-level statistics object.
+)"_d};
+
+    stats_view //
+        .def("__str__", &ConstStats::str, R"(A readable representation to inspect the statistics.)")
+        .def("__getitem__", &ConstStats::get, "Get the element at the given index.")
+        .def("__getitem__", &ConstStats::at, py::arg("key"), "Lookup the value with the given key.")
+        .def("__len__", &ConstStats::len, "Get the length of this element.")
+        .def("__contains__", &ConstStats::contains,
+             "Checks whether the given key is in the element, which must be a map.")
+        .def("__iter__", &ConstStats::iter, "Get an iterator over the keys of the map.")
+        .def("__float__", &ConstStats::get_value, "Get the value of the element.")
+        .def("__eq__",
+             [](const ConstStats &lhs, const py::object &rhs) {
+                 if (!py::isinstance<ConstStats>(rhs)) {
+                     return lhs.nestify().equal(rhs);
+                 }
+                 return lhs == rhs.cast<ConstStats>();
+             })
+        .def("nestify", &ConstStats::nestify, R"(
+Convert the statistics object into a nested structure consisting of sequencens,
+mappings with string keys, and floats.
 )"_d)
+        .def_property_readonly("type", &ConstStats::type, R"(Get the type of the stats object.)")
+        .def_property_readonly("array", &ConstStats::array, R"(Get an array of stats objects.)")
+        .def_property_readonly("map", &ConstStats::map, R"(Get a map of stats objects.)")
+        .def_property_readonly("value", &ConstStats::get_value, R"(Get the value of the stats object.)");
+
+    stats_array_view //
+        .def("__len__", &ConstStatsArray::len, "Get the length of the array.")
+        .def("__iter__", &ConstStatsArray::items, "Get an iterator over the elements of the array.")
+        .def("__getitem__", &ConstStatsArray::get, "Get the element at the given index.");
+
+    stats_array //
         .def("__setitem__", &StatsArray::set, "Set the element at the given index to the given value.")
         .def("__getitem__", &StatsArray::get, "Get the element at the given index.")
         .def("append", &StatsArray::append, py::arg("value"), R"(
@@ -417,11 +461,7 @@ Args:
 	value: The value to append.
 )"_d);
 
-    py::class_<ConstStatsMap>(module, "StatsMapView", R"(
-Class representing a read-only map of stats.
-
-This class partially implements the mutable mapping protocol.
-)"_d)
+    stats_map_view //
         .def("__len__", &ConstStatsMap::len, "Get the length of the map.")
         .def("__iter__", &ConstStatsMap::keys, "Get an iterator over the keys of the map.")
         .def("keys", &ConstStatsMap::keys, "Get an iterator over the keys of the map.")
@@ -429,20 +469,11 @@ This class partially implements the mutable mapping protocol.
         .def("items", &ConstStatsMap::items, "Get an iterator over the items of the map.")
         .def("__getitem__", &ConstStatsMap::get, py::arg("key"), "Lookup the value with the given key.");
 
-    py::class_<StatsMap, ConstStatsMap>(module, "StatsMap", R"(
-Class representing a map of stats.
-
-This class partially implements the mutable mapping protocol - value of keys
-can be modified but they cannot be deleted. Modifications are implemented via
-`Stats.update`.
-
-Most use cases should be implementable just using the update function of the
-top-level statistics object.
-)"_d)
+    stats_map //
         .def("__setitem__", &StatsMap::set, py::arg("key"), py::arg("value"), "Set the value at the given key.")
         .def("__getitem__", &StatsMap::get, py::arg("key"), "Lookup the value with the given key.");
 
-    stats
+    stats //
         .def("update", &Stats::update, py::arg("values"), R"(
 Update the statistics with the given values.
 

--- a/lib/python-api/src/stats.hh
+++ b/lib/python-api/src/stats.hh
@@ -15,51 +15,112 @@ enum class StatsType : uint8_t {
 };
 
 class Stats;
+class ConstStats;
 
-class StatsArray {
+class StatsArray;
+class ConstStatsArray {
   public:
-    StatsArray(clingo_stats_t *stats, uint64_t key) : stats_{stats}, key_{key} {}
+    ConstStatsArray(clingo_stats_t *stats, uint64_t key) : stats_{stats}, key_{key} {}
+    [[nodiscard]] auto get(size_t index) const -> ConstStats;
+    [[nodiscard]] auto len() const -> size_t;
+    explicit operator StatsArray() const;
+
+  private:
+    friend class StatsArray;
+    clingo_stats_t *stats_;
+    uint64_t key_;
+};
+
+class StatsArray : public ConstStatsArray {
+  public:
+    using ConstStatsArray::ConstStatsArray;
     void set(size_t index, py::handle value);
     auto get(size_t index) -> Stats;
     void append(py::handle value);
-    auto len() -> size_t;
+};
+
+class StatsMap;
+class ConstStatsMap {
+  public:
+    class KeyIter {
+      public:
+        KeyIter(clingo_stats_t *stats, uint64_t key, std::size_t len);
+        bool operator==(const KeyIter &) const = default;
+        friend bool operator==(const KeyIter &iter, std::default_sentinel_t) { return iter.pos_ == iter.end_; }
+        auto operator*() const -> std::string_view;
+        auto operator++() -> KeyIter & {
+            ++pos_;
+            return *this;
+        }
+        auto operator++(int) -> KeyIter {
+            KeyIter t(*this);
+            ++*this;
+            return t;
+        }
+
+      private:
+        clingo_stats_t *stats_;
+        uint64_t key_;
+        std::size_t pos_;
+        std::size_t end_;
+    };
+    ConstStatsMap(clingo_stats_t *stats, uint64_t key) : stats_{stats}, key_{key} {}
+    [[nodiscard]] auto get(std::string_view name) const -> ConstStats;
+    [[nodiscard]] auto len() const -> size_t;
+    [[nodiscard]] auto contains(std::string_view name) const -> bool;
+    [[nodiscard]] auto keys() const -> KeyIter;
+
+    explicit operator StatsMap() const;
 
   private:
+    friend class StatsMap;
     clingo_stats_t *stats_;
     uint64_t key_;
 };
 
-class StatsMap {
+class StatsMap : public ConstStatsMap {
   public:
-    StatsMap(clingo_stats_t *stats, uint64_t key) : stats_{stats}, key_{key} {}
+    using ConstStatsMap::ConstStatsMap;
     auto get(std::string_view name) -> Stats;
     void set(std::string_view name, py::handle value);
-    auto len() -> size_t;
-    auto contains(std::string_view name) -> bool;
+};
+
+class ConstStats {
+  public:
+    ConstStats(clingo_stats_t *stats, uint64_t key) : stats_{stats}, key_{key} {}
+
+    [[nodiscard]] auto type() const -> StatsType;
+    [[nodiscard]] auto array() const -> ConstStatsArray;
+    [[nodiscard]] auto map() const -> ConstStatsMap;
+    [[nodiscard]] auto get_value() const -> double;
+    [[nodiscard]] auto str() const -> std::string_view;
+    [[nodiscard]] auto c_ptr() const -> clingo_stats_t * { return stats_; }
+    [[nodiscard]] auto key() const -> uint64_t { return key_; }
+    [[nodiscard]] auto nestify() const -> py::object;
+
+    [[nodiscard]] auto get(std::size_t key) const -> ConstStats;
+    [[nodiscard]] auto at(std::string_view key) const -> ConstStats;
+    [[nodiscard]] auto len() const -> size_t;
+    [[nodiscard]] auto contains(std::string_view key) const -> bool;
+
+    explicit operator Stats() const;
+    [[nodiscard]] bool operator==(const ConstStats &) const = default;
+    [[nodiscard]] bool operator!=(const ConstStats &) const = default;
 
   private:
     clingo_stats_t *stats_;
     uint64_t key_;
 };
-
-class Stats {
+class Stats : public ConstStats {
   public:
-    Stats(clingo_stats_t *stats, uint64_t key) : stats_{stats}, key_{key} {}
-
-    auto type() -> StatsType;
-    auto array() -> StatsArray;
-    auto map() -> StatsMap;
-    auto get_value() -> double;
+    using ConstStats::ConstStats;
+    auto array() const -> StatsArray;
+    auto map() const -> StatsMap;
+    auto get(std::size_t key) -> Stats;
+    auto at(std::string_view key) -> Stats;
     void set_value(double value);
-    auto nestify() -> py::object;
     void update(py::handle value) { update_(value, false); }
     void update_(py::handle value, bool init);
-    auto str() -> std::string_view;
-    auto c_ptr() -> clingo_stats_t * { return stats_; }
-
-  private:
-    clingo_stats_t *stats_;
-    uint64_t key_;
 };
 
 void register_stats(pybind11::module &m);

--- a/lib/python-api/src/stats.hh
+++ b/lib/python-api/src/stats.hh
@@ -16,13 +16,14 @@ enum class StatsType : uint8_t {
 
 class Stats;
 class ConstStats;
-
 class StatsArray;
+
 class ConstStatsArray {
   public:
     ConstStatsArray(clingo_stats_t *stats, uint64_t key) : stats_{stats}, key_{key} {}
     [[nodiscard]] auto get(size_t index) const -> ConstStats;
     [[nodiscard]] auto len() const -> size_t;
+    [[nodiscard]] auto items() const -> py::iterator;
     explicit operator StatsArray() const;
 
   private:
@@ -42,38 +43,18 @@ class StatsArray : public ConstStatsArray {
 class StatsMap;
 class ConstStatsMap {
   public:
-    class KeyIter {
-      public:
-        KeyIter(clingo_stats_t *stats, uint64_t key, std::size_t len);
-        bool operator==(const KeyIter &) const = default;
-        friend bool operator==(const KeyIter &iter, std::default_sentinel_t) { return iter.pos_ == iter.end_; }
-        auto operator*() const -> std::string_view;
-        auto operator++() -> KeyIter & {
-            ++pos_;
-            return *this;
-        }
-        auto operator++(int) -> KeyIter {
-            KeyIter t(*this);
-            ++*this;
-            return t;
-        }
-
-      private:
-        clingo_stats_t *stats_;
-        uint64_t key_;
-        std::size_t pos_;
-        std::size_t end_;
-    };
     ConstStatsMap(clingo_stats_t *stats, uint64_t key) : stats_{stats}, key_{key} {}
     [[nodiscard]] auto get(std::string_view name) const -> ConstStats;
     [[nodiscard]] auto len() const -> size_t;
     [[nodiscard]] auto contains(std::string_view name) const -> bool;
-    [[nodiscard]] auto keys() const -> KeyIter;
+    [[nodiscard]] auto keys() const -> py::iterator;
+    [[nodiscard]] auto values() const -> py::iterator;
+    [[nodiscard]] auto items() const -> py::iterator;
 
     explicit operator StatsMap() const;
 
   private:
-    auto try_get(std::string_view name) const -> std::optional<ConstStats>;
+    [[nodiscard]] auto try_get(std::string_view name) const -> std::optional<ConstStats>;
     friend class StatsMap;
     clingo_stats_t *stats_;
     uint64_t key_;
@@ -98,6 +79,7 @@ class ConstStats {
     [[nodiscard]] auto c_ptr() const -> clingo_stats_t * { return stats_; }
     [[nodiscard]] auto key() const -> uint64_t { return key_; }
     [[nodiscard]] auto nestify() const -> py::object;
+    [[nodiscard]] auto iter() const -> py::iterator;
 
     [[nodiscard]] auto get(std::size_t key) const -> ConstStats;
     [[nodiscard]] auto at(std::string_view key) const -> ConstStats;
@@ -105,8 +87,8 @@ class ConstStats {
     [[nodiscard]] auto contains(std::string_view key) const -> bool;
 
     explicit operator Stats() const;
-    [[nodiscard]] bool operator==(const ConstStats &) const = default;
-    [[nodiscard]] bool operator!=(const ConstStats &) const = default;
+    [[nodiscard]] auto operator==(const ConstStats &) const -> bool = default;
+    [[nodiscard]] auto operator!=(const ConstStats &) const -> bool = default;
 
   private:
     clingo_stats_t *stats_;
@@ -115,8 +97,8 @@ class ConstStats {
 class Stats : public ConstStats {
   public:
     using ConstStats::ConstStats;
-    auto array() const -> StatsArray;
-    auto map() const -> StatsMap;
+    auto array() -> StatsArray;
+    auto map() -> StatsMap;
     auto get(std::size_t key) -> Stats;
     auto at(std::string_view key) -> Stats;
     void set_value(double value);

--- a/lib/python-api/src/stats.hh
+++ b/lib/python-api/src/stats.hh
@@ -73,6 +73,7 @@ class ConstStatsMap {
     explicit operator StatsMap() const;
 
   private:
+    auto try_get(std::string_view name) const -> std::optional<ConstStats>;
     friend class StatsMap;
     clingo_stats_t *stats_;
     uint64_t key_;

--- a/lib/python-api/src/stats.hh
+++ b/lib/python-api/src/stats.hh
@@ -2,6 +2,8 @@
 
 #include "clingo/stats.h"
 
+#include "iterable.hh"
+
 #include <pybind11/pybind11.h>
 
 namespace PyClingo {
@@ -23,7 +25,7 @@ class ConstStatsArray {
     ConstStatsArray(clingo_stats_t *stats, uint64_t key) : stats_{stats}, key_{key} {}
     [[nodiscard]] auto get(size_t index) const -> ConstStats;
     [[nodiscard]] auto len() const -> size_t;
-    [[nodiscard]] auto items() const -> py::iterator;
+    [[nodiscard]] auto items() const -> TypeHint<"Iterator[StatsView]">;
     explicit operator StatsArray() const;
 
   private:
@@ -47,9 +49,9 @@ class ConstStatsMap {
     [[nodiscard]] auto get(std::string_view name) const -> ConstStats;
     [[nodiscard]] auto len() const -> size_t;
     [[nodiscard]] auto contains(std::string_view name) const -> bool;
-    [[nodiscard]] auto keys() const -> py::iterator;
-    [[nodiscard]] auto values() const -> py::iterator;
-    [[nodiscard]] auto items() const -> py::iterator;
+    [[nodiscard]] auto keys() const -> TypeHint<"Iterator[str]">;
+    [[nodiscard]] auto values() const -> TypeHint<"Iterator[StatsView]">;
+    [[nodiscard]] auto items() const -> TypeHint<"Iterator[tuple[str,StatsView]]">;
 
     explicit operator StatsMap() const;
 
@@ -79,7 +81,7 @@ class ConstStats {
     [[nodiscard]] auto c_ptr() const -> clingo_stats_t * { return stats_; }
     [[nodiscard]] auto key() const -> uint64_t { return key_; }
     [[nodiscard]] auto nestify() const -> py::object;
-    [[nodiscard]] auto iter() const -> py::iterator;
+    [[nodiscard]] auto iter() const -> TypeHint<"Iterator[str|StatsView]">;
 
     [[nodiscard]] auto get(std::size_t key) const -> ConstStats;
     [[nodiscard]] auto at(std::string_view key) const -> ConstStats;

--- a/lib/python-api/stubs/control.pyi
+++ b/lib/python-api/stubs/control.pyi
@@ -403,7 +403,7 @@ class Control:
         """
 
     @property
-    def stats(self) -> dict:
+    def stats(self) -> clingo.stats.StatsView:
         """
         Get the solver stats.
         """

--- a/lib/python-api/stubs/stats.pyi
+++ b/lib/python-api/stubs/stats.pyi
@@ -39,10 +39,19 @@ option only basic stats are reported.
 
 from __future__ import annotations
 
+import collections.abc
 import enum
 import typing
 
-__all__ = ["Stats", "StatsArray", "StatsMap", "StatsType"]
+__all__ = [
+    "Stats",
+    "StatsArray",
+    "StatsArrayView",
+    "StatsMap",
+    "StatsMapView",
+    "StatsType",
+    "StatsView",
+]
 
 class StatsType(enum.IntEnum):
     """
@@ -59,13 +68,47 @@ class StatsType(enum.IntEnum):
         Convert to a string according to format_spec.
         """
 
-class Stats:
+class StatsView:
     """
-    Class representing solver stats.
+    Class representing read-only solver stats.
     """
 
+    __hash__: typing.ClassVar[None] = None
     @staticmethod
     def _pybind11_conduit_v1_(*args, **kwargs): ...
+    def __contains__(self, arg0: str) -> bool:
+        """
+        Checks whether the given key is in the element, which must be a map.
+        """
+
+    def __eq__(self, arg0: typing.Any) -> bool: ...
+    def __float__(self) -> float:
+        """
+        Get the value of the element.
+        """
+
+    @typing.overload
+    def __getitem__(self, arg0: int) -> StatsView:
+        """
+        Get the element at the given index.
+        """
+
+    @typing.overload
+    def __getitem__(self, key: str) -> StatsView:
+        """
+        Lookup the value with the given key.
+        """
+
+    def __iter__(self) -> collections.abc.Iterator:
+        """
+        Get an iterator over the keys of the map.
+        """
+
+    def __len__(self) -> int:
+        """
+        Get the length of this element.
+        """
+
     def __str__(self) -> str:
         """
         A readable representation to inspect the statistics.
@@ -75,6 +118,49 @@ class Stats:
         """
         Convert the statistics object into a nested structure consisting of sequencens,
         mappings with string keys, and floats.
+        """
+
+    @property
+    def array(self) -> StatsArrayView:
+        """
+        Get an array of stats objects.
+        """
+
+    @property
+    def map(self) -> StatsMapView:
+        """
+        Get a map of stats objects.
+        """
+
+    @property
+    def type(self) -> StatsType:
+        """
+        Get the type of the stats object.
+        """
+
+    @property
+    def value(self) -> float:
+        """
+        Get the value of the stats object.
+        """
+
+class Stats(StatsView):
+    """
+    Class representing solver stats.
+    """
+
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs): ...
+    @typing.overload
+    def __getitem__(self, arg0: int) -> Stats:
+        """
+        Get the element at the given index.
+        """
+
+    @typing.overload
+    def __getitem__(self, key: str) -> Stats:
+        """
+        Lookup the value with the given key.
         """
 
     def update(self, values: typing.Any) -> None:
@@ -105,12 +191,6 @@ class Stats:
         """
 
     @property
-    def type(self) -> StatsType:
-        """
-        Get the type of the stats object.
-        """
-
-    @property
     def value(self) -> float:
         """
         Get/set the value of the stats object.
@@ -119,7 +199,7 @@ class Stats:
     @value.setter
     def value(self, arg1: typing.SupportsFloat) -> None: ...
 
-class StatsArray:
+class StatsArray(StatsArrayView):
     """
     Class representing an array of stats.
 
@@ -138,11 +218,6 @@ class StatsArray:
         Get the element at the given index.
         """
 
-    def __len__(self) -> int:
-        """
-        Get the length of the array.
-        """
-
     def __setitem__(self, arg0: int, arg1: typing.Any) -> None:
         """
         Set the element at the given index to the given value.
@@ -156,7 +231,31 @@ class StatsArray:
                 value: The value to append.
         """
 
-class StatsMap:
+class StatsArrayView:
+    """
+    Class representing a read-only array of stats.
+
+    This class partially implements the mutable sequence protocol.
+    """
+
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs): ...
+    def __getitem__(self, arg0: int) -> StatsView:
+        """
+        Get the element at the given index.
+        """
+
+    def __iter__(self) -> collections.abc.Iterator:
+        """
+        Get an iterator over the elements of the array.
+        """
+
+    def __len__(self) -> int:
+        """
+        Get the length of the array.
+        """
+
+class StatsMap(StatsMapView):
     """
     Class representing a map of stats.
 
@@ -175,12 +274,46 @@ class StatsMap:
         Lookup the value with the given key.
         """
 
+    def __setitem__(self, key: str, value: typing.Any) -> None:
+        """
+        Set the value at the given key.
+        """
+
+class StatsMapView:
+    """
+    Class representing a read-only map of stats.
+
+    This class partially implements the mutable mapping protocol.
+    """
+
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs): ...
+    def __getitem__(self, key: str) -> StatsView:
+        """
+        Lookup the value with the given key.
+        """
+
+    def __iter__(self) -> collections.abc.Iterator:
+        """
+        Get an iterator over the keys of the map.
+        """
+
     def __len__(self) -> int:
         """
         Get the length of the map.
         """
 
-    def __setitem__(self, key: str, value: typing.Any) -> None:
+    def items(self) -> collections.abc.Iterator:
         """
-        Set the value at the given key.
+        Get an iterator over the items of the map.
+        """
+
+    def keys(self) -> collections.abc.Iterator:
+        """
+        Get an iterator over the keys of the map.
+        """
+
+    def values(self) -> collections.abc.Iterator:
+        """
+        Get an iterator over the values of the map.
         """

--- a/lib/python-api/stubs/stats.pyi
+++ b/lib/python-api/stubs/stats.pyi
@@ -73,7 +73,6 @@ class StatsView:
     Class representing read-only solver stats.
     """
 
-    __hash__: typing.ClassVar[None] = None
     @staticmethod
     def _pybind11_conduit_v1_(*args, **kwargs): ...
     def __contains__(self, arg0: str) -> bool:

--- a/lib/python-api/tests/test_stats.py
+++ b/lib/python-api/tests/test_stats.py
@@ -5,7 +5,14 @@ Unit tests for the clingo.stats module.
 import pytest
 from clingo.control import Control
 from clingo.core import Library
-from clingo.stats import Stats
+from clingo.stats import (
+    Stats,
+    StatsType,
+    StatsMap,
+    StatsMapView,
+    StatsArray,
+    StatsArrayView,
+)
 from util import MCB
 
 
@@ -54,8 +61,8 @@ class TestStats:
             assert hnd.get().satisfiable
         assert mcb.symbols == res
         stats = ctl.stats
-        assert isinstance(stats, dict)
-        cpu = stats["summary"]["times"]["cpu"]
+        cpu = stats["summary"]["times"]["cpu"].value
+        print(f"Choices: {stats["solving"]["solvers"]["choices"].value}")
         assert isinstance(cpu, float) and cpu >= 0.0
 
     def test_user(self):
@@ -69,17 +76,35 @@ class TestStats:
         mcb = MCB()
 
         def on_stats(step: Stats, accu: Stats):
+            assert step.type == StatsType.Map
+            assert isinstance(step.map, StatsMap)
             step.update({"a": 10.0})
             step.update({"b": [10.0]})
             step.update({"c": {"x": 1.0}})
             accu.update({"Test": {"x": 10.0, "y": [1.0, 2.0, 3.0]}})
             accu.update({"Test": {"x": lambda x: x + 2}})
             accu.update({"Test": {"y": lambda x: [y + 1 for y in x]}})
+            assert isinstance(accu["Test"]["y"].array, StatsArray)
 
         assert ctl.solve(on_model=mcb, on_stats=on_stats).satisfiable
         assert mcb.symbols == res
 
         stats = ctl.stats
+        assert stats.type == StatsType.Map
+        assert isinstance(stats.map, StatsMapView)
+        print(f"Times: {ctl.stats['summary']['times']}")
+        if (
+            "cpu" in ctl.stats["summary"]["times"]
+            and "cpu" in ctl.stats["summary"]["times"].map
+        ):
+            print("FOUND cpu")
+        for k in ctl.stats["summary"]["times"].map:
+            print(f"key: {k}")
+
+        print(f"str: {ctl.stats["user_accu"]["Test"]["y"]}")
+
+        for i in ctl.stats["user_accu"]["Test"]["y"].array:
+            print(f"item: {i}/{i.type}")
         # TBD: Should we make these strings available in the Python-API?
         assert stats["user_step"] == {"a": 10.0, "b": [10.0], "c": {"x": 1.0}}
         assert stats["user_accu"] == {"Test": {"x": 12.0, "y": [2.0, 3.0, 4.0]}}

--- a/lib/python-api/tests/test_stats.py
+++ b/lib/python-api/tests/test_stats.py
@@ -101,10 +101,16 @@ class TestStats:
         for k in ctl.stats["summary"]["times"].map:
             print(f"key: {k}")
 
+        for v in ctl.stats["summary"]["times"].map.values():
+            print(f"val: {v}")
+        for k, v in ctl.stats["summary"]["times"].map.items():
+            print(f"{k}:{v}")
+
         print(f"str: {ctl.stats["user_accu"]["Test"]["y"]}")
 
-        for i in ctl.stats["user_accu"]["Test"]["y"].array:
+        for i in ctl.stats["user_accu"]["Test"]["y"]:
             print(f"item: {i}/{i.type}")
+
         # TBD: Should we make these strings available in the Python-API?
         assert stats["user_step"] == {"a": 10.0, "b": [10.0], "c": {"x": 1.0}}
         assert stats["user_accu"] == {"Test": {"x": 12.0, "y": [2.0, 3.0, 4.0]}}

--- a/lib/python-api/tests/test_stats.py
+++ b/lib/python-api/tests/test_stats.py
@@ -80,5 +80,6 @@ class TestStats:
         assert mcb.symbols == res
 
         stats = ctl.stats
+        # TBD: Should we make these strings available in the Python-API?
         assert stats["user_step"] == {"a": 10.0, "b": [10.0], "c": {"x": 1.0}}
         assert stats["user_accu"] == {"Test": {"x": 12.0, "y": [2.0, 3.0, 4.0]}}

--- a/scripts/stubs.py
+++ b/scripts/stubs.py
@@ -17,6 +17,44 @@ import black
 import isort
 
 
+def reorder_classes(content: str, order: list[str]) -> str:
+    class_regex = re.compile(
+        r"^class\s+(\w+).*?:\n"  # class preamble
+        r"(?:^[ ]{4}.*\n|^\n)*"  # class body
+        r"^[ ]{4}[^ ].*$",  # end of class body
+        re.MULTILINE,
+    )
+
+    pieces = []
+    classes = {}
+    last_end = 0
+
+    for match in class_regex.finditer(content):
+        start, end = match.span()
+        if start > last_end:
+            pieces.append(content[last_end:start])
+        class_block = match.group(0)
+        class_name = match.group(1)
+        pieces.append(class_name)
+        classes[class_name] = class_block
+        last_end = end
+    if last_end < len(content):
+        pieces.append(content[last_end:])
+
+    order_stack = order[:]
+
+    result = []
+    for piece in pieces:
+        if piece in classes:
+            if piece in order:
+                result.append(classes[order_stack.pop(0)])
+            else:
+                result.append(classes[piece])
+        else:
+            result.append(piece)
+    return "".join(result)
+
+
 class Rewriter:
     """
     Rewriter to fine-tune generated stubs.
@@ -266,6 +304,17 @@ class Rewriter:
                         content += "\n" + "\n".join(unions) + "\n"
                     if self.python:
                         content = self.doc_enums(content)
+                        content = reorder_classes(
+                            content,
+                            [
+                                "StatsView",
+                                "StatsArrayView",
+                                "StatsMapView",
+                                "Stats",
+                                "StatsArray",
+                                "StatsMap",
+                            ],
+                        )
                     else:
                         content = self.format(path, content)
                         gen_content = None


### PR DESCRIPTION
@rkaminsk This is a draft PR just to gather some feedback from you.


Key questions:

- What's your opinion on making "user_accu"/"user_stats" part of the public C-API? (commit: 52fbbbc627b0e695f79d23bb02ada01954a95be9)
- What's your opinion on the new try_at function? (commit: 094e8ca988f271fa40e9806f7cc5b3271f6720bc). I also considered adding a second out parameter to `clingo_stats_map_has_subkey`, which seems more natural but would make certain call wrappers more complicated.
- What do you think about the reworked Python stats API (commit: 1b40d596ef0f9ad61d764305f12d9522dae80089)?
  - I added support for `__eq__` so that tests could still use asserts like `assert ctl.stats["summary"]["lower"] == [3.0]`
  - Do we need `keys()`, `values()`, `items()` for map?
  - Should (Const)Stats also implement `__iter__`?
  - Should we additionally add `__getattr__`?
- What do you think about an "item" based map interface, i.e. having `clingo_stats_map_item()` instead of `clingo_stats_map_subkey_name` + `clingo_stats_map_at`?