### PR TITLE
extend write_aspif to write to internal text buffer

### DIFF
--- a/.github/conda/meta.yaml
+++ b/.github/conda/meta.yaml
@@ -12,7 +12,7 @@ requirements:
   build:
   - cmake
   - ninja
-  - re2c  # [not win]
+  - re2c
   - {{ compiler('c') }}
   - {{ compiler('cxx') }}
   host:

--- a/.github/workflows/conda.yaml
+++ b/.github/workflows/conda.yaml
@@ -64,12 +64,6 @@ jobs:
             echo "BUILD_NUMBER=${{ inputs.build_number }}" >> $GITHUB_ENV
           fi
 
-      - name: Windows re2c
-        if: ${{ runner.os == 'windows' }}
-        shell: powershell
-        run: |
-          choco install re2c
-
       - name: Conda
         if: ${{ runner.os != 'linux' }}
         uses: conda-incubator/setup-miniconda@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,31 +42,8 @@ jobs:
 
       - name: Dependencies
         run: |
-          pkgs=(cmake ninja pytest python c-compiler cxx-compiler)
-          if [[ "$RUNNER_OS" != "Windows" ]]; then
-            pkgs+=(re2c)
-          fi
+          pkgs=(cmake ninja pytest python c-compiler cxx-compiler re2c)
           conda install "${pkgs[@]}"
-
-      - name: Install re2c
-        if: runner.os == 'Windows'
-        run: |
-          git clone https://github.com/skvadrik/re2c.git
-          cmake -S re2c -B re2c/build -G "${{ matrix.generator }}" \
-            -DCMAKE_INSTALL_PREFIX="$CONDA_PREFIX" \
-            -DRE2C_BUILD_RE2D=OFF \
-            -DRE2C_BUILD_RE2GO=OFF \
-            -DRE2C_BUILD_RE2HS=OFF \
-            -DRE2C_BUILD_RE2JAVA=OFF \
-            -DRE2C_BUILD_RE2JS=OFF \
-            -DRE2C_BUILD_RE2OCAML=OFF \
-            -DRE2C_BUILD_RE2PY=OFF \
-            -DRE2C_BUILD_RE2RUST=OFF \
-            -DRE2C_BUILD_RE2SWIFT=OFF \
-            -DRE2C_BUILD_RE2V=OFF \
-            -DRE2C_BUILD_RE2ZIG=OFF
-          cmake --build re2c/build --config Release
-          cmake --install re2c/build --config Release
 
       - name: Configure
         run: |

