### PR TITLE
correctly track next_lit and next_term

### DIFF
--- a/lib/control/src/solver.cc
+++ b/lib/control/src/solver.cc
@@ -27,8 +27,13 @@ namespace {
 //! Implementation of the backend interface.
 //!
 //! This implementation forwards grounded statements to a
-//! Potassco::AbstractProgram. As such it can create neither atom ids nor term
-//! ids, which is the responsibility of derived classes.
+//! Potassco::AbstractProgram. The implementation leaves the management of term
+//! ids for show statements to derived classes.
+//!
+//! @note Maximum literal tracking is not required by all derived classes. For
+//! example, base classes using Clasp's LogicProgram, can use the tracking
+//! provided by this classes. We still implement it here for simplicity. The
+//! performance overhead should be negligible.
 class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
   public:
     AbstractProgramBackendImpl(Potassco::AbstractProgram &prg) : prg_{&prg} {}
@@ -64,7 +69,8 @@ class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
         std::cerr << (choice ? "{ " : "") << Util::p_range(head, ", ") << (choice ? " }" : "") << " :- "
                   << Util::p_range(body, ", ") << ".\n";
 #endif
-        prg_->rule(choice ? Potassco::HeadType::choice : Potassco::HeadType::disjunctive, as_atoms_(head), body);
+        prg_->rule(choice ? Potassco::HeadType::choice : Potassco::HeadType::disjunctive, as_atoms_(head),
+                   as_lits_(body));
     }
 
     void do_bd_aggr(PrgLitSpan head, WeightedPrgLitSpan body, prg_weight_t bound, bool choice) override {
@@ -80,11 +86,10 @@ class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
     }
 
     void do_edge(prg_id_t u, prg_id_t v, PrgLitSpan body) override {
-        prg_->acycEdge(static_cast<int>(u), static_cast<int>(v), body);
+        prg_->acycEdge(static_cast<int>(u), static_cast<int>(v), as_lits_(body));
     }
 
     void do_heuristic(prg_lit_t atom, int32_t weight, int32_t prio, HeuristicType type, PrgLitSpan body) override {
-        assert(atom > 0);
         static_assert(static_cast<unsigned>(CppClingo::HeuristicType::init) ==
                       static_cast<unsigned>(Clasp::DomModType::init));
         static_assert(static_cast<unsigned>(CppClingo::HeuristicType::factor) ==
@@ -97,7 +102,7 @@ class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
                       static_cast<unsigned>(Clasp::DomModType::sign));
         static_assert(static_cast<unsigned>(CppClingo::HeuristicType::true_) ==
                       static_cast<unsigned>(Clasp::DomModType::true_));
-        prg_->heuristic(atom, static_cast<Clasp::DomModType>(type), weight, prio, body);
+        prg_->heuristic(as_atom_(atom), static_cast<Clasp::DomModType>(type), weight, prio, as_lits_(body));
     }
 
     void do_external(prg_lit_t atom, ExternalType type) override {
@@ -107,12 +112,12 @@ class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
                       static_cast<unsigned>(Potassco::TruthValue::false_));
         static_assert(static_cast<unsigned>(ExternalType::release) ==
                       static_cast<unsigned>(Potassco::TruthValue::release));
-        prg_->external(atom, static_cast<Potassco::TruthValue>(type));
+        prg_->external(as_atom_(atom), static_cast<Potassco::TruthValue>(type));
     }
 
     void do_project(PrgLitSpan atoms) override { prg_->project(as_atoms_(atoms)); }
 
-    void do_assume(PrgLitSpan literals) override { prg_->assume(literals); }
+    void do_assume(PrgLitSpan literals) override { prg_->assume(as_lits_(literals)); }
 
     void do_minimize(prg_weight_t priority, WeightedPrgLitSpan body) override {
         prg_->minimize(priority, as_wlits_(body));
@@ -124,17 +129,16 @@ class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
     }
 
     void do_show_term(Symbol sym, PrgLitSpan body) override {
-        show_term(term_id(sym), body);
+        show_term(term_id(sym), as_lits_(body));
 #ifdef DEBUG_BACKEND
         std::cerr << "#show " << sym << " : " << Util::p_range(body, ", ") << ".\n";
 #endif
     }
 
-    void do_show_term(prg_id_t id, PrgLitSpan body) override { prg_->output(id, body); }
+    void do_show_term(prg_id_t id, PrgLitSpan body) override { prg_->output(id, as_lits_(body)); }
 
     void do_show_atom(Symbol sym, prg_lit_t lit) override {
-        assert(lit > 0);
-        prg_->outputAtom(lit, as_str(sym));
+        prg_->outputAtom(as_atom_(lit), as_str(sym));
 #ifdef DEBUG_BACKEND
         std::cerr << "#show " << sym << " : " << lit << ".\n";
 #endif
@@ -167,7 +171,9 @@ class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
                          args);
     }
 
