### PR TITLE
add test under cygwin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,3 +70,75 @@ jobs:
           clingo --version
           clasp --version
           lpconvert --version
+
+  cygwin-test:
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        re2c_version: [4.5]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
+      - name: Setup cygwin
+        uses: egor-tensin/setup-cygwin@v4
+        with:
+          packages: cmake python312 python312-devel python312-pytest ninja make gcc-g++ doxygen
+
+      - name: Download re2c
+        run: |
+          Invoke-WebRequest https://github.com/skvadrik/re2c/releases/download/${{ matrix.re2c_version }}/re2c-${{ matrix.re2c_version }}.tar.xz -OutFile re2c-${{ matrix.re2c_version }}.tar.xz
+          tar xf re2c-${{ matrix.re2c_version }}.tar.xz
+
+      - name: Configure re2c
+        run: >
+          cmake -S re2c-${{ matrix.re2c_version }} -B build_re2c -G "Ninja Multi-Config"
+          -DRE2C_BUILD_RE2D=no
+          -DRE2C_BUILD_RE2GO=no
+          -DRE2C_BUILD_RE2HS=no
+          -DRE2C_BUILD_RE2JAVA=no
+          -DRE2C_BUILD_RE2JS=no
+          -DRE2C_BUILD_RE2OCAML=no
+          -DRE2C_BUILD_RE2PY=no
+          -DRE2C_BUILD_RE2RUST=no
+          -DRE2C_BUILD_RE2SWIFT=no
+          -DRE2C_BUILD_RE2V=no
+          -DRE2C_BUILD_RE2ZIG=no
+
+      - name: Build re2c
+        run: |
+          cmake --build build_re2c --config Release
+
+      - name: Install re2c
+        run: |
+          cmake --install build_re2c --config Release
+
+      - name: Configure clingo
+        run: >
+          cmake -S . -B build -G "Ninja Multi-Config"
+          -DPYTEST_EXECUTABLE="/usr/bin/pytest-3.12"
+          -DCLINGO_BUILD_TESTS=On
+          -DCLINGO_BUILD_APP=On
+          -DCLINGO_BUILD_EXAMPLES=On
+          -DCLASP_BUILD_TESTS=On
+          -DCLASP_BUILD_EXAMPLES=On
+          -DLIB_POTASSCO_BUILD_TESTS=On
+
+      - name: Build clingo
+        run: |
+          $env:PATH = "$($PWD.Path)\build\bin\Release;$env:PATH"
+          cmake --build build --config Release
+
+      - name: Test clingo
+        run: |
+          $env:PATH = "$($PWD.Path)\build\bin\Release;$env:PATH"
+          ctest --test-dir build -C Release --output-on-failure
+
+      - name: Install clingo
+        run: |
+          cmake --install build --config Release
+          clingo --version
+          clasp --version
+          lpconvert --version

--- a/lib/python-api/CMakeLists.txt
+++ b/lib/python-api/CMakeLists.txt
@@ -48,7 +48,7 @@ add_library(clingo-python STATIC)
 target_sources(clingo-python PRIVATE ${source})
 clingo_target_properties(TARGETS clingo-python FOLDER lib)
 target_compile_definitions(clingo-python PRIVATE CLINGO_PYTHON_VERSION="${Python_VERSION}")
-target_link_libraries(clingo-python PRIVATE pybind11::pybind11 clingo)
+target_link_libraries(clingo-python PRIVATE clingo pybind11::pybind11)
 
 # the standalone module
 pybind11_add_module(pyclingo "src/module.cc")
@@ -109,7 +109,7 @@ if(CLINGO_BUILD_APP)
     clingo_target_properties(TARGETS clingo-python-embed FOLDER lib TYPE extra)
     target_include_directories(clingo-python-embed PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
     target_compile_definitions(clingo-python-embed PUBLIC CLINGO_PYTHON_ENABLED)
-    target_link_libraries(clingo-python-embed PRIVATE pybind11::embed clingo clingo-python)
+    target_link_libraries(clingo-python-embed PRIVATE clingo clingo-python pybind11::embed)
 
     target_compile_definitions(clingo-python PUBLIC CLINGO_PYTHON_EMBED)
 endif()


### PR DESCRIPTION
Adds a new CI job to build and run the project’s test suite under Cygwin on GitHub Actions, and adjusts link-library ordering in the Python API CMake targets to correctly reflect library dependencies:

- Reordered `target_link_libraries(...)` entries for `clingo-python` and `clingo-python-embed`.
- Added a new `cygwin-test` job to `.github/workflows/test.yml` that installs Cygwin packages, builds `re2c`, then configures/builds/tests/installs the project.

I did not find a way to nicely set the PATH for the test jobs. The workflow contains a small hack setting the required path for testing in the surrounding environment.