### PR TITLE
Update clasp and rework python stats API

### DIFF
--- a/lib/c-api/include/clingo/stats.h
+++ b/lib/c-api/include/clingo/stats.h
@@ -58,6 +58,11 @@ typedef int clingo_stats_type_t;
 //! Handle for the solver stats.
 typedef struct clingo_statistic clingo_stats_t;
 
+//! Well-known key name intended to be used for user-specific step statistics.
+CLINGO_VISIBILITY_DEFAULT extern clingo_string_t const clingo_user_stats_step;
+//! Well-known key name intended to be used for user-specific accu statistics.
+CLINGO_VISIBILITY_DEFAULT extern clingo_string_t const clingo_user_stats_accu;
+
 //! Get the root key of the stats.
 //!
 //! @param[in] stats the target stats
@@ -135,10 +140,12 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_stats_map_size(clingo_stats_t const *stats
 //! @param[in] key the key
 //! @param[in] name name of the subkey
 //! @param[in] size the size of the name
+//! @param[out] subkey resulting subkey if @p result is true
 //! @param[out] result true if the map has a subkey with the given name
 //! @return whether the call was successful
+//! @note @p subkey is optional and can be set to NULL to only check for existence
 CLINGO_VISIBILITY_DEFAULT bool clingo_stats_map_has_subkey(clingo_stats_t const *stats, uint64_t key, char const *name,
-                                                           size_t size, bool *result);
+                                                           size_t size, uint64_t *subkey, bool *result);
 //! Get the name associated with the offset-th subkey.
 //!
 //! @pre The @link clingo_stats_type() type@endlink of the entry must be @ref ::clingo_stats_type_map.

--- a/lib/c-api/src/stats.cc
+++ b/lib/c-api/src/stats.cc
@@ -59,6 +59,11 @@ inline auto c_cast(Potassco::StatisticsType type) -> clingo_stats_type_e {
 } // namespace
 } // namespace CppClingo::CAPI
 
