### PR TITLE
Flush stdout if a custom model printer has been registered.

### DIFF
--- a/lib/python-api/src/app.cc
+++ b/lib/python-api/src/app.cc
@@ -1,3 +1,4 @@
+#include <iostream>
 #include <utility>
 
 #include "app.hh"
@@ -138,7 +139,11 @@ class App : public reference_keeper<App> {
                              void *data) -> bool {
         auto &app = *static_cast<App *>(data);
         CLINGO_TRY {
+            auto acquire = py::gil_scoped_acquire{};
+            // NOTE: Python seems to directly write large buffers
+            std::cout.flush();
             app.print_model(Model{model}, [printer, printer_data]() { handle_error(printer(printer_data)); });
+            py::module_::import("sys").attr("stdout").attr("flush")();
         }
         CLINGO_CATCH;
     }


### PR DESCRIPTION
Output might get tangled if a model printer is registered in Python because python manages its own output buffer. I pushed a preliminary fix. @BenKaufmann what do you think about this? Should we flush the output in general or should we just do it for the Python API? For the C/C++ APIs there should be no issues because here we do not have separate buffers.