### PR TITLE
Fix small_vector::capacity() reporting size instead of capacity

### DIFF
--- a/lib/util/CMakeLists.txt
+++ b/lib/util/CMakeLists.txt
@@ -31,9 +31,10 @@ set(header
 # [[[test: tests
 set(ide_test_group "Test Files")
 set(test-group
-    "tests/interval_set.cc"
     "tests/index_sequence.cc"
-    "tests/record.cc")
+    "tests/interval_set.cc"
+    "tests/record.cc"
+    "tests/small_vector.cc")
 source_group("${ide_test_group}" FILES ${test-group})
 set(test
     ${test-group})

--- a/lib/util/include/clingo/util/small_vector.hh
+++ b/lib/util/include/clingo/util/small_vector.hh
@@ -72,7 +72,7 @@ class small_vector {
         } else {
             std::ranges::copy(first, last, std::back_inserter(*this));
         }
-        check_invariant_();
+        assert(check_());
     }
 
     //! Copy assign the vector.
@@ -98,7 +98,7 @@ class small_vector {
                 std::ranges::swap(cap_large_(), other.cap_large_());
             }
         }
-        check_invariant_();
+        assert(check_());
         return *this;
     }
 
@@ -206,7 +206,7 @@ class small_vector {
             end_large_() = std::ranges::next(begin_large_(), l);
             cap_large_() = std::ranges::next(begin_large_(), n);
         }
-        check_invariant_();
+        assert(check_());
     }
 
     //! Get the first element in the vector.
@@ -242,7 +242,7 @@ class small_vector {
         } else {
             std::ranges::advance(end_large_(), -1);
         }
-        check_invariant_();
+        assert(check_());
         return it;
     }
 
@@ -258,7 +258,7 @@ class small_vector {
                 std::ranges::advance(last, -n);
             }
         }
-        check_invariant_();
+        assert(check_());
         return last;
     }
 
@@ -278,7 +278,7 @@ class small_vector {
         } else {
             std::ranges::advance(end_large_(), 1);
         }
-        check_invariant_();
+        assert(check_());
     }
 
     //! Emplace an element after the last element.
@@ -290,7 +290,7 @@ class small_vector {
         } else {
             std::advance(end_large_(), 1);
         }
-        check_invariant_();
+        assert(check_());
     }
 
     //! Append an element after the last element.
@@ -305,7 +305,7 @@ class small_vector {
         } else {
             std::advance(end_large_(), -1);
         }
-        check_invariant_();
+        assert(check_());
     }
 
     //! Clear the vector.
@@ -314,7 +314,7 @@ class small_vector {
     void clear() noexcept {
         destroy_();
         begin_ = 1;
-        check_invariant_();
+        assert(check_());
     }
 
     //! Deconstruct the vector.
@@ -349,19 +349,15 @@ class small_vector {
     [[nodiscard]] auto size_small_() const -> size_t { return begin_ >> 1; }
     [[nodiscard]] auto size_small_(size_t n) { begin_ = (n << 1) | 1; }
 
-    //! Assert the storage invariant that every mutator must preserve: in the
-    //! large state `begin <= end <= cap`, i.e. `size() <= capacity()`; in the
-    //! small state `size() <= N`. Checked directly on the raw boundary pointers
-    //! -- not through size()/capacity() -- so that an end/cap mix-up in a reader
-    //! cannot hide from it. Debug-only: expands to nothing under -DNDEBUG.
-    void check_invariant_() const {
+#ifndef NDEBUG
+    //! Check begin/end/capacity invariant.
+    [[nodiscard]] auto check_() const -> bool {
         if (is_small_()) {
-            assert(size_small_() <= N);
-        } else {
-            assert(begin_large_() <= end_large_());
-            assert(end_large_() <= cap_large_());
+            return size_small_() <= N;
         }
+        return begin_large_() <= end_large_() && end_large_() <= cap_large_();
     }
+#endif
 
     void destroy_() noexcept {
         std::destroy(begin(), end());

--- a/lib/util/include/clingo/util/small_vector.hh
+++ b/lib/util/include/clingo/util/small_vector.hh
@@ -72,6 +72,7 @@ class small_vector {
         } else {
             std::ranges::copy(first, last, std::back_inserter(*this));
         }
+        check_invariant_();
     }
 
     //! Copy assign the vector.
@@ -97,6 +98,7 @@ class small_vector {
                 std::ranges::swap(cap_large_(), other.cap_large_());
             }
         }
+        check_invariant_();
         return *this;
     }
 
@@ -113,6 +115,10 @@ class small_vector {
     }
 
     //! Get the size of the vector.
+    //!
+    //! In the large state this is the distance from the buffer start to the
+    //! `end` boundary -- contrast capacity(), which measures to the `cap`
+    //! boundary.
     [[nodiscard]] auto size() const -> size_t {
         if (is_small_()) {
             return size_small_();
@@ -124,11 +130,15 @@ class small_vector {
     [[nodiscard]] auto empty() const -> bool { return size() == 0; }
 
     //! Get the capacity of the vector.
+    //!
+    //! In the large state this is the distance from the buffer start to the
+    //! `cap` boundary -- the allocated space -- not the `end` boundary that
+    //! size() reads.
     [[nodiscard]] auto capacity() const -> size_t {
         if (is_small_()) {
             return N;
         }
-        return std::ranges::distance(begin_large_(), end_large_());
+        return std::ranges::distance(begin_large_(), cap_large_());
     }
 
     //! Get an iterator to the beginning of the vector.
@@ -196,6 +206,7 @@ class small_vector {
             end_large_() = std::ranges::next(begin_large_(), l);
             cap_large_() = std::ranges::next(begin_large_(), n);
         }
+        check_invariant_();
     }
 
     //! Get the first element in the vector.
@@ -231,6 +242,7 @@ class small_vector {
         } else {
             std::ranges::advance(end_large_(), -1);
         }
+        check_invariant_();
         return it;
     }
 
@@ -246,6 +258,7 @@ class small_vector {
                 std::ranges::advance(last, -n);
             }
         }
+        check_invariant_();
         return last;
     }
 