+clingo_string_t const clingo_user_stats_step = {.data = Clasp::ClaspFacade::user_step_stats.data(),
+                                                .size = Clasp::ClaspFacade::user_step_stats.size()};
+clingo_string_t const clingo_user_stats_accu = {.data = Clasp::ClaspFacade::user_accu_stats.data(),
+                                                .size = Clasp::ClaspFacade::user_accu_stats.size()};
+
 extern "C" auto clingo_stats_root(clingo_stats_t const *stats, uint64_t *key) -> bool {
     CLINGO_TRY {
         if (stats == nullptr || key == nullptr) {
@@ -122,12 +127,12 @@ extern "C" auto clingo_stats_map_size(clingo_stats_t const *stats, uint64_t key,
 }
 
 extern "C" auto clingo_stats_map_has_subkey(clingo_stats_t const *stats, uint64_t key, char const *name, size_t size,
-                                            bool *result) -> bool {
+                                            uint64_t *subkey, bool *result) -> bool {
     CLINGO_TRY {
         if (stats == nullptr || (name == nullptr && size > 0) || result == nullptr) {
             return fail_arguments();
         }
-        *result = cpp_cast(stats)->find(key, std::string_view{name, size}, nullptr);
+        *result = cpp_cast(stats)->find(key, std::string_view{name, size}, subkey);
     }
     CLINGO_CATCH;
 }

--- a/lib/control/include/clingo/control/solver.hh
+++ b/lib/control/include/clingo/control/solver.hh
@@ -396,8 +396,8 @@ class SolveEventHandler {
     //! Callback to update statistics.
     //!
     //! Applications can add user defined statistics here. Statistics should be
-    //! added under keys "user_step" and "user_accu" to appear in the text
-    //! output.
+    //! added under keys \ref clingo_user_stats_step and \ref
+    //! clingo_user_stats_accu to appear in the text output.
     //!
     //! @param stats a handle to the statistics
     void on_stats(Potassco::AbstractStatistics &stats) { do_on_stats(stats); }

--- a/lib/cxx-api/include/clingo/control.hh
+++ b/lib/cxx-api/include/clingo/control.hh
@@ -674,13 +674,13 @@ class Control {
                         CLINGO_TRY {
                             auto *hnd = UserData::cast(data);
                             assert(hnd != nullptr);
-                            std::string_view user_step = "user_step";
-                            std::string_view user_accu = "user_accu";
                             uint64_t root = Detail::call<clingo_stats_root>(stats);
                             uint64_t step = Detail::call<clingo_stats_map_add_subkey>(
-                                stats, root, user_step.data(), user_step.size(), clingo_stats_type_map);
+                                stats, root, clingo_user_stats_step.data, clingo_user_stats_step.size,
+                                clingo_stats_type_map);
                             uint64_t accu = Detail::call<clingo_stats_map_add_subkey>(
-                                stats, root, user_accu.data(), user_accu.size(), clingo_stats_type_map);
+                                stats, root, clingo_user_stats_accu.data, clingo_user_stats_accu.size,
+                                clingo_stats_type_map);
                             hnd->stats(Stats{stats, step}, Stats{stats, accu});
                         }
                         CLINGO_CATCH;

--- a/lib/cxx-api/include/clingo/solve.hh
+++ b/lib/cxx-api/include/clingo/solve.hh
@@ -542,13 +542,11 @@ static constexpr clingo_solve_event_handler_t c_solve_event_handler{
         CLINGO_TRY {
             auto *hnd = static_cast<SolveEventHandler *>(data);
             assert(hnd != nullptr);
-            std::string_view user_step = "user_step";
-            std::string_view user_accu = "user_accu";
             uint64_t root = Detail::call<clingo_stats_root>(stats);
-            uint64_t step = Detail::call<clingo_stats_map_add_subkey>(stats, root, user_step.data(), user_step.size(),
-                                                                      clingo_stats_type_map);
-            uint64_t accu = Detail::call<clingo_stats_map_add_subkey>(stats, root, user_accu.data(), user_accu.size(),
-                                                                      clingo_stats_type_map);
+            uint64_t step = Detail::call<clingo_stats_map_add_subkey>(
+                stats, root, clingo_user_stats_step.data, clingo_user_stats_step.size, clingo_stats_type_map);
+            uint64_t accu = Detail::call<clingo_stats_map_add_subkey>(
+                stats, root, clingo_user_stats_accu.data, clingo_user_stats_accu.size, clingo_stats_type_map);
             hnd->stats(Stats{stats, step}, Stats{stats, accu});
         }
         CLINGO_CATCH;

--- a/lib/cxx-api/include/clingo/stats.hh
+++ b/lib/cxx-api/include/clingo/stats.hh
@@ -86,7 +86,7 @@ class ConstStats {
 
     //! Get a string representation of the statistics entry.
     //!
-    //! The represention is YAML-like and can be used for debugging purposes.
+    //! The representation is YAML-like and can be used for debugging purposes.
     //!
     //! @return a string representation of the statistics entry
     [[nodiscard]] auto to_string() const -> std::string {
@@ -347,7 +347,7 @@ class ConstStatsMap {
     //! @param name the name of the subkey to check
     //! @return whether the map contains a subkey with the given name
     [[nodiscard]] auto contains(std::string_view name) const -> bool {
-        return Detail::call<clingo_stats_map_has_subkey>(stats_, key_, name.data(), name.size());
+        return Detail::call<clingo_stats_map_has_subkey>(stats_, key_, name.data(), name.size(), nullptr);
     }
 
     //! Get an iterator to the beginning of the map.
@@ -468,6 +468,16 @@ inline auto Stats::map() const -> StatsMap {
 
 inline auto Stats::get(std::string_view name) const -> Stats {
     return map().get(name);
+}
+
+//! Get the root statistics entry for user step stats.
+inline auto stats_step_root() -> std::string_view {
+    return {clingo_user_stats_step.data, clingo_user_stats_step.size};
+}
+
+//! Get the root statistics entry for user accumulated stats.
+inline auto stats_accu_root() -> std::string_view {
+    return {clingo_user_stats_accu.data, clingo_user_stats_accu.size};
 }
 
 //! @}

--- a/lib/cxx-api/tests/propagate.cc
+++ b/lib/cxx-api/tests/propagate.cc
@@ -43,8 +43,8 @@ class AIFFBPropagator : public Propagator {
     }
     void do_attach([[maybe_unused]] Assignment assignment, [[maybe_unused]] PropagateControl ctl) override {
         auto thread_id = assignment.thread_id();
-        REQUIRE(thread_id < n_threads);
         auto lock = std::scoped_lock{mut};
+        REQUIRE(thread_id < n_threads);
         REQUIRE(attached.insert(thread_id).second);
     }
 

--- a/lib/cxx-api/tests/stats.cc
+++ b/lib/cxx-api/tests/stats.cc
@@ -72,15 +72,17 @@ TEST_CASE_METHOD(Fixture, "stats user", "[cxx][stats][user]") {
     REQUIRE(models == MV{{"a"}, {"b"}, {"c"}, {"d"}});
 
     auto stats = ctl.stats();
+    auto user_step = stats_step_root();
+    auto user_accu = stats_accu_root();
 
-    REQUIRE(*stats["user_step"]["a"] == 10.0);
-    REQUIRE(*stats["user_step"]["b"][0] == 10.0);
-    REQUIRE(*stats["user_step"]["c"]["x"] == 1.0);
+    REQUIRE(*stats[user_step]["a"] == 10.0);
+    REQUIRE(*stats[user_step]["b"][0] == 10.0);
+    REQUIRE(*stats[user_step]["c"]["x"] == 1.0);
 
-    REQUIRE(*stats["user_accu"]["Test"]["x"] == 12.0);
-    REQUIRE(*stats["user_accu"]["Test"]["y"][0] == 2.0);
-    REQUIRE(*stats["user_accu"]["Test"]["y"][1] == 3.0);
-    REQUIRE(*stats["user_accu"]["Test"]["y"][2] == 4.0);
+    REQUIRE(*stats[user_accu]["Test"]["x"] == 12.0);
+    REQUIRE(*stats[user_accu]["Test"]["y"][0] == 2.0);
+    REQUIRE(*stats[user_accu]["Test"]["y"][1] == 3.0);
+    REQUIRE(*stats[user_accu]["Test"]["y"][2] == 4.0);
 }
 
 } // namespace Clingo::Test

--- a/lib/cxx-api/tests/theory.cc
+++ b/lib/cxx-api/tests/theory.cc
@@ -65,7 +65,7 @@ struct TestTheory {
             uint64_t root = 0;
             Detail::handle_error(clingo_stats_root(stats, &root));
             auto st = Stats{stats, root};
-            auto step = st.map().insert("user_step", StatsType::map).map();
+            auto step = st.map().insert(Clingo::stats_step_root(), StatsType::map).map();
             step.insert("test_key", StatsType::value).value(3.14);
         }
         CLINGO_CATCH;
@@ -198,7 +198,7 @@ TEST_CASE_METHOD(Fixture, "theory", "[cxx][theory]") {
     REQUIRE(dta->prepared);
     REQUIRE(ctl.solve({}, std::ref(*this)).satisfiable());
     REQUIRE(dta->models == 1);
-    REQUIRE(ctl.stats()["user_step"]["test_key"].value() == 3.14);
+    REQUIRE(ctl.stats()[Clingo::stats_step_root()]["test_key"].value() == 3.14);
 }
 
 } // namespace Clingo::Test

--- a/lib/python-api/src/control.cc
+++ b/lib/python-api/src/control.cc
@@ -213,13 +213,13 @@ auto Control::config() -> Config {
     return Config{*this, config, key};
 }
 
-auto Control::stats() -> py::dict {
+auto Control::stats() -> ConstStats {
     clingo_stats_t const *stats = nullptr;
     handle_error(clingo_control_stats(get(), &stats));
     uint64_t key = 0;
     handle_error(clingo_stats_root(stats, &key));
     // NOLINTNEXTLINE
-    return Stats{const_cast<clingo_stats_t *>(stats), key}.nestify();
+    return ConstStats{const_cast<clingo_stats_t *>(stats), key};
 }
 
 auto Control::profile() -> py::list {

--- a/lib/python-api/src/control.cc
+++ b/lib/python-api/src/control.cc
@@ -331,12 +331,10 @@ auto Control::start_solve(MixedLitSpan const &assumptions, Annotation<std::optio
                 uint64_t root = 0;
                 handle_error(clingo_stats_root(stats, &root));
                 uint64_t step = 0;
-                std::string_view user_step = "user_step";
-                std::string_view user_accu = "user_accu";
-                handle_error(clingo_stats_map_add_subkey(stats, root, user_step.data(), user_step.size(),
+                handle_error(clingo_stats_map_add_subkey(stats, root, clingo_user_stats_step.data, clingo_user_stats_step.size,
                                                          clingo_stats_type_map, &step));
                 uint64_t accu = 0;
-                handle_error(clingo_stats_map_add_subkey(stats, root, user_accu.data(), user_accu.size(),
+                handle_error(clingo_stats_map_add_subkey(stats, root, clingo_user_stats_accu.data, clingo_user_stats_accu.size,
                                                          clingo_stats_type_map, &accu));
                 (*hnd->stats_)(Stats{stats, step}, Stats{stats, accu});
             }

--- a/lib/python-api/src/control.hh
+++ b/lib/python-api/src/control.hh
@@ -65,7 +65,7 @@ class Control : public registered_handle<Control, clingo_control_t>, public refe
     void observe(Observer &obs, bool preprocess);
     auto backend() -> BackendManager;
     auto config() -> Config;
-    auto stats() -> py::dict;
+    auto stats() -> ConstStats;
     auto profile() -> py::list;
     void main();
     auto buffer() -> std::string_view;

--- a/lib/python-api/src/stats.cc
+++ b/lib/python-api/src/stats.cc
@@ -6,8 +6,61 @@
 namespace PyClingo {
 
 namespace {
+class StatsIterBase {
+  public:
+    template <typename ContainerT>
+    explicit StatsIterBase(ContainerT const &container)
+        : stats_(container.c_ptr(), container.key()), pos_(0), end_(container.len()) {}
+    auto operator==(const StatsIterBase &) const -> bool = default;
+    friend auto operator==(const StatsIterBase &iter, [[maybe_unused]] std::default_sentinel_t s) -> bool {
+        return iter.pos_ == iter.end_;
+    }
+    void next() { ++pos_; }
+    [[nodiscard]] auto map_key() const -> std::string_view { return stats_.as<ConstStatsMap>().get_key(pos_); }
+    [[nodiscard]] auto const_map_value() const -> ConstStats { return const_map_item().second; }
+    [[nodiscard]] auto map_value() const -> Stats { return map_item().second; }
+    [[nodiscard]] auto const_map_item() const -> std::pair<std::string_view, ConstStats> {
+        auto name = this->map_key();
+        auto value = stats_.as<ConstStatsMap>().get(name);
+        return {name, value};
+    }
+    [[nodiscard]] auto map_item() const -> std::pair<std::string_view, Stats> {
+        auto name = this->map_key();
+        auto value = stats_.as<StatsMap>().get(name);
+        return {name, value};
+    }
+    [[nodiscard]] auto const_array_item() const -> ConstStats { return stats_.as<ConstStatsArray>().get(pos_); }
+    [[nodiscard]] auto array_item() const -> Stats { return stats_.as<StatsArray>().get(pos_); }
 
-auto get_type(py::handle value, std::optional<Stats> old_value) -> std::pair<StatsType, py::object> {
+  private:
+    StatsBase stats_;
+    std::size_t pos_;
+    std::size_t end_;
+};
+// Minimal interface required for py::iterator
+template <auto Pmf>
+    requires(std::is_invocable_v<decltype(Pmf), StatsIterBase const &>)
+class StatsIter : public StatsIterBase {
+  public:
+    using StatsIterBase::operator==;
+    using StatsIterBase::StatsIterBase;
+    auto operator*() const -> std::invoke_result_t<decltype(Pmf), StatsIterBase const &> {
+        return (static_cast<StatsIterBase const &>(*this).*Pmf)();
+    }
+    auto operator++() -> StatsIter & {
+        this->next();
+        return *this;
+    }
+    auto operator++(int) -> StatsIter {
+        StatsIter t(*this);
+        this->next();
+        return t;
+    }
+};
+template <auto Fun, typename Container> auto make_py_iter(Container const &container) {
+    return py::make_iterator(StatsIter<Fun>(container), std::default_sentinel);
+}
+auto get_type(py::handle value, std::optional<ConstStats> old_value) -> std::pair<StatsType, py::object> {
     py::object new_value = py::none{};
     if (PyCallable_Check(value.ptr()) == 1) {
         new_value = value(old_value ? old_value->nestify() : py::none{});
@@ -29,122 +82,182 @@ auto get_type(py::handle value, std::optional<Stats> old_value) -> std::pair<Sta
     throw py::type_error{"expected sequence, mapping, or float"};
 }
 
-} // namespace
-
-auto StatsArray::get(size_t index) -> Stats {
-    uint64_t subkey = 0;
-    handle_error(clingo_stats_array_at(stats_, key_, index, &subkey));
-    return {stats_, subkey};
+template <auto Fun, typename... Args> void stats_call(StatsBase const &stats, Args &&...args) {
+    handle_error(Fun(stats.c_ptr(), stats.key(), std::forward<Args>(args)...));
 }
 
-auto StatsArray::len() -> size_t {
+} // namespace
+
+auto StatsBase::str() const -> std::string_view {
+    auto *bld = string_builder();
+    stats_call<clingo_stats_to_string>(*this, bld);
+    clingo_string_t res;
+    handle_error(clingo_string_builder_string(bld, &res));
+    return {res.data, res.size};
+}
+
+auto ConstStatsArray::len() const -> size_t {
     size_t size = 0;
-    handle_error(clingo_stats_array_size(stats_, key_, &size));
+    stats_call<clingo_stats_array_size>(*this, &size);
     return size;
 }
 
-void StatsArray::set(size_t index, py::handle value) {
+auto ConstStatsArray::get(size_t index) const -> ConstStats {
     if (index < len()) {
-        get(index).update_(value, false);
-    } else {
-        throw py::index_error{"array index out of bounds"};
+        uint64_t subkey = 0;
+        stats_call<clingo_stats_array_at>(*this, index, &subkey);
+        return {c_ptr(), subkey};
     }
+    throw py::index_error{"array index out of bounds"};
+}
+
+auto ConstStatsArray::items() const -> TypeHint<"Iterator[StatsView]"> {
+    return make_py_iter<&StatsIterBase::const_array_item>(*this);
+}
+
+auto StatsArray::get(size_t index) -> Stats {
+    return ConstStatsArray::get(index).as<Stats>();
+}
+
+void StatsArray::set(size_t index, py::handle value) {
+    get(index).update_(value, false);
+}
+
+auto StatsArray::items() -> TypeHint<"Iterator[Stats]"> { // NOLINT(*-make-member-function-const)
+    return make_py_iter<&StatsIterBase::array_item>(*this);
 }
 
 void StatsArray::append(py::handle value) {
     uint64_t subkey = 0;
     auto [subtype, subval] = get_type(value, std::nullopt);
-    handle_error(clingo_stats_array_push(stats_, key_, static_cast<clingo_stats_type_t>(subtype), &subkey));
-    Stats{stats_, subkey}.update_(std::move(subval), true);
+    stats_call<clingo_stats_array_push>(*this, static_cast<clingo_stats_type_t>(subtype), &subkey);
+    Stats{c_ptr(), subkey}.update_(std::move(subval), true);
 }
 
-auto StatsMap::len() -> size_t {
+auto ConstStatsMap::len() const -> size_t {
     size_t size = 0;
-    handle_error(clingo_stats_map_size(stats_, key_, &size));
+    stats_call<clingo_stats_map_size>(*this, &size);
     return size;
 }
 
-auto StatsMap::get(std::string_view name) -> Stats {
+auto ConstStatsMap::contains(std::string_view name) const -> bool {
+    auto res = false;
+    stats_call<clingo_stats_map_has_subkey>(*this, name.data(), name.size(), nullptr, &res);
+    return res;
+}
+
+auto ConstStatsMap::get(std::string_view name) const -> ConstStats {
     if (auto stats = try_get(name); stats.has_value()) {
         return *stats;
     }
     throw py::index_error{"invalid key"};
 }
 
-auto StatsMap::contains(std::string_view name) -> bool {
-    auto res = false;
-    handle_error(clingo_stats_map_has_subkey(stats_, key_, name.data(), name.size(), nullptr, &res));
-    return res;
+auto ConstStatsMap::get_key(size_t index) const -> std::string_view {
+    clingo_string_t name;
+    stats_call<clingo_stats_map_subkey_name>(*this, index, &name);
+    return {name.data, name.size};
 }
 
-auto StatsMap::try_get(std::string_view name) -> std::optional<Stats> {
+auto ConstStatsMap::try_get(std::string_view name) const -> std::optional<ConstStats> {
     uint64_t subkey = 0;
     auto found = false;
-    handle_error(clingo_stats_map_has_subkey(stats_, key_, name.data(), name.size(), &subkey, &found));
-    return found ? std::make_optional<Stats>(stats_, subkey) : std::nullopt;
+    stats_call<clingo_stats_map_has_subkey>(*this, name.data(), name.size(), &subkey, &found);
+    return found ? std::make_optional<Stats>(c_ptr(), subkey) : std::nullopt;
+}
+
+auto ConstStatsMap::keys() const -> TypeHint<"Iterator[str]"> {
+    return make_py_iter<&StatsIterBase::map_key>(*this);
+}
+
+auto ConstStatsMap::values() const -> TypeHint<"Iterator[StatsView]"> {
+    return make_py_iter<&StatsIterBase::const_map_value>(*this);
+}
+
+auto ConstStatsMap::items() const -> TypeHint<"Iterator[tuple[str,StatsView]]"> {
+    return make_py_iter<&StatsIterBase::const_map_item>(*this);
+}
+
+auto StatsMap::get(std::string_view name) -> Stats {
+    return ConstStatsMap::get(name).as<Stats>();
 }
 
 void StatsMap::set(std::string_view name, py::handle value) {
     auto old = try_get(name);
     auto [subtype, subval] = get_type(value, old);
     uint64_t subkey = 0;
-    handle_error(clingo_stats_map_add_subkey(stats_, key_, name.data(), name.size(),
-                                             static_cast<clingo_stats_type_t>(subtype), &subkey));
-    Stats{stats_, subkey}.update_(std::move(subval), !old.has_value());
+    stats_call<clingo_stats_map_add_subkey>(*this, name.data(), name.size(), static_cast<clingo_stats_type_t>(subtype),
+                                            &subkey);
+    Stats{c_ptr(), subkey}.update_(std::move(subval), !old.has_value());
 }
 
-auto Stats::type() -> StatsType {
+auto StatsMap::values() -> TypeHint<"Iterator[Stats]"> { // NOLINT(*-make-member-function-const)
+    return make_py_iter<&StatsIterBase::map_value>(*this);
+}
+
+auto StatsMap::items() -> TypeHint<"Iterator[tuple[str,Stats]]"> { // NOLINT(*-make-member-function-const)
+    return make_py_iter<&StatsIterBase::map_item>(*this);
+}
+
+auto ConstStats::type() const -> StatsType {
     clingo_stats_type_t type = 0;
-    handle_error(clingo_stats_type(stats_, key_, &type));
+    stats_call<clingo_stats_type>(*this, &type);
     return static_cast<StatsType>(type);
 }
 
-auto Stats::array() -> StatsArray {
+auto ConstStats::array() const -> ConstStatsArray {
     if (type() == StatsType::array) {
-        return {stats_, key_};
+        return as<ConstStatsArray>();
     }
     throw py::type_error{"not an array"};
 }
 
-auto Stats::map() -> StatsMap {
+auto ConstStats::map() const -> ConstStatsMap {
     if (type() == StatsType::map) {
-        return {stats_, key_};
+        return as<ConstStatsMap>();
     }
     throw py::type_error{"not a map"};
 }
 
-auto Stats::get_value() -> double {
+auto ConstStats::get_value() const -> double {
     if (type() == StatsType::value) {
         double value = 0;
-        handle_error(clingo_stats_value_get(stats_, key_, &value));
+        stats_call<clingo_stats_value_get>(*this, &value);
         return value;
     }
     throw py::type_error{"not a value"};
 }
 
-void Stats::set_value(double value) {
-    if (type() == StatsType::value) {
-        handle_error(clingo_stats_value_set(stats_, key_, value));
-    } else {
-        throw py::type_error{"not a value"};
+auto ConstStats::get(std::size_t key) const -> ConstStats {
+    return array().get(key);
+}
+
+auto ConstStats::at(std::string_view key) const -> ConstStats {
+    return map().get(key);
+}
+
+auto ConstStats::len() const -> size_t {
+    switch (type()) {
+        case StatsType::array:
+            return as<ConstStatsArray>().len();
+        case StatsType::map:
+            return as<ConstStatsMap>().len();
+        default:
+            return 0;
     }
 }
 
-auto Stats::str() -> std::string_view {
-    auto *bld = string_builder();
-    handle_error(clingo_stats_to_string(stats_, key_, bld));
-    clingo_string_t res;
-    handle_error(clingo_string_builder_string(bld, &res));
-    return {res.data, res.size};
+auto ConstStats::contains(std::string_view key) const -> bool {
+    return map().contains(key);
 }
 
-auto Stats::nestify() -> py::object {
+auto ConstStats::nestify() const -> py::object {
     switch (type()) {
         case StatsType::value: {
             return py::float_{get_value()};
         }
         case StatsType::array: {
-            auto x = array();
+            auto x = as<ConstStatsArray>();
             auto n = x.len();
             auto res = py::list{n};
             for (size_t i = 0; i < n; ++i) {
@@ -153,18 +266,35 @@ auto Stats::nestify() -> py::object {
             return res;
         }
         case StatsType::map: {
-            auto x = map();
-            auto n = x.len();
             auto res = py::dict{};
-            for (size_t i = 0; i < n; ++i) {
-                clingo_string_t name;
-                handle_error(clingo_stats_map_subkey_name(stats_, key_, i, &name));
-                res[py::str{name.data, name.size}] = x.get(std::string_view{name.data, name.size}).nestify();
+            for (auto it = StatsIterBase{as<ConstStatsMap>()}; it != std::default_sentinel; it.next()) {
+                auto [name, object] = it.const_map_item();
+                res[py::str{name}] = object.nestify();
             }
             return res;
         }
     }
     unreachable();
+}
+
+auto ConstStats::iter() const -> TypeHint<"Iterator[str|StatsView]"> {
+    switch (type()) {
+        case StatsType::map:
+            return map().keys();
+        case StatsType::array:
+            return array().items();
+        case StatsType::value:
+            throw py::type_error{"'StatsType::value' is not iterable"};
+    }
+    unreachable();
+}
+
+void Stats::set_value(double value) {
+    if (type() == StatsType::value) {
+        stats_call<clingo_stats_value_set>(*this, value);
+    } else {
+        throw py::type_error{"not a value"};
+    }
 }
 
 void Stats::update_(py::handle value, bool init) {
@@ -201,6 +331,34 @@ void Stats::update_(py::handle value, bool init) {
             break;
         }
     }
+}
+
+auto Stats::array() -> StatsArray {
+    return ConstStats::array().as<StatsArray>();
+}
+
+auto Stats::map() -> StatsMap {
+    return ConstStats::map().as<StatsMap>();
+}
+
+auto Stats::get(std::size_t key) -> Stats {
+    return ConstStats::get(key).as<Stats>();
+}
+
+auto Stats::at(std::string_view key) -> Stats {
+    return ConstStats::at(key).as<Stats>();
+}
+
+auto Stats::iter() -> TypeHint<"Iterator[str|Stats]"> {
+    switch (type()) {
+        case StatsType::map:
+            return map().keys();
+        case StatsType::array:
+            return array().items();
+        case StatsType::value:
+            throw py::type_error{"'StatsType::value' is not iterable"};
+    }
+    unreachable();
 }
 
 void register_stats(pybind11::module &m) {
@@ -243,15 +401,20 @@ Note that the control object is created passing options `--stats`; without this
 option only basic stats are reported.
 )"_d);
 
-    py::native_enum<StatsType>(module, "StatsType", "enum.IntEnum", "The type of a stats object.")
+    py::native_enum<StatsType>{module, "StatsType", "enum.IntEnum", "The type of a stats object."}
         .value("Map", StatsType::map, R"(Indicate a map of stats.)")
         .value("Array", StatsType::array, R"(Indicate an array of stats.)")
         .value("Value", StatsType::value, R"(Indicate a value of stats.)")
         .finalize();
 
-    auto stats = py::class_<Stats>(module, "Stats", R"(Class representing solver stats.)");
+    auto stats_view = py::class_<ConstStats>{module, "StatsView", R"(Class representing read-only solver stats.)"};
+    auto stats = py::class_<Stats, ConstStats>{module, "Stats", R"(Class representing solver stats.)"};
+    auto stats_array_view = py::class_<ConstStatsArray>{module, "StatsArrayView", R"(
+Class representing a read-only array of stats.
 
-    py::class_<StatsArray>(module, "StatsArray", R"(
+This class partially implements the mutable sequence protocol.
+)"_d};
+    auto stats_array = py::class_<StatsArray, ConstStatsArray>{module, "StatsArray", R"(
 Class representing an array of stats.
 
 This class partially implements the mutable sequence protocol - elements of
@@ -260,18 +423,13 @@ implemented via `Stats.update`.
 
 Most use cases should be implementable just using the update function of the
 top-level statistics object.
-)"_d)
-        .def("__len__", &StatsArray::len, "Get the length of the array.")
-        .def("__setitem__", &StatsArray::set, "Set the element at the given index to the given value.")
-        .def("__getitem__", &StatsArray::get, "Get the element at the given index.")
-        .def("append", &StatsArray::append, py::arg("value"), R"(
-Append the given value to the array.
+)"_d};
+    auto stats_map_view = py::class_<ConstStatsMap>{module, "StatsMapView", R"(
+Class representing a read-only map of stats.
 
-Args:
-	value: The value to append.
-)"_d);
-
-    py::class_<StatsMap>(module, "StatsMap", R"(
+This class partially implements the mutable mapping protocol.
+)"_d};
+    auto stats_map = py::class_<StatsMap, ConstStatsMap>{module, "StatsMap", R"(
 Class representing a map of stats.
 
 This class partially implements the mutable mapping protocol - value of keys
@@ -280,16 +438,59 @@ can be modified but they cannot be deleted. Modifications are implemented via
 
 Most use cases should be implementable just using the update function of the
 top-level statistics object.
-)"_d)
-        .def("__len__", &StatsMap::len, "Get the length of the map.")
-        .def("__setitem__", &StatsMap::set, py::arg("key"), py::arg("value"), "Set the value at the given key.")
-        .def("__getitem__", &StatsMap::get, py::arg("key"), "Lookup the value with the given key.");
+)"_d};
 
-    stats
-        .def("nestify", &Stats::nestify, R"(
+    stats_view //
+        .def("__str__", &ConstStats::str, R"(A readable representation to inspect the statistics.)")
+        .def("__getitem__", &ConstStats::get, "Get the element at the given index.")
+        .def("__getitem__", &ConstStats::at, py::arg("key"), "Lookup the value with the given key.")
+        .def("__len__", &ConstStats::len, "Get the length of this element.")
+        .def("__contains__", &ConstStats::contains,
+             "Checks whether the given key is in the element, which must be a map.")
+        .def("__iter__", &ConstStats::iter,
+             "Get an iterator over this statistics object, which must be a map or an array.")
+        .def("nestify", &ConstStats::nestify, R"(
 Convert the statistics object into a nested structure consisting of sequencens,
 mappings with string keys, and floats.
 )"_d)
+        .def_property_readonly("type", &ConstStats::type, R"(Get the type of the stats object.)")
+        .def_property_readonly("array", &ConstStats::array, R"(Get an array of stats objects.)")
+        .def_property_readonly("map", &ConstStats::map, R"(Get a map of stats objects.)")
+        .def_property_readonly("value", &ConstStats::get_value, R"(Get the value of the stats object.)");
+
+    stats_array_view //
+        .def("__str__", &ConstStatsArray::str, R"(A readable representation to inspect the array.)")
+        .def("__len__", &ConstStatsArray::len, "Get the length of the array.")
+        .def("__iter__", &ConstStatsArray::items, "Get an iterator over the elements of the array.")
+        .def("__getitem__", &ConstStatsArray::get, "Get the element at the given index.");
+
+    stats_array //
+        .def("__setitem__", &StatsArray::set, "Set the element at the given index to the given value.")
+        .def("__getitem__", &StatsArray::get, "Get the element at the given index.")
+        .def("__iter__", &StatsArray::items, "Get an iterator over the elements of the array.")
+        .def("append", &StatsArray::append, py::arg("value"), R"(
+Append the given value to the array.
+
+Args:
+	value: The value to append.
+)"_d);
+
+    stats_map_view //
+        .def("__str__", &ConstStatsMap::str, R"(A readable representation to inspect the map.)")
+        .def("__len__", &ConstStatsMap::len, "Get the length of the map.")
+        .def("__iter__", &ConstStatsMap::keys, "Get an iterator over the keys of the map.")
+        .def("keys", &ConstStatsMap::keys, "Get an iterator over the keys of the map.")
+        .def("values", &ConstStatsMap::values, "Get an iterator over the values of the map.")
+        .def("items", &ConstStatsMap::items, "Get an iterator over the items of the map.")
+        .def("__getitem__", &ConstStatsMap::get, py::arg("key"), "Lookup the value with the given key.");
+
+    stats_map //
+        .def("values", &StatsMap::values, "Get an iterator over the values of the map.")
+        .def("items", &StatsMap::items, "Get an iterator over the items of the map.")
+        .def("__setitem__", &StatsMap::set, py::arg("key"), py::arg("value"), "Set the value at the given key.")
+        .def("__getitem__", &StatsMap::get, py::arg("key"), "Lookup the value with the given key.");
+
+    stats //
         .def("update", &Stats::update, py::arg("values"), R"(
 Update the statistics with the given values.
 
@@ -303,8 +504,9 @@ Args:
         return an updated value. If there is no previous value, `None` is
         passed as argument.
 )"_d)
-        .def("__str__", &Stats::str, R"(A readable representation to inspect the statistics.)")
-        .def_property_readonly("type", &Stats::type, R"(Get the type of the stats object.)")
+        .def("__getitem__", &Stats::get, "Get the element at the given index.")
+        .def("__getitem__", &Stats::at, py::arg("key"), "Lookup the value with the given key.")
+        .def("__iter__", &Stats::iter, "Get an iterator over this statistics object, which must be a map or an array.")
         .def_property_readonly("array", &Stats::array, R"(Get an array of stats objects.)")
         .def_property_readonly("map", &Stats::map, R"(Get a map of stats objects.)")
         .def_property("value", &Stats::get_value, &Stats::set_value, R"(Get/set the value of the stats object.)");

--- a/lib/python-api/src/stats.cc
+++ b/lib/python-api/src/stats.cc
@@ -374,7 +374,7 @@ The following example shows how to add custom stats and access the stats:
 >>> from clingo.control import Control
 >>>
 >>> def on_stats(step, accu):
-...     accu.update({"example": [21]})
+...     step.update({"example": [21]})
 ...     accu.update({"example": [lambda x: (x or 0) + 21]})
 ...
 >>> lib = Library()
@@ -385,11 +385,11 @@ The following example shows how to add custom stats and access the stats:
 SAT
 >>> print(ctl.solve(on_stats=on_stats))
 SAT
->>> ctl.stats['user_step']
+>>> ctl.stats['user_step'].nestify()
 { "example": [21.0] }
->>> ctl.stats['user_accu']
+>>> ctl.stats['user_accu'].nestify()
 { "example": [42.0] }
->>> ctl.stats['summary']['times']
+>>> ctl.stats['summary']['times'].nestify()
 { "cpu": 0.000785999999999995,
   "sat": 7.867813110351562e-06,
   "solve": 2.288818359375e-05,

--- a/lib/python-api/src/stats.cc
+++ b/lib/python-api/src/stats.cc
@@ -65,22 +65,27 @@ auto StatsMap::len() -> size_t {
 }
 
 auto StatsMap::get(std::string_view name) -> Stats {
-    if (contains(name)) {
-        uint64_t subkey = 0;
-        handle_error(clingo_stats_map_at(stats_, key_, name.data(), name.size(), &subkey));
-        return {stats_, subkey};
+    if (auto stats = try_get(name); stats.has_value()) {
+        return *stats;
     }
     throw py::index_error{"invalid key"};
 }
 
 auto StatsMap::contains(std::string_view name) -> bool {
     auto res = false;
-    handle_error(clingo_stats_map_has_subkey(stats_, key_, name.data(), name.size(), &res));
+    handle_error(clingo_stats_map_has_subkey(stats_, key_, name.data(), name.size(), nullptr, &res));
     return res;
 }
 
+auto StatsMap::try_get(std::string_view name) -> std::optional<Stats> {
+    uint64_t subkey = 0;
+    auto found = false;
+    handle_error(clingo_stats_map_has_subkey(stats_, key_, name.data(), name.size(), &subkey, &found));
+    return found ? std::make_optional<Stats>(stats_, subkey) : std::nullopt;
+}
+
 void StatsMap::set(std::string_view name, py::handle value) {
-    auto old = contains(name) ? std::optional{get(name)} : std::nullopt;
+    auto old = try_get(name);
     auto [subtype, subval] = get_type(value, old);
     uint64_t subkey = 0;
     handle_error(clingo_stats_map_add_subkey(stats_, key_, name.data(), name.size(),

--- a/lib/python-api/src/stats.hh
+++ b/lib/python-api/src/stats.hh
@@ -2,6 +2,8 @@
 
 #include "clingo/stats.h"
 
+#include "iterable.hh"
+
 #include <pybind11/pybind11.h>
 
 #include <optional>
@@ -16,53 +18,90 @@ enum class StatsType : uint8_t {
     map = clingo_stats_type_map,
 };
 
-class Stats;
-
-class StatsArray {
+class StatsBase {
   public:
-    StatsArray(clingo_stats_t *stats, uint64_t key) : stats_{stats}, key_{key} {}
+    constexpr StatsBase(clingo_stats_t *stats, uint64_t key) : stats_(stats), key_(key) {}
+    [[nodiscard]] auto c_ptr() const -> clingo_stats_t * { return stats_; }
+    [[nodiscard]] auto key() const -> uint64_t { return key_; }
+    [[nodiscard]] auto str() const -> std::string_view;
+    template <typename T> [[nodiscard]] auto as() const -> T { return T{c_ptr(), key()}; }
+    constexpr auto operator==(StatsBase const &) const -> bool = default;
+    constexpr auto operator!=(StatsBase const &) const -> bool = default;
+
+  private:
+    clingo_stats_t *stats_;
+    uint64_t key_;
+};
+class Stats;
+class ConstStats;
+
+class ConstStatsArray : public StatsBase {
+  public:
+    using StatsBase::StatsBase;
+    [[nodiscard]] auto get(size_t index) const -> ConstStats;
+    [[nodiscard]] auto len() const -> size_t;
+    [[nodiscard]] auto items() const -> TypeHint<"Iterator[StatsView]">;
+};
+
+class StatsArray : public ConstStatsArray {
+  public:
+    using ConstStatsArray::ConstStatsArray;
     void set(size_t index, py::handle value);
     auto get(size_t index) -> Stats;
+    auto items() -> TypeHint<"Iterator[Stats]">;
     void append(py::handle value);
-    auto len() -> size_t;
-
-  private:
-    clingo_stats_t *stats_;
-    uint64_t key_;
 };
 
-class StatsMap {
+class ConstStatsMap : public StatsBase {
   public:
-    StatsMap(clingo_stats_t *stats, uint64_t key) : stats_{stats}, key_{key} {}
+    using StatsBase::StatsBase;
+    [[nodiscard]] auto get(std::string_view name) const -> ConstStats;
+    [[nodiscard]] auto len() const -> size_t;
+    [[nodiscard]] auto contains(std::string_view name) const -> bool;
+    [[nodiscard]] auto keys() const -> TypeHint<"Iterator[str]">;
+    [[nodiscard]] auto values() const -> TypeHint<"Iterator[StatsView]">;
+    [[nodiscard]] auto items() const -> TypeHint<"Iterator[tuple[str,StatsView]]">;
+    [[nodiscard]] auto try_get(std::string_view name) const -> std::optional<ConstStats>;
+    [[nodiscard]] auto get_key(size_t index) const -> std::string_view;
+};
+
+class StatsMap : public ConstStatsMap {
+  public:
+    using ConstStatsMap::ConstStatsMap;
     auto get(std::string_view name) -> Stats;
     void set(std::string_view name, py::handle value);
-    auto len() -> size_t;
-    auto contains(std::string_view name) -> bool;
-
-  private:
-    auto try_get(std::string_view name) -> std::optional<Stats>;
-    clingo_stats_t *stats_;
-    uint64_t key_;
+    auto values() -> TypeHint<"Iterator[Stats]">;
+    auto items() -> TypeHint<"Iterator[tuple[str,Stats]]">;
 };
 
-class Stats {
+class ConstStats : public StatsBase {
   public:
-    Stats(clingo_stats_t *stats, uint64_t key) : stats_{stats}, key_{key} {}
+    using StatsBase::StatsBase;
 
-    auto type() -> StatsType;
+    [[nodiscard]] auto type() const -> StatsType;
+    [[nodiscard]] auto array() const -> ConstStatsArray;
+    [[nodiscard]] auto map() const -> ConstStatsMap;
+    [[nodiscard]] auto get_value() const -> double;
+    [[nodiscard]] auto len() const -> size_t;
+    [[nodiscard]] auto get(std::size_t key) const -> ConstStats;
+    [[nodiscard]] auto at(std::string_view key) const -> ConstStats;
+    [[nodiscard]] auto contains(std::string_view key) const -> bool;
+    [[nodiscard]] auto iter() const -> TypeHint<"Iterator[str|StatsView]">;
+
+    [[nodiscard]] auto nestify() const -> py::object;
+};
+
+class Stats : public ConstStats {
+  public:
+    using ConstStats::ConstStats;
     auto array() -> StatsArray;
     auto map() -> StatsMap;
-    auto get_value() -> double;
+    auto get(std::size_t key) -> Stats;
+    auto at(std::string_view key) -> Stats;
+    auto iter() -> TypeHint<"Iterator[str|Stats]">;
     void set_value(double value);
-    auto nestify() -> py::object;
     void update(py::handle value) { update_(value, false); }
     void update_(py::handle value, bool init);
-    auto str() -> std::string_view;
-    auto c_ptr() -> clingo_stats_t * { return stats_; }
-
-  private:
-    clingo_stats_t *stats_;
-    uint64_t key_;
 };
 
 void register_stats(pybind11::module &m);

--- a/lib/python-api/src/stats.hh
+++ b/lib/python-api/src/stats.hh
@@ -4,6 +4,8 @@
 
 #include <pybind11/pybind11.h>
 
+#include <optional>
+
 namespace PyClingo {
 
 namespace py = pybind11;
@@ -38,6 +40,7 @@ class StatsMap {
     auto contains(std::string_view name) -> bool;
 
   private:
+    auto try_get(std::string_view name) -> std::optional<Stats>;
     clingo_stats_t *stats_;
     uint64_t key_;
 };

--- a/lib/python-api/stubs/control.pyi
+++ b/lib/python-api/stubs/control.pyi
@@ -403,7 +403,7 @@ class Control:
         """
 
     @property
-    def stats(self) -> dict:
+    def stats(self) -> clingo.stats.StatsView:
         """
         Get the solver stats.
         """

--- a/lib/python-api/stubs/stats.pyi
+++ b/lib/python-api/stubs/stats.pyi
@@ -42,7 +42,15 @@ from __future__ import annotations
 import enum
 import typing
 
-__all__ = ["Stats", "StatsArray", "StatsMap", "StatsType"]
+__all__ = [
+    "Stats",
+    "StatsArray",
+    "StatsArrayView",
+    "StatsMap",
+    "StatsMapView",
+    "StatsType",
+    "StatsView",
+]
 
 class StatsType(enum.IntEnum):
     """
@@ -59,22 +67,28 @@ class StatsType(enum.IntEnum):
         Convert to a string according to format_spec.
         """
 
-class Stats:
+class Stats(StatsView):
     """
     Class representing solver stats.
     """
 
     @staticmethod
     def _pybind11_conduit_v1_(*args, **kwargs): ...
-    def __str__(self) -> str:
+    @typing.overload
+    def __getitem__(self, arg0: int) -> Stats:
         """
-        A readable representation to inspect the statistics.
+        Get the element at the given index.
         """
 
-    def nestify(self) -> typing.Any:
+    @typing.overload
+    def __getitem__(self, key: str) -> Stats:
         """
-        Convert the statistics object into a nested structure consisting of sequencens,
-        mappings with string keys, and floats.
+        Lookup the value with the given key.
+        """
+
+    def __iter__(self) -> typing.Iterator[str | Stats]:
+        """
+        Get an iterator over this statistics object, which must be a map or an array.
         """
 
     def update(self, values: typing.Any) -> None:
@@ -105,12 +119,6 @@ class Stats:
         """
 
     @property
-    def type(self) -> StatsType:
-        """
-        Get the type of the stats object.
-        """
-
-    @property
     def value(self) -> float:
         """
         Get/set the value of the stats object.
@@ -119,7 +127,7 @@ class Stats:
     @value.setter
     def value(self, arg1: typing.SupportsFloat) -> None: ...
 
-class StatsArray:
+class StatsArray(StatsArrayView):
     """
     Class representing an array of stats.
 
@@ -138,9 +146,9 @@ class StatsArray:
         Get the element at the given index.
         """
 
-    def __len__(self) -> int:
+    def __iter__(self) -> typing.Iterator[Stats]:
         """
-        Get the length of the array.
+        Get an iterator over the elements of the array.
         """
 
     def __setitem__(self, arg0: int, arg1: typing.Any) -> None:
@@ -156,7 +164,36 @@ class StatsArray:
                 value: The value to append.
         """
 
-class StatsMap:
+class StatsArrayView:
+    """
+    Class representing a read-only array of stats.
+
+    This class partially implements the mutable sequence protocol.
+    """
+
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs): ...
+    def __getitem__(self, arg0: int) -> StatsView:
+        """
+        Get the element at the given index.
+        """
+
+    def __iter__(self) -> typing.Iterator[StatsView]:
+        """
+        Get an iterator over the elements of the array.
+        """
+
+    def __len__(self) -> int:
+        """
+        Get the length of the array.
+        """
+
+    def __str__(self) -> str:
+        """
+        A readable representation to inspect the array.
+        """
+
+class StatsMap(StatsMapView):
     """
     Class representing a map of stats.
 
@@ -175,12 +212,130 @@ class StatsMap:
         Lookup the value with the given key.
         """
 
+    def __setitem__(self, key: str, value: typing.Any) -> None:
+        """
+        Set the value at the given key.
+        """
+
+    def items(self) -> typing.Iterator[tuple[str, Stats]]:
+        """
+        Get an iterator over the items of the map.
+        """
+
+    def values(self) -> typing.Iterator[Stats]:
+        """
+        Get an iterator over the values of the map.
+        """
+
+class StatsMapView:
+    """
+    Class representing a read-only map of stats.
+
+    This class partially implements the mutable mapping protocol.
+    """
+
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs): ...
+    def __getitem__(self, key: str) -> StatsView:
+        """
+        Lookup the value with the given key.
+        """
+
+    def __iter__(self) -> typing.Iterator[str]:
+        """
+        Get an iterator over the keys of the map.
+        """
+
     def __len__(self) -> int:
         """
         Get the length of the map.
         """
 
-    def __setitem__(self, key: str, value: typing.Any) -> None:
+    def __str__(self) -> str:
         """
-        Set the value at the given key.
+        A readable representation to inspect the map.
+        """
+
+    def items(self) -> typing.Iterator[tuple[str, StatsView]]:
+        """
+        Get an iterator over the items of the map.
+        """
+
+    def keys(self) -> typing.Iterator[str]:
+        """
+        Get an iterator over the keys of the map.
+        """
+
+    def values(self) -> typing.Iterator[StatsView]:
+        """
+        Get an iterator over the values of the map.
+        """
+
+class StatsView:
+    """
+    Class representing read-only solver stats.
+    """
+
+    @staticmethod
+    def _pybind11_conduit_v1_(*args, **kwargs): ...
+    def __contains__(self, arg0: str) -> bool:
+        """
+        Checks whether the given key is in the element, which must be a map.
+        """
+
+    @typing.overload
+    def __getitem__(self, arg0: int) -> StatsView:
+        """
+        Get the element at the given index.
+        """
+
+    @typing.overload
+    def __getitem__(self, key: str) -> StatsView:
+        """
+        Lookup the value with the given key.
+        """
+
+    def __iter__(self) -> typing.Iterator[str | StatsView]:
+        """
+        Get an iterator over this statistics object, which must be a map or an array.
+        """
+
+    def __len__(self) -> int:
+        """
+        Get the length of this element.
+        """
+
+    def __str__(self) -> str:
+        """
+        A readable representation to inspect the statistics.
+        """
+
+    def nestify(self) -> typing.Any:
+        """
+        Convert the statistics object into a nested structure consisting of sequencens,
+        mappings with string keys, and floats.
+        """
+
+    @property
+    def array(self) -> StatsArrayView:
+        """
+        Get an array of stats objects.
+        """
+
+    @property
+    def map(self) -> StatsMapView:
+        """
+        Get a map of stats objects.
+        """
+
+    @property
+    def type(self) -> StatsType:
+        """
+        Get the type of the stats object.
+        """
+
+    @property
+    def value(self) -> float:
+        """
+        Get the value of the stats object.
         """

--- a/lib/python-api/tests/test_incremental.py
+++ b/lib/python-api/tests/test_incremental.py
@@ -85,17 +85,17 @@ class TestIncremental:
         ctl.ground()
         mcb = MCB()
         ctl.solve(on_model=mcb)
-        assert ctl.stats["summary"]["costs"] == [0.0]
+        assert ctl.stats["summary"]["costs"].nestify() == [0.0]
         assert mcb.symbols == [["b"]]
         ctl.parse_string("#program x. :- not a. :- not b.")
         ctl.ground([("x", [])])
         mcb = MCB()
         ctl.solve(on_model=mcb)
-        assert ctl.stats["summary"]["costs"] == [1.0]
+        assert ctl.stats["summary"]["costs"].nestify() == [1.0]
         assert mcb.symbols == [["a", "b"]]
         ctl.parse_string("#program y. {c}. #minimize{ 1: b; 2 : not c }.")
         ctl.ground([("y", [])])
         mcb = MCB()
         ctl.solve(on_model=mcb)
-        assert ctl.stats["summary"]["costs"] == [1.0]
+        assert ctl.stats["summary"]["costs"].nestify() == [1.0]
         assert mcb.symbols == [["a", "b", "c"]]

--- a/lib/python-api/tests/test_solve.py
+++ b/lib/python-api/tests/test_solve.py
@@ -166,7 +166,7 @@ class TestSolve:
         ctl.ground()
         lower = []
         assert ctl.solve(on_unsat=lower.append).satisfiable
-        assert ctl.stats["summary"]["lower"] == [3.0]
+        assert ctl.stats["summary"]["lower"].nestify() == [3.0]
         assert lower == [[1], [2], [3]]
 
     def test_consequence(self):

--- a/lib/python-api/tests/test_stats.py
+++ b/lib/python-api/tests/test_stats.py
@@ -5,7 +5,15 @@ Unit tests for the clingo.stats module.
 import pytest
 from clingo.control import Control
 from clingo.core import Library
-from clingo.stats import Stats
+from clingo.stats import (
+    Stats,
+    StatsArray,
+    StatsArrayView,
+    StatsMap,
+    StatsMapView,
+    StatsType,
+    StatsView,
+)
 from util import MCB
 
 
@@ -37,6 +45,105 @@ class TestStats:
         assert self._lib is not None
         return self._lib
 
+    def test_stats_view(self):
+        """
+        Test read-only stats API.
+        """
+        ctl = Control(self.lib, ["0"])
+        ctl.parse_string("1 { a; b; c; d } 1. #minimize { 1,a:a;1,b:b;1,c:c;1,d:d }.")
+        ctl.ground()
+        ctl.solve()
+        stats = ctl.stats
+        assert isinstance(stats, StatsView)
+        assert isinstance(stats.map, StatsMapView)
+        assert not isinstance(stats, Stats)
+        assert not isinstance(stats.map, StatsMap)
+        for x in stats:
+            assert isinstance(x, str)
+            if x == "solving":
+                assert "solvers" in stats[x]
+                assert "choices" in stats[x]["solvers"]
+                break
+        choices = stats["solving"]["solvers"]["choices"]
+        assert isinstance(choices, StatsView)
+        assert choices.value > 0
+        for x in stats["solving"].map.keys():
+            assert isinstance(x, str)
+            if x == "solvers":
+                break
+        for x in stats["solving"]["solvers"].map.values():
+            assert isinstance(x, StatsView)
+            break
+        for k, v in stats["solving"]["solvers"].map.items():
+            assert isinstance(k, str)
+            assert isinstance(v, StatsView)
+            if k == "choices":
+                assert v.value == choices.value
+                break
+        assert "costs" in stats["summary"]
+        costs = stats["summary"]["costs"]
+        assert isinstance(costs, StatsView)
+        assert costs.nestify() == [1.0]
+        expected = float(1.0)
+        for x in costs:
+            assert isinstance(x, StatsView)
+            assert isinstance(x.value, float)
+            assert x.value == expected
+        assert isinstance(costs.array, StatsArrayView)
+        assert not isinstance(costs.array, StatsArray)
+        for x in costs.array:
+            assert isinstance(x, StatsView)
+
+    def test_stats(self):
+        """
+        Test mutable stats API.
+        """
+        ctl = Control(self.lib, ["0"])
+        ctl.parse_string("1 { a; b; c; d } 1.")
+        ctl.ground()
+
+        def on_stats(step: Stats, accu: Stats):
+            assert isinstance(step, Stats)
+            assert isinstance(step, StatsView)
+            assert isinstance(accu, Stats)
+            assert isinstance(accu, StatsView)
+
+            step.update({"map": {"val": 10.0, "arr": [1.0, 0.0, 3.0, {"nested": 1.0}]}})
+            assert "map" in step
+            assert isinstance(step["map"].map, StatsMap)
+            assert sorted(list(step["map"].map.keys())) == ["arr", "val"]
+            assert len(step["map"]["arr"]) == 4
+            assert step["map"]["arr"][1].value == 0.0
+            step["map"]["arr"][1].value = 2.0
+            for k, v in step["map"].map.items():
+                if k == "val":
+                    v.value += v.value
+                elif k == "arr":
+                    assert isinstance(v.array, StatsArray)
+                    for item in v.array:
+                        if item.type == StatsType.Value:
+                            item.value *= 2
+                            with pytest.raises(TypeError):
+                                for _ in item:
+                                    pass
+                        else:
+                            assert item.type == StatsType.Map
+                            with pytest.raises(TypeError):
+                                item.value *= 2
+                            for v in item.map.values():
+                                v.value *= 4711.0
+
+            assert step["map"]["val"].value == 20.0
+            assert step["map"]["arr"].nestify() == [2.0, 4.0, 6.0, {"nested": 4711.0}]
+
+            step.map["tested"] = 1.0
+            accu.map["tested"] = 1.0
+
+        assert ctl.solve(on_stats=on_stats).satisfiable
+        stats = ctl.stats
+        assert stats["user_step"]["tested"].value > 0
+        assert stats["user_accu"]["tested"].value > 0
+
     def test_solve(self):
         """
         Test the solver stats.
@@ -54,9 +161,9 @@ class TestStats:
             assert hnd.get().satisfiable
         assert mcb.symbols == res
         stats = ctl.stats
-        assert isinstance(stats, dict)
+        assert isinstance(stats, StatsView)
         cpu = stats["summary"]["times"]["cpu"]
-        assert isinstance(cpu, float) and cpu >= 0.0
+        assert isinstance(cpu, StatsView) and cpu.value >= 0.0
 
     def test_user(self):
         """
@@ -80,5 +187,7 @@ class TestStats:
         assert mcb.symbols == res
 
         stats = ctl.stats
-        assert stats["user_step"] == {"a": 10.0, "b": [10.0], "c": {"x": 1.0}}
-        assert stats["user_accu"] == {"Test": {"x": 12.0, "y": [2.0, 3.0, 4.0]}}
+        assert stats["user_step"].nestify() == {"a": 10.0, "b": [10.0], "c": {"x": 1.0}}
+        assert stats["user_accu"].nestify() == {
+            "Test": {"x": 12.0, "y": [2.0, 3.0, 4.0]}
+        }

--- a/scripts/stubs.py
+++ b/scripts/stubs.py
@@ -17,6 +17,44 @@ import black
 import isort
 
 
+def reorder_classes(content: str, order: list[str]) -> str:
+    class_regex = re.compile(
+        r"^class\s+(\w+).*?:\n"  # class preamble
+        r"(?:^[ ]{4}.*\n|^\n)*"  # class body
+        r"^[ ]{4}[^ ].*$",  # end of class body
+        re.MULTILINE,
+    )
+
+    pieces = []
+    classes = {}
+    last_end = 0
+
+    for match in class_regex.finditer(content):
+        start, end = match.span()
+        if start > last_end:
+            pieces.append(content[last_end:start])
+        class_block = match.group(0)
+        class_name = match.group(1)
+        pieces.append(class_name)
+        classes[class_name] = class_block
+        last_end = end
+    if last_end < len(content):
+        pieces.append(content[last_end:])
+
+    order_stack = order[:]
+
+    result = []
+    for piece in pieces:
+        if piece in classes:
+            if piece in order:
+                result.append(classes[order_stack.pop(0)])
+            else:
+                result.append(classes[piece])
+        else:
+            result.append(piece)
+    return "".join(result)
+
+
 class Rewriter:
     """
     Rewriter to fine-tune generated stubs.
@@ -266,6 +304,17 @@ class Rewriter:
                         content += "\n" + "\n".join(unions) + "\n"
                     if self.python:
                         content = self.doc_enums(content)
+                        content = reorder_classes(
+                            content,
+                            [
+                                "StatsView",
+                                "StatsArrayView",
+                                "StatsMapView",
+                                "Stats",
+                                "StatsArray",
+                                "StatsMap",
+                            ],
+                        )
                     else:
                         content = self.format(path, content)
                         gen_content = None


### PR DESCRIPTION
#### extend stats C-API
* make key names for user stats part of the public API
* add (optional) subkey parameter to `clingo_stats_map_has_subkey` to
  enable more efficient "get-if-found" queries

#### rework python stats API
* add view (read-only) types for Stats, StatsArray, and StatsMap
  and expose `Control.stats` as a read-only and lazy StatsView
  instead of an eagerly populated dictionary