### PR TITLE
update clasp and use new update mode

### DIFF
--- a/lib/control/include/clingo/control/solver.hh
+++ b/lib/control/include/clingo/control/solver.hh
@@ -740,12 +740,14 @@ class Solver : public BaseView {
 
     //! Get the output buffer.
     //!
-    //! If the control object has been constructed without a null output FILE,
-    //! this buffer contains the output of the textoutput.
-    [[nodiscard]] auto buf() -> Util::OutputBuffer & { return stream_.buffer(); };
+    //! If the control object has been constructed without an output FILE, this
+    //! buffer contains the output of the textoutput.
+    [[nodiscard]] auto buf() -> Util::OutputBuffer & { return stream_.buffer(); }
 
-    //! Get the text buffer.
-    [[nodiscard]] auto stream() -> Util::OutputStream & { return stream_; };
+    //! Get the output stream.
+    //!
+    //! This stream simply forwards to the underlying output buffer.
+    [[nodiscard]] auto stream() -> Util::OutputStream & { return stream_; }
 
     //! Get a handle that provides access to the backend to add atoms and rules.
     //!

--- a/lib/control/src/solver.cc
+++ b/lib/control/src/solver.cc
@@ -1278,16 +1278,24 @@ auto Solver::map_model(Clasp::Model const &mdl) -> Model & {
 
 auto Solver::solve(USolveEventHandler handler, PrgLitSpan assumptions, SolveMode mode) -> USolveHandle {
     auto guard = unlock_guard{lock_};
-    if (state_ == State::solved || state_ == State::initial) {
+    if (state_ == State::initial || (state_ == State::solved && opts_.backend_type != BackendType::clasp)) {
         // we inject an empty ground to go to grounded state
         ground(Input::ProgramParamVec{}, nullptr);
     }
-    state_ = State::solved;
+    auto prev_state = std::exchange(state_, State::solved);
     if (opts_.mode == AppMode::solve) {
-        if (!assumptions.empty()) {
-            backend_->assume(assumptions);
+        if (prev_state != State::solved) {
+            if (!assumptions.empty()) {
+                backend_->assume(assumptions);
+            }
+            backend_->end_step();
+        } else {
+            // we keep the current program and only update solving-related state
+            clasp_->update(Clasp::ClaspFacade::update_solve);
+            if (!assumptions.empty()) {
+                backend_->assume(assumptions);
+            }
         }
-        backend_->end_step();
         bool prepared = clasp_->prepare();
         theory_->reset();
         buf().flush();

--- a/lib/cxx-api/tests/solve.cc
+++ b/lib/cxx-api/tests/solve.cc
@@ -108,6 +108,12 @@ TEST_CASE("solve assume", "[cxx][solve][assume]") {
         REQUIRE((std::ranges::find(core, assumptions[0]) != core.end() &&
                  std::ranges::find(core, assumptions[1]) != core.end()));
     }
+    assumptions = std::vector{lit("a"), lit("c")};
+    {
+        auto models = std::vector<std::vector<std::string>>{};
+        REQUIRE(ctl.solve(assumptions, MCB{models}).satisfiable());
+        REQUIRE(models == std::vector<std::vector<std::string>>{{"a", "c"}});
+    }
 }
 
 TEST_CASE("solve extend base", "[cxx][solve][extend][base]") {


### PR DESCRIPTION
Use new (more efficient) clasp update mode when updating a solved program. With the new mode, we don't have to add an empty program when "re-solving" a solved program (e.g. only changing assumptions or reasoning modes), thereby avoiding the overhead incurred by preprocessing.

**NOTE:** We probably have to adjust this once https://github.com/potassco/clingo/pull/599 has been merged