--- a/lib/c-api/include/clingo/observe.h
+++ b/lib/c-api/include/clingo/observe.h
@@ -157,6 +157,13 @@ CLINGO_VISIBILITY_DEFAULT bool clingo_control_observe(clingo_control_t *control,
 
 //! Write the current logic program in aspif format to a file.
 //!
+//! If the path size is zero, clingo's internal output buffer is used instead
+//! of writing to a file. The buffer content can be accessed via
+//! clingo_control_buffer(). In auto mode, the preamble is written only if the
+//! buffer is currently empty. In application mode, the buffer is printed to
+//! stdout and cleared after each major operation like grounding, so the
+//! preamble flag should be set explicitly in this case.
+//!
 //! @param control the target control
 //! @param path the path to the file to write to
 //! @param size the size of the path

--- a/lib/c-api/src/observe.cc
+++ b/lib/c-api/src/observe.cc
@@ -217,8 +217,7 @@ extern "C" auto clingo_control_observe(clingo_control_t *control, clingo_observe
 extern "C" auto clingo_control_write_aspif(clingo_control_t *control, char const *path, size_t size,
                                            clingo_write_aspif_mode_t mode) -> bool {
     CLINGO_TRY {
-        auto path_view = std::string_view{path, size};
-        if (control == nullptr || path == nullptr) {
+        if (control == nullptr || (path == nullptr && size != 0)) {
             return fail_arguments();
         }
         // NOLINTNEXTLINE
@@ -226,27 +225,40 @@ extern "C" auto clingo_control_write_aspif(clingo_control_t *control, char const
         if ((mode & clingo_write_aspif_mode_preprocess) != 0) {
             prg.endProgram();
         }
-        auto app = (mode & clingo_write_aspif_mode_append) != 0 && std::filesystem::exists(path_view);
+        auto path_view = std::string_view{path, size};
+        // NOTE: The buffer is always flushed after grounding. Hence, it will
+        // always be empty if it is attached to an output stream in app mode.
+        // In this scenario, it is better to explicitly set the preamble flag
+        // to false to avoid writing the preamble multiple times.
+        auto app = (mode & clingo_write_aspif_mode_append) != 0 &&
+                   (size > 0 ? std::filesystem::exists(path_view) : !control->slv->buf().empty());
         auto pre = (mode & clingo_write_aspif_mode_preamble) != 0;
         if ((mode & clingo_write_aspif_mode_preamble_auto) != 0) {
             pre = !app;
         }
-        auto out = std::ofstream{std::string{path_view}, app ? std::ios::app : std::ios::out};
-        out.exceptions(std::ios::failbit | std::ios::badbit);
-        if ((mode & clingo_write_aspif_mode_symbols) != 0) {
-            auto obs = ExtendedAspifWriter{control->slv->sym_tab(), *control->slv, out};
-            prg.accept(obs, pre);
-            if (!pre) {
-                obs.endStep();
+        auto output = [&](auto &out) {
+            if ((mode & clingo_write_aspif_mode_symbols) != 0) {
+                auto obs = ExtendedAspifWriter{control->slv->sym_tab(), *control->slv, out};
+                prg.accept(obs, pre);
+                if (!pre) {
+                    obs.endStep();
+                }
+            } else {
+                auto obs = Potassco::AspifOutput{out};
+                prg.accept(obs, pre);
+                // Clingo's aspif reader requires all programs to be zero terminated.
+                // Thus, we call endStep here.
+                if (!pre) {
+                    obs.endStep();
+                }
             }
+        };
+        if (size > 0) {
+            auto out = std::ofstream{std::string{path_view}, app ? std::ios::app : std::ios::out};
+            out.exceptions(std::ios::failbit | std::ios::badbit);
+            output(out);
         } else {
-            auto obs = Potassco::AspifOutput{out};
-            prg.accept(obs, pre);
-            // Clingo's aspif reader requires all programs to be zero terminated.
-            // Thus, we call endStep here.
-            if (!pre) {
-                obs.endStep();
-            }
+            output(control->slv->stream());
         }
     }
     CLINGO_CATCH;

--- a/lib/control/include/clingo/control/grounder.hh
+++ b/lib/control/include/clingo/control/grounder.hh
@@ -25,7 +25,8 @@ class Grounder {
     //! Join with the given program.
     void join(Input::UnprocessedProgram const &prg);
     //! Parse a program from the given string.
-    auto parse(std::string_view str, Ground::ScriptExec *code = nullptr) -> BuiltinIncludes;
+    auto parse(std::string_view str, Ground::ScriptExec *code = nullptr, ProgramBackend *prg = nullptr,
+               TheoryBackend *thy = nullptr) -> BuiltinIncludes;
     //! Parse the given files.
     auto parse(std::span<std::string_view const> const &files, Ground::ScriptExec *code = nullptr,
                ProgramBackend *prg = nullptr, TheoryBackend *thy = nullptr) -> BuiltinIncludes;

--- a/lib/control/include/clingo/control/solver.hh
+++ b/lib/control/include/clingo/control/solver.hh
@@ -744,6 +744,9 @@ class Solver : public BaseView {
     //! this buffer contains the output of the textoutput.
     [[nodiscard]] auto buf() -> Util::OutputBuffer & { return stream_.buffer(); };
 
+    //! Get the text buffer.
+    [[nodiscard]] auto stream() -> Util::OutputStream & { return stream_; };
+
     //! Get a handle that provides access to the backend to add atoms and rules.
     //!
     //! While the handle is alive, the solver object should not be accessed.

--- a/lib/control/src/grounder.cc
+++ b/lib/control/src/grounder.cc
@@ -315,15 +315,17 @@ void Grounder::join(Input::UnprocessedProgram const &prg) {
     }
 }
 
-auto Grounder::parse(std::string_view str, Ground::ScriptExec *code) -> BuiltinIncludes {
+auto Grounder::parse(std::string_view str, Ground::ScriptExec *code, ProgramBackend *prg, TheoryBackend *thy)
+    -> BuiltinIncludes {
     CLINGO_REPORT(*impl_->log, debug) << "parsing...";
 #ifdef CLINGO_PROFILE
     auto prof = Profiler{"clingo-parse.prof"};
 #endif
     if (impl_->status == GroundResult::ok) {
         GCLock lock{*impl_->store};
-        auto prs = ParseHelper{*impl_->log, *impl_->store,
-                               [&](Input::Stm stm) { impl_->unprocessed_prg.add(store(), std::move(stm)); }, code};
+        auto prs = ParseHelper{
+            *impl_->log, *impl_->store, [&](Input::Stm stm) { impl_->unprocessed_prg.add(store(), std::move(stm)); },
+            code,        prg,           thy};
         return prs.process_string(str);
     }
     return BuiltinIncludes::empty;

--- a/lib/control/src/solver.cc
+++ b/lib/control/src/solver.cc
@@ -1326,7 +1326,7 @@ void Solver::parse_with(std::function<void(ProgramBackend *, TheoryBackend *)> c
 }
 
 void Solver::parse(std::string_view str) {
-    includes_ |= grd_.parse(str, scripts_);
+    parse_with([&](ProgramBackend *bck, TheoryBackend *thy) { includes_ |= grd_.parse(str, scripts_, bck, thy); });
 }
 
 void Solver::parse(std::span<std::string_view const> const &files) {

--- a/lib/cxx-api/include/clingo/control.hh
+++ b/lib/cxx-api/include/clingo/control.hh
@@ -204,10 +204,22 @@ class Control {
     //! after calls to solve(). Only the part of the program grounded after the
     //! last call to solve() or at the beginning are written to the file.
     //!
+    //! If no path is given, clingo's internal output buffer is used instead of
+    //! writing to a file. The buffer content can be accessed via
+    //! Control::buffer(). If WriteAspifFlags::preamble_auto is used, the
+    //! preamble is written only if the buffer is currently empty. In
+    //! application mode, the buffer is printed to stdout and cleared after
+    //! each major operation like grounding, so the preamble flag should be set
+    //! explicitly in this case.
+    //!
     //! @param path the path to the ASPIF file
     //! @param flags the flags to use when writing the ASPIF file
-    void write_aspif(std::string_view path, WriteAspifFlags flags = WriteAspifFlags::none) const {
-        Detail::handle_error(clingo_control_write_aspif(ctl_.get(), path.data(), path.size(),
+    void write_aspif(std::optional<std::string_view> path, WriteAspifFlags flags = WriteAspifFlags::none) const {
+        if (path && path->empty()) {
+            throw std::invalid_argument{"path cannot be empty"};
+        }
+        auto path_view = path.value_or(std::string_view{});
+        Detail::handle_error(clingo_control_write_aspif(ctl_.get(), path_view.data(), path_view.size(),
                                                         static_cast<clingo_write_aspif_mode_t>(flags)));
     }
 

--- a/lib/input/src/parse/parser_state.hh
+++ b/lib/input/src/parse/parser_state.hh
@@ -482,10 +482,8 @@ class ParserState {
         stms_.clear();
         token_ = TokenType::begin;
         file_ = SharedString{file};
-        cond_ = yycnormal;
+        cond_ = prg_backend_ != nullptr && thy_backend_ != nullptr ? yycprogram : yycnormal;
         state_.init(in, YYMAXFILL);
-        prg_backend_ = nullptr;
-        thy_backend_ = nullptr;
     }
 
     //! Initialize the parser state with the given stream.

--- a/lib/python-api/src/control.cc
+++ b/lib/python-api/src/control.cc
@@ -64,7 +64,7 @@ void Control::parse_string(std::string_view str) {
     handle_error(clingo_control_parse_string(get(), str.data(), str.size()));
 }
 
-void Control::write_aspif(std::string_view path, bool symbols, bool append, std::optional<bool> preamble,
+void Control::write_aspif(std::optional<std::string_view> path, bool symbols, bool append, std::optional<bool> preamble,
                           bool preprocess) {
     clingo_write_aspif_mode_t mode = 0;
     if (symbols) {
@@ -81,7 +81,11 @@ void Control::write_aspif(std::string_view path, bool symbols, bool append, std:
     if (preprocess) {
         mode |= clingo_write_aspif_mode_preprocess;
     }
-    handle_error(clingo_control_write_aspif(get(), path.data(), path.size(), mode));
+    if (path && path->empty()) {
+        throw std::invalid_argument{"path cannot be empty"};
+    }
+    auto path_view = path ? *path : std::string_view{};
+    handle_error(clingo_control_write_aspif(get(), path_view.data(), path_view.size(), mode));
 }
 
 void Control::parse_files(std::span<std::string const> files) {
@@ -517,7 +521,7 @@ Args:
     files:
         A list of file paths to parse.
 )"_d)
-        .def("write_aspif", &Control::write_aspif, py::arg("path"), py::arg("symbols") = false,
+        .def("write_aspif", &Control::write_aspif, py::arg("path") = std::nullopt, py::arg("symbols") = false,
              py::arg("append") = false, py::arg("preamble") = std::nullopt, py::arg("preprocess") = true, R"(
 Write the current logic programs to the given file.
 
@@ -525,9 +529,16 @@ If append is true, a file will be created if none exists yet. If preamble is
 None, then the aspif preamble is written for newly created files and omitted
 for existing files.
 
+If `path` is None, clingo's internal output buffer is used instead of writing
+to a file. The buffer content is available via `Control.buffer`. If `preamble`
+is None, the preamble is written only if the buffer is currently empty. In
+application mode, the buffer is printed to stdout and cleared after each major
+operation like grounding, so the preamble flag should be set explicitly in this
+case.
+
 Args:
     path:
-        The path to write the program to.
+        The optional path to write the program to.
     append:
         Whether to append to an existing file.
     preamble:

--- a/lib/python-api/src/control.hh
+++ b/lib/python-api/src/control.hh
@@ -48,7 +48,8 @@ class Control : public registered_handle<Control, clingo_control_t>, public refe
     auto mode() -> clingo_mode_e;
     void parse_files(std::span<std::string const> files);
     void parse_string(std::string_view str);
-    void write_aspif(std::string_view path, bool symbols, bool append, std::optional<bool> preamble, bool preprocess);
+    void write_aspif(std::optional<std::string_view> path, bool symbols, bool append, std::optional<bool> preamble,
+                     bool preprocess);
     void join(AST::Program &prg);
     void ground(std::optional<PartSpan> parts, py::handle ctx);
     auto start_ground(std::optional<PartSpan> parts, py::handle ctx,

--- a/lib/python-api/stubs/control.pyi
+++ b/lib/python-api/stubs/control.pyi
@@ -315,7 +315,7 @@ class Control:
 
     def write_aspif(
         self,
-        path: str,
+        path: str | None = None,
         symbols: bool = False,
         append: bool = False,
         preamble: bool | None = None,
@@ -328,9 +328,16 @@ class Control:
         None, then the aspif preamble is written for newly created files and omitted
         for existing files.
 
+        If `path` is None, clingo's internal output buffer is used instead of writing
+        to a file. The buffer content is available via `Control.buffer`. If `preamble`
+        is None, the preamble is written only if the buffer is currently empty. In
+        application mode, the buffer is printed to stdout and cleared after each major
+        operation like grounding, so the preamble flag should be set explicitly in this
+        case.
+
         Args:
             path:
-                The path to write the program to.
+                The optional path to write the program to.
             append:
                 Whether to append to an existing file.
             preamble:

--- a/lib/python-api/tests/test_write_aspif.py
+++ b/lib/python-api/tests/test_write_aspif.py
@@ -86,6 +86,26 @@ class TestWriteAspif:
             ctl.write_aspif(path, symbols=symbols)
             yield path
 
+    def parse_string(self, content: str, symbols: bool = False):
+        """
+        Parse the given program and return a string with its aspif grounding.
+        """
+        ctl = Control(self.lib)
+        ctl.parse_string(content)
+        ctl.ground()
+        ctl.write_aspif(symbols=symbols)
+        return ctl.buffer
+
+    def test_buffer(self):
+        """
+        Test writing aspif to a buffer and parsing it again.
+        """
+        prg = self.parse_string("a. {b}. c :- b.")
+        self.ctl.parse_string(prg)
+        mcb = MCB()
+        self.ctl.solve(on_model=mcb)
+        assert mcb.symbols == [["a"], ["a", "b", "c"]]
+
     def test_rule(self):
         """
         Test rules.


### PR DESCRIPTION
This PR extends write_aspif across the C, C++, and Python APIs to support writing ASPIF output to clingo’s internal text buffer (instead of a file), and adjusts parsing/grounding plumbing so that ASPIF content can be round-tripped more easily:

- Allow omitting the path argument in `write_aspif`, routing output to the internal buffer.
- Implement buffer-backed output in the C API `clingo_control_write_aspif` implementation.
- Update parsing/grounding internals to pass backends during string parsing
- Add a Python test for buffer round-tripping.