-    void do_elem(prg_id_t id, PrgIdSpan terms, PrgLitSpan cond) override { prg_->theoryElement(id, terms, cond); }
+    void do_elem(prg_id_t id, PrgIdSpan terms, PrgLitSpan cond) override {
+        prg_->theoryElement(id, terms, as_lits_(cond));
+    }
 
 #ifdef DEBUG_BACKEND
     void print(Potassco::TheoryTerm const &term) {
@@ -217,10 +223,11 @@ class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
 
     void do_atom(prg_lit_t lit_or_zero, prg_id_t name, PrgIdSpan elems,
                  std::optional<std::pair<prg_id_t, prg_id_t>> guard) override {
+        auto atom_or_zero = lit_or_zero != 0 ? as_atom_(lit_or_zero) : 0;
         if (guard) {
-            prg_->theoryAtom(lit_or_zero, name, elems, guard->first, guard->second);
+            prg_->theoryAtom(atom_or_zero, name, elems, guard->first, guard->second);
         } else {
-            prg_->theoryAtom(lit_or_zero, name, elems);
+            prg_->theoryAtom(atom_or_zero, name, elems);
         }
 #ifdef DEBUG_BACKEND
         std::cerr << lit_or_zero << " <> ";
@@ -229,16 +236,40 @@ class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
 #endif
     }
 
+    auto do_next_lit() -> prg_lit_t override {
+        if (max_lit_ < prg_lit_max) {
+            return ++max_lit_;
+        }
+        throw std::range_error("number of literals exhausted");
+    }
+
   private:
     virtual auto do_term_id(Symbol sym) -> prg_id_t = 0;
 
     virtual void do_term_id(Symbol sym, prg_id_t id) = 0;
 
+    auto as_atom_(prg_lit_t lit) -> Potassco::Atom_t {
+        assert(lit > 0 && lit <= prg_lit_max);
+        max_lit_ = std::max(max_lit_, lit);
+        return lit;
+    }
+
+    auto as_lit_(prg_lit_t lit) -> Potassco::Lit_t {
+        assert(lit != 0 && lit >= prg_lit_min && lit <= prg_lit_max);
+        max_lit_ = std::max(max_lit_, std::abs(lit));
+        return lit;
+    }
+    auto as_lits_(PrgLitSpan body) -> Potassco::LitSpan {
+        for (auto lit : body) {
+            as_lit_(lit);
+        }
+        return body;
+    }
+
     auto as_atoms_(PrgLitSpan lits) -> Potassco::AtomSpan {
         atoms_.clear();
         for (auto const &lit : lits) {
-            assert(lit > 0);
-            atoms_.push_back(lit);
+            atoms_.push_back(as_atom_(lit));
         }
         return atoms_;
     }
@@ -246,8 +277,7 @@ class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
     auto as_wlits_(WeightedPrgLitSpan wlits) -> Potassco::WeightLitSpan {
         wlits_.clear();
         for (auto const &[lit, weight] : wlits) {
-            assert(lit != 0);
-            wlits_.emplace_back(lit, weight);
+            wlits_.emplace_back(as_lit_(lit), weight);
         }
         return wlits_;
     }
@@ -256,6 +286,7 @@ class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
     Util::OutputBuffer buf_;
     std::vector<Potassco::Atom_t> atoms_;
     std::vector<Potassco::WeightLit> wlits_;
+    prg_lit_t max_lit_{0};
 };
 
 class PotasscoBackend : public AbstractProgramBackendImpl {
@@ -264,19 +295,8 @@ class PotasscoBackend : public AbstractProgramBackendImpl {
         : AbstractProgramBackendImpl{prg}, terms_{&terms} {}
 
   private:
-    auto do_next_lit() -> prg_lit_t override {
-        if (auto lit = next_atom_++; std::cmp_less_equal(lit, prg_lit_max)) {
-            return static_cast<prg_lit_t>(lit);
-        }
-        throw std::range_error("number of literals exhausted");
-    }
-
     auto do_fact_lit() -> std::optional<prg_lit_t> override {
-        if (fact_ == 0) {
-            fact_ = do_next_lit();
-            program().rule(Potassco::HeadType::disjunctive, Potassco::toSpan(fact_), {});
-        }
-        return fact_;
+        return fact_ != 0 ? std::optional{static_cast<prg_lit_t>(fact_)} : std::nullopt;
     }
 
     void do_rule(PrgLitSpan head, PrgLitSpan body, bool choice) override {
@@ -288,17 +308,22 @@ class PotasscoBackend : public AbstractProgramBackendImpl {
 
     auto do_term_id(Symbol sym) -> prg_id_t override {
         return terms_->add(sym, [&]() {
-            auto nId = next_show_term_++;
-            program().outputTerm(nId, as_str(sym));
-            return nId;
+            if (max_term_id_ < std::numeric_limits<prg_id_t>::max()) {
+                auto ret = max_term_id_++;
+                program().outputTerm(ret, as_str(sym));
+                return ret;
+            }
+            throw std::range_error("number of terms exhausted");
         });
     }
 
-    void do_term_id(Symbol sym, prg_id_t id) override { terms_->add(sym, id); }
+    void do_term_id(Symbol sym, prg_id_t id) override {
+        terms_->add(sym, id);
+        max_term_id_ = std::max(max_term_id_, id);
+    }
 
-    Potassco::Atom_t next_atom_{1};
     prg_id_t fact_{0};
-    prg_id_t next_show_term_{0};
+    prg_id_t max_term_id_{0};
     TermBaseMap *terms_;
 };
 

--- a/lib/core/include/clingo/core/backend.hh
+++ b/lib/core/include/clingo/core/backend.hh
@@ -42,6 +42,8 @@ using WeightedPrgLitSpan = std::span<std::pair<prg_lit_t, prg_weight_t> const>;
 //! A vector of program literals.
 using WeightedPrgLitVec = std::vector<std::pair<prg_lit_t, prg_weight_t>>;
 
+//! The maximum id.
+static constexpr auto prg_id_max = std::numeric_limits<prg_id_t>::max() - 1;
 //! The maximum literal.
 static constexpr auto prg_lit_max = std::numeric_limits<prg_lit_t>::max();
 //! The minimum literal.

--- a/lib/input/src/parse/aspif.cc
+++ b/lib/input/src/parse/aspif.cc
@@ -182,9 +182,18 @@ class AspifParser {
         return res;
     }
 
+    auto expect_id_() -> prg_id_t {
+        auto m = expect_unsigned_();
+        if (m > prg_id_max) {
+            CLINGO_REPORT_LOC(state_->log(), error, state_->loc()) << "invalid program id";
+            throw aspif_error{};
+        }
+        return static_cast<prg_id_t>(m);
+    }
+
     auto expect_atom_() -> prg_lit_t {
         auto m = static_cast<prg_lit_t>(expect_unsigned_());
-        if (m <= 0) {
+        if (m <= 0 || m > prg_lit_max) {
             CLINGO_REPORT_LOC(state_->log(), error, state_->loc()) << "invalid program atom";
             throw aspif_error{};
         }
@@ -203,19 +212,19 @@ class AspifParser {
     }
 
     auto expect_ids_() -> PrgIdVec {
-        auto m = expect_unsigned_();
+        auto m = expect_id_();
         auto ids = PrgIdVec{};
         ids.reserve(m);
         for (unsigned i = 0; i < m; ++i) {
             expect_(AspifToken::space);
-            ids.emplace_back(expect_unsigned_());
+            ids.emplace_back(expect_id_());
         }
         return ids;
     }
 
     auto expect_lit_() -> prg_lit_t {
         auto lit = expect_signed_();
-        if (lit == 0) {
+        if (lit == 0 || lit > prg_lit_max || lit < prg_lit_min) {
             CLINGO_REPORT_LOC(state_->log(), error, state_->loc()) << "invalid program literal";
             throw aspif_error{};
         }
@@ -385,14 +394,14 @@ class AspifParser {
                 break;
             }
             case OutputType::term: {
-                auto term = expect_unsigned_();
+                auto term = expect_id_();
                 expect_(AspifToken::space);
                 auto sym = output_symbol_();
                 state_->prg_backend()->show_term(*sym, term);
                 break;
             }
             case OutputType::term_cnd: {
-                auto term = expect_unsigned_();
+                auto term = expect_id_();
                 expect_(AspifToken::space);
                 auto body = expect_lits_();
                 state_->prg_backend()->show_term(term, body);
@@ -406,7 +415,7 @@ class AspifParser {
     void output_symbols_() {
         auto type = output_type_(OutputType::term_fun);
         expect_(AspifToken::space);
-        auto sym_id = expect_unsigned_();
+        auto sym_id = expect_id_();
         auto add = [this, sym_id]<class T>(T &&sym) {
             if (sym_id < symbols_.size()) {
                 symbols_[sym_id] = SharedSymbol{std::forward<T>(sym)};
@@ -436,7 +445,7 @@ class AspifParser {
             case OutputType::term: {
                 auto sym = get(sym_id);
                 expect_(AspifToken::space);
-                auto id = expect_unsigned_();
+                auto id = expect_id_();
                 state_->prg_backend()->show_term(*sym, id);
                 break;
             }
@@ -487,7 +496,7 @@ class AspifParser {
                     throw aspif_error{};
                 }
                 expect_(AspifToken::space);
-                auto name = get(expect_unsigned_());
+                auto name = get(expect_id_());
                 if (name->type() != SymbolType::string) {
                     CLINGO_REPORT_LOC(state_->log(), error, state_->loc())
                         << "expected string instead of `" << *name << "`";
@@ -544,9 +553,9 @@ class AspifParser {
     }
 
     void edge_() {
-        auto u = expect_unsigned_();
+        auto u = expect_id_();
         expect_(AspifToken::space);
-        auto v = expect_unsigned_();
+        auto v = expect_id_();
         expect_(AspifToken::space);
         state_->prg_backend()->edge(u, v, expect_lits_());
     }
@@ -561,13 +570,13 @@ class AspifParser {
     }
 
     void theory_number_() {
-        auto id = expect_unsigned_();
+        auto id = expect_id_();
         expect_(AspifToken::space);
         auto num = expect_signed_();
         state_->thy_backend()->num(id, num);
     }
     void theory_symbol_() {
-        auto id = expect_unsigned_();
+        auto id = expect_id_();
         expect_(AspifToken::space);
         auto num = expect_nstr_();
         state_->thy_backend()->str(id, num);
@@ -582,7 +591,7 @@ class AspifParser {
     }
 
     void theory_compound_() {
-        auto id = expect_unsigned_();
+        auto id = expect_id_();
         expect_(AspifToken::space);
         auto type = expect_signed_();
         expect_(AspifToken::space);
@@ -594,7 +603,7 @@ class AspifParser {
         }
     }
     void theory_element_() {
-        auto id = expect_unsigned_();
+        auto id = expect_id_();
         expect_(AspifToken::space);
         auto tuple = expect_ids_();
         expect_(AspifToken::space);
@@ -605,15 +614,15 @@ class AspifParser {
     void theory_atom_(bool parse_guard) {
         auto atom = expect_signed_();
         expect_(AspifToken::space);
-        auto name = expect_unsigned_();
+        auto name = expect_id_();
         expect_(AspifToken::space);
         auto elems = expect_ids_();
         auto guard = std::optional<std::pair<prg_id_t, prg_id_t>>{};
         if (parse_guard) {
             expect_(AspifToken::space);
-            auto op = expect_unsigned_();
+            auto op = expect_id_();
             expect_(AspifToken::space);
-            auto term = expect_unsigned_();
+            auto term = expect_id_();
             guard.emplace(op, term);
         }
         state_->thy_backend()->atom(atom, name, elems, guard);

--- a/lib/python-api/tests/test_write_aspif.py
+++ b/lib/python-api/tests/test_write_aspif.py
@@ -106,6 +106,37 @@ class TestWriteAspif:
         self.ctl.solve(on_model=mcb)
         assert mcb.symbols == [["a"], ["a", "b", "c"]]
 
+    def test_buffer_inc(self):
+        """
+        Test writing aspif to a buffer and parsing it again.
+        """
+        ctl = Control(self.lib, ["--convert", "aspif"])
+        ctl.parse_string("""\
+asp 1 0 0
+1 1 1 1 0 0
+4 1 a 1 1
+4 1 b 0
+0
+""")
+        ctl.parse_string("""{c}. #show d : a, c.""")
+        ctl.ground()
+        ctl.solve()
+        assert (
+            ctl.buffer
+            == """\
+asp 2 0 0 incremental
+1 1 1 1 0 0
+4 1 0 1 b
+4 2 0 0
+4 0 1 1 a
+1 1 1 2 0 0
+4 1 1 1 d
+4 2 1 2 1 2
+4 0 2 1 c
+0
+"""
+        )
+
     def test_rule(self):
         """
         Test rules.


### PR DESCRIPTION
This PR fixes ID tracking when parsing/forwarding ASPIF programs so that subsequent grounding steps allocate fresh literal/term IDs without collisions, and adds a regression test for incremental ASPIF conversion:

- Track maximum literal by updating internal counters whenever existing atoms/literals are encountered (rules, assumptions, outputs, theory conditions, etc.).
- Track maximum term id for output terms so IDs remain consistent across parse + later grounding.
- Add a Python test covering an incremental ASPIF parse followed by additional grounding and verifying the produced ASPIF.