@@ -265,6 +278,7 @@ class small_vector {
         } else {
             std::ranges::advance(end_large_(), 1);
         }
+        check_invariant_();
     }
 
     //! Emplace an element after the last element.
@@ -276,6 +290,7 @@ class small_vector {
         } else {
             std::advance(end_large_(), 1);
         }
+        check_invariant_();
     }
 
     //! Append an element after the last element.
@@ -290,6 +305,7 @@ class small_vector {
         } else {
             std::advance(end_large_(), -1);
         }
+        check_invariant_();
     }
 
     //! Clear the vector.
@@ -298,6 +314,7 @@ class small_vector {
     void clear() noexcept {
         destroy_();
         begin_ = 1;
+        check_invariant_();
     }
 
     //! Deconstruct the vector.
@@ -331,6 +348,20 @@ class small_vector {
     [[nodiscard]] auto is_small_() const -> bool { return (begin_ & 1) != 0; }
     [[nodiscard]] auto size_small_() const -> size_t { return begin_ >> 1; }
     [[nodiscard]] auto size_small_(size_t n) { begin_ = (n << 1) | 1; }
+
+    //! Assert the storage invariant that every mutator must preserve: in the
+    //! large state `begin <= end <= cap`, i.e. `size() <= capacity()`; in the
+    //! small state `size() <= N`. Checked directly on the raw boundary pointers
+    //! -- not through size()/capacity() -- so that an end/cap mix-up in a reader
+    //! cannot hide from it. Debug-only: expands to nothing under -DNDEBUG.
+    void check_invariant_() const {
+        if (is_small_()) {
+            assert(size_small_() <= N);
+        } else {
+            assert(begin_large_() <= end_large_());
+            assert(end_large_() <= cap_large_());
+        }
+    }
 
     void destroy_() noexcept {
         std::destroy(begin(), end());

--- a/lib/util/tests/small_vector.cc
+++ b/lib/util/tests/small_vector.cc
@@ -21,20 +21,20 @@ TEST_CASE("small_vector capacity", "[base]") {
             REQUIRE(v.capacity() >= v.size());
         }
         REQUIRE(v.size() == 4);
-        REQUIRE(v.capacity() == 4);      // still in the small buffer
-        REQUIRE(v.data() == buffer);     // no allocation while size <= N
+        REQUIRE(v.capacity() == 4);
+        REQUIRE(v.data() == buffer);
     }
 
     SECTION("large state: capacity reflects the requested reserve") {
-        small_vector<int> v; // N == 2
+        small_vector<int> v;
         v.reserve(100);
-        REQUIRE(v.capacity() >= 100);    // the bug reported size (0) here
+        REQUIRE(v.capacity() >= 100);
         REQUIRE(v.capacity() >= v.size());
         REQUIRE(v.size() == 0);
     }
 
     SECTION("capacity() >= size() across the small -> large crossover") {
-        small_vector<int> v; // N == 2, so the third element forces a heap buffer
+        small_vector<int> v;
         for (int i = 0; i < 64; ++i) {
             v.push_back(i);
             REQUIRE(v.capacity() >= v.size());
@@ -45,13 +45,9 @@ TEST_CASE("small_vector capacity", "[base]") {
 }
 
 TEST_CASE("small_vector reserve prevents reallocation", "[base]") {
-    // The direct regression for the capacity() == size() bug: once space is
-    // reserved, filling up to that capacity must not reallocate. With the bug
-    // capacity() reported size(), so reserve() was defeated and the first
-    // push_back reallocated -- moving the storage out from under `reserved`.
     constexpr std::size_t count = 100;
 
-    small_vector<int> v; // N == 2
+    small_vector<int> v;
     v.reserve(count);
     auto const *reserved = v.data();
 
@@ -60,11 +56,11 @@ TEST_CASE("small_vector reserve prevents reallocation", "[base]") {
     }
 
     REQUIRE(v.size() == count);
-    REQUIRE(v.data() == reserved); // storage never moved
+    REQUIRE(v.data() == reserved);
     REQUIRE(v.capacity() >= count);
 
     for (std::size_t i = 0; i < count; ++i) {
-        REQUIRE(v[i] == static_cast<int>(i)); // elements intact
+        REQUIRE(v[i] == static_cast<int>(i));
     }
 }
 

--- a/lib/util/tests/small_vector.cc
+++ b/lib/util/tests/small_vector.cc
@@ -1,0 +1,73 @@
+#include "clingo/util/small_vector.hh"
+
+#include <catch2/catch_test_macros.hpp>
+
+#include <cstddef>
+
+namespace CppClingo::Util::Test {
+
+// NOLINTBEGIN(readability-magic-numbers)
+
+TEST_CASE("small_vector capacity", "[base]") {
+    SECTION("small state: capacity is N and holds N elements without allocating") {
+        small_vector<int, 4> v;
+        REQUIRE(v.size() == 0);
+        REQUIRE(v.capacity() == 4);
+        REQUIRE(v.capacity() >= v.size());
+
+        auto const *buffer = v.data();
+        for (int i = 0; i < 4; ++i) {
+            v.push_back(i);
+            REQUIRE(v.capacity() >= v.size());
+        }
+        REQUIRE(v.size() == 4);
+        REQUIRE(v.capacity() == 4);      // still in the small buffer
+        REQUIRE(v.data() == buffer);     // no allocation while size <= N
+    }
+
+    SECTION("large state: capacity reflects the requested reserve") {
+        small_vector<int> v; // N == 2
+        v.reserve(100);
+        REQUIRE(v.capacity() >= 100);    // the bug reported size (0) here
+        REQUIRE(v.capacity() >= v.size());
+        REQUIRE(v.size() == 0);
+    }
+
+    SECTION("capacity() >= size() across the small -> large crossover") {
+        small_vector<int> v; // N == 2, so the third element forces a heap buffer
+        for (int i = 0; i < 64; ++i) {
+            v.push_back(i);
+            REQUIRE(v.capacity() >= v.size());
+        }
+        REQUIRE(v.size() == 64);
+        REQUIRE(v.capacity() >= 64);
+    }
+}
+
+TEST_CASE("small_vector reserve prevents reallocation", "[base]") {
+    // The direct regression for the capacity() == size() bug: once space is
+    // reserved, filling up to that capacity must not reallocate. With the bug
+    // capacity() reported size(), so reserve() was defeated and the first
+    // push_back reallocated -- moving the storage out from under `reserved`.
+    constexpr std::size_t count = 100;
+
+    small_vector<int> v; // N == 2
+    v.reserve(count);
+    auto const *reserved = v.data();
+
+    for (std::size_t i = 0; i < count; ++i) {
+        v.push_back(static_cast<int>(i));
+    }
+
+    REQUIRE(v.size() == count);
+    REQUIRE(v.data() == reserved); // storage never moved
+    REQUIRE(v.capacity() >= count);
+
+    for (std::size_t i = 0; i < count; ++i) {
+        REQUIRE(v[i] == static_cast<int>(i)); // elements intact
+    }
+}
+
+// NOLINTEND(readability-magic-numbers)
+
+} // namespace CppClingo::Util::Test


### PR DESCRIPTION
In the heap-allocated state `capacity()` returned the distance to `end` -- the
same value as `size()` -- instead of the distance to the capacity pointer.
`reserve()` consults `capacity()`, so a reserve was defeated: the container
reallocated on nearly every growth even when it already had room. The stored
capacity pointer was correct; only the reader was wrong.

Fixes the read, adds a debug-only invariant (`begin <= end <= cap`, i.e.
`size() <= capacity()`) checked at every mutation so the confusion can't
silently return, and adds regression tests (capacity >= size across
transitions; no reallocation when reserved capacity suffices).
