### PR TITLE
`Windows.h` -> `windows.h` for cross-compiling with MinGW

### DIFF
--- a/libgringo/gringo/shared_mutex.hh
+++ b/libgringo/gringo/shared_mutex.hh
@@ -19,7 +19,7 @@
 #if GRINGO_PLATFORM_WINDOWS
 #define WIN32_LEAN_AND_MEAN
 #define NOMINMAX
-#include <Windows.h>
+#include <windows.h>
 #elif GRINGO_PLATFORM_POSIX
 #include <pthread.h>
 #else


### PR DESCRIPTION
Without this change, cross-compilation with MinGW fails because the file is actually `windows.h` and Linux file systems are case-sensitive. The build was successful on Windows because its file system is not case-sensitive.

### Checklist

**Please only open Pull Requests against the wip branch**

- [x] Have you followed the guidelines in our [CONTRIBUTING.md](/potassco/clingo/blob/master/CONTRIBUTING.md) document?
- [x] Have you checked to ensure there aren't other open Pull Requests for the same update/change?
- [ ] Have you made sure that all tests succeed?
