### PR TITLE
Add missing standard includes for libc++

### DIFF
--- a/lib/cxx-api/include/clingo/control.hh
+++ b/lib/cxx-api/include/clingo/control.hh
@@ -15,6 +15,7 @@
 #include <clingo/control.h>
 
 #include <cassert>
+#include <exception>
 #include <optional>
 #include <span>
 

--- a/lib/cxx-api/include/clingo/core.hh
+++ b/lib/cxx-api/include/clingo/core.hh
@@ -10,6 +10,8 @@
 #include <memory>
 #include <span>
 #include <stdexcept>
+#include <string>
+#include <string_view>
 #include <utility>
 #include <vector>
 

--- a/lib/util/include/clingo/util/hash.hh
+++ b/lib/util/include/clingo/util/hash.hh
@@ -5,10 +5,13 @@
 #include <clingo/util/small_vector.hh>
 
 #include <cstring>
+#include <functional>
 #include <memory>
 #include <numeric>
 #include <optional>
 #include <span>
+#include <string>
+#include <string_view>
 #include <typeinfo>
 #include <variant>
 #include <vector>


### PR DESCRIPTION
util/hash.hh, cxx-api/core.hh, and cxx-api/control.hh use std::string, std::string_view, std::hash, and std::exception but were only getting those headers transitively. Current libc++ no longer provides them that way, so wip-20 fails to build with an up-to-date clang/libc++. This adds the explicit includes — no behavior change.

Note: this pairs with companion PRs adding the same fix to clasp (https://github.com/potassco/clasp/pull/119) and libpotassco (https://github.com/potassco/libpotassco/pull/19). clingo builds against the clasp commit it pins, so those need to land first for clingo's own CI to go fully green.