### PR TITLE
Make signed/unsigned conversions in the grounder explicit

### DIFF
--- a/app/main.cc
+++ b/app/main.cc
@@ -40,7 +40,7 @@ auto main(int argc, char *argv[]) -> int {
 #endif
     auto args = std::vector<clingo_string_t>{};
     try {
-        args.reserve(argc - 1);
+        args.reserve(static_cast<size_t>(argc - 1));
         // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-pointer-arithmetic)
         std::ranges::transform(std::span{argv + 1, static_cast<size_t>(argc - 1)}, std::back_inserter(args),
                                [](auto const &x) { return clingo_string_t{x, strlen(x)}; });

--- a/lib/c-api/src/ast.cc
+++ b/lib/c-api/src/ast.cc
@@ -2946,7 +2946,7 @@ extern "C" auto clingo_ast_rewrite(clingo_ast_rewrite_context_t *context, clingo
         auto stm = convert<Stm>(statement);
         rewrite(context->ctx, stm, stms);
         ASTVec res{stms.size()};
-        int i = 0;
+        size_t i = 0;
         for (auto &stm : stms) {
             if (auto res_stm = unmap_params(*lib->store, context->param_unmap, stm); res_stm) {
                 stm = *std::move(res_stm);

--- a/lib/c-api/src/backend.cc
+++ b/lib/c-api/src/backend.cc
@@ -193,7 +193,8 @@ extern "C" auto clingo_backend_acyc_edge(clingo_backend_t *backend, int node_u, 
         if (backend == nullptr || (condition == nullptr && size > 0)) {
             return fail_arguments();
         }
-        get_program(backend).addAcycEdge(node_u, node_v, std::span{condition, size});
+        get_program(backend).addAcycEdge(static_cast<uint32_t>(node_u), static_cast<uint32_t>(node_v),
+                                         std::span{condition, size});
     }
     CLINGO_CATCH;
 }
@@ -204,7 +205,9 @@ extern "C" auto clingo_backend_add_atom(clingo_backend_t *backend, clingo_symbol
         if (backend == nullptr || atom == nullptr) {
             return fail_arguments();
         }
-        *atom = symbol != nullptr ? cpp_cast(backend)->add_atom(*cpp_cast(symbol)) : get_program(backend).newAtom();
+        // add_atom / newAtom yield fresh positive atom ids
+        *atom = symbol != nullptr ? static_cast<clingo_atom_t>(cpp_cast(backend)->add_atom(*cpp_cast(symbol)))
+                                  : get_program(backend).newAtom();
     }
     CLINGO_CATCH;
 }
@@ -293,9 +296,10 @@ extern "C" auto clingo_backend_theory_atom(clingo_backend_t *backend, clingo_sym
             op = get_store(backend).string(std::string_view{operator_name->data, operator_name->size});
             guard.emplace(*op, right_hand_side_id);
         }
-        *atom_out =
+        // theory atom() returns a fresh positive atom id
+        *atom_out = static_cast<clingo_atom_t>(
             get_theory(backend).atom([&]() { return atom_in != nullptr ? *atom_in : get_program(backend).newAtom(); },
-                                     *cpp_cast(&name), std::span{elements, size}, std::move(guard));
+                                     *cpp_cast(&name), std::span{elements, size}, std::move(guard)));
     }
     CLINGO_CATCH;
 }

--- a/lib/c-api/src/base.cc
+++ b/lib/c-api/src/base.cc
@@ -214,7 +214,8 @@ extern "C" auto clingo_base_is_fact(clingo_base_t const *atoms, clingo_literal_t
         if (atoms == nullptr || is_fact == nullptr) {
             return fail_arguments();
         }
-        *is_fact = get_program(atoms).isFact(std::abs(literal));
+        // non-negative via std::abs
+        *is_fact = get_program(atoms).isFact(static_cast<clingo_atom_t>(std::abs(literal)));
     }
     CLINGO_CATCH;
 }
@@ -224,7 +225,8 @@ extern "C" auto clingo_base_is_shown(clingo_base_t const *atoms, clingo_literal_
         if (atoms == nullptr || is_shown == nullptr) {
             return fail_arguments();
         }
-        *is_shown = get_program(atoms).isShown(std::abs(literal));
+        // non-negative via std::abs
+        *is_shown = get_program(atoms).isShown(static_cast<clingo_atom_t>(std::abs(literal)));
     }
     CLINGO_CATCH;
 }
@@ -235,7 +237,8 @@ extern "C" auto clingo_base_is_projected(clingo_base_t const *atoms, clingo_lite
         if (atoms == nullptr || is_projected == nullptr) {
             return fail_arguments();
         }
-        *is_projected = get_program(atoms).isProjected(std::abs(literal));
+        // non-negative via std::abs
+        *is_projected = get_program(atoms).isProjected(static_cast<clingo_atom_t>(std::abs(literal)));
     }
     CLINGO_CATCH;
 }
@@ -246,7 +249,8 @@ extern "C" auto clingo_base_is_external(clingo_base_t const *atoms, clingo_liter
         if (atoms == nullptr || is_external == nullptr) {
             return fail_arguments();
         }
-        *is_external = get_program(atoms).isExternal(std::abs(literal));
+        // non-negative via std::abs
+        *is_external = get_program(atoms).isExternal(static_cast<clingo_atom_t>(std::abs(literal)));
     }
     CLINGO_CATCH;
 }

--- a/lib/c-api/src/config.cc
+++ b/lib/c-api/src/config.cc
@@ -223,7 +223,8 @@ extern "C" auto clingo_config_map_subkey_name(clingo_config_t const *config, cli
         if (config == nullptr || name == nullptr) {
             return fail_arguments();
         }
-        auto str = cpp_cast(config)->map_nth(key, offset);
+        // offset indexes config subkeys, well within KeyType's range
+        auto str = cpp_cast(config)->map_nth(key, static_cast<CppClingo::Control::ClingoConfig::KeyType>(offset));
         name->data = str.data();
         name->size = str.size();
     }

--- a/lib/control/include/clingo/control/solver.hh
+++ b/lib/control/include/clingo/control/solver.hh
@@ -194,7 +194,7 @@ class TermBaseMap {
     //!
     //! @param sym the symbol
     //! @return the index
-    [[nodiscard]] auto index(Symbol sym) const -> size_t { return map_.find(sym) - map_.begin(); }
+    [[nodiscard]] auto index(Symbol sym) const -> size_t { return static_cast<size_t>(map_.find(sym) - map_.begin()); }
 
     //! Get the number of mapped symbols.
     //!

--- a/lib/control/src/config.cc
+++ b/lib/control/src/config.cc
@@ -78,7 +78,7 @@ auto ClingoConfig::description(KeyType key) const -> std::string_view {
         int clasp_keys = 0;
         config_->getKeyInfo(key_root(), &clasp_keys, nullptr, nullptr, nullptr);
         if (std::cmp_greater_equal(index, clasp_keys)) {
-            if (auto name = nodes_.front().map_nth(index - clasp_keys)) {
+            if (auto name = nodes_.front().map_nth(index - static_cast<KeyType>(clasp_keys))) {
                 return *name;
             }
         }
@@ -370,7 +370,7 @@ void ClingoConfig::str_(Util::OutputBuffer &out, KeyType key, size_t first_inden
     }
     if (map_keys > 0 && arr_len <= 0) {
         for (int i = 0; i < map_keys; ++i) {
-            auto name = std::string_view{map_nth(key, i)};
+            auto name = std::string_view{map_nth(key, static_cast<KeyType>(i))};
             assert(!name.empty());
             out << fi() << name << ":";
             auto sub_key = map_at(key, name);
@@ -390,7 +390,7 @@ void ClingoConfig::str_(Util::OutputBuffer &out, KeyType key, size_t first_inden
         if (int e = arr_len; e > 0) {
             for (int i = 0, e = arr_len; i != e; ++i) {
                 out << fi() << "- ";
-                auto sub_key = array_at(key, i);
+                auto sub_key = array_at(key, static_cast<KeyType>(i));
                 str_(out, sub_key, 0, indent + 2);
             }
 

--- a/lib/control/src/solver.cc
+++ b/lib/control/src/solver.cc
@@ -102,7 +102,9 @@ class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
                       static_cast<unsigned>(Clasp::DomModType::sign));
         static_assert(static_cast<unsigned>(CppClingo::HeuristicType::true_) ==
                       static_cast<unsigned>(Clasp::DomModType::true_));
-        prg_->heuristic(as_atom_(atom), static_cast<Clasp::DomModType>(type), weight, prio, as_lits_(body));
+        // heuristic priority is non-negative
+        prg_->heuristic(as_atom_(atom), static_cast<Clasp::DomModType>(type), weight, static_cast<unsigned>(prio),
+                        as_lits_(body));
     }
 
     void do_external(prg_lit_t atom, ExternalType type) override {
@@ -251,7 +253,8 @@ class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
     auto as_atom_(prg_lit_t lit) -> Potassco::Atom_t {
         assert(lit > 0 && lit <= prg_lit_max);
         max_lit_ = std::max(max_lit_, lit);
-        return lit;
+        // lit > 0 (asserted above)
+        return static_cast<Potassco::Atom_t>(lit);
     }
 
     auto as_lit_(prg_lit_t lit) -> Potassco::Lit_t {
@@ -301,7 +304,8 @@ class PotasscoBackend : public AbstractProgramBackendImpl {
 
     void do_rule(PrgLitSpan head, PrgLitSpan body, bool choice) override {
         if (fact_ == 0 && !choice && head.size() == 1 && body.empty()) {
-            fact_ = head[0];
+            // single positive head literal of a fact
+            fact_ = static_cast<prg_id_t>(head[0]);
         }
         AbstractProgramBackendImpl::do_rule(head, body, choice);
     }
@@ -776,7 +780,8 @@ void end_ground_(std::vector<std::pair<prg_lit_t, SharedSymbol>> &added, Clasp::
         auto sig = sym->signature();
         assert(sig.has_value());
         grd.mark_sig(*sig);
-        if (prg.isFact(lit)) {
+        // lit > 0 (asserted above)
+        if (prg.isFact(static_cast<Potassco::Atom_t>(lit))) {
             auto *base = grd.base().get_base(*sig);
             assert(base != nullptr);
             auto it = base->find(*sym);
@@ -1113,7 +1118,7 @@ auto SymbolTable::output(CppClingo::Symbol const &sym) -> State & {
                 for (auto const &arg : std::span{buf_.begin() + size, buf_.end()}) {
                     *out_ << " " << arg;
                 }
-                buf_.resize(size);
+                buf_.resize(static_cast<size_t>(size));
                 *out_ << "\n";
                 break;
             }
@@ -1132,7 +1137,7 @@ auto SymbolTable::output(CppClingo::Symbol const &sym) -> State & {
                 for (auto const &arg : std::span{buf_.begin() + size, buf_.end()}) {
                     *out_ << " " << arg;
                 }
-                buf_.resize(size);
+                buf_.resize(static_cast<size_t>(size));
                 *out_ << "\n";
                 break;
             }
@@ -1516,7 +1521,8 @@ void Solver::simplify_() {
         auto const &prg = *clasp->asp();
         // NOTE: Externals are not simplified because they must be available in
         // domains until released.
-        if (prg.isExternal(std::abs(lit))) {
+        // non-negative via std::abs
+        if (prg.isExternal(static_cast<Potassco::Atom_t>(std::abs(lit)))) {
             return TruthValue::unknown;
         }
         auto slit = Clasp::Asp::solverLiteral(prg, lit);

--- a/lib/core/include/clingo/core/logger.hh
+++ b/lib/core/include/clingo/core/logger.hh
@@ -124,7 +124,7 @@ class Report {
 
 inline auto Logger::check(MessageCode code) -> bool {
     // ignore the message
-    if (static_cast<uint8_t>(code) < static_cast<uint8_t>(level_) || disabled_[static_cast<int>(code)]) {
+    if (static_cast<uint8_t>(code) < static_cast<uint8_t>(level_) || disabled_[static_cast<size_t>(code)]) {
         return false;
     }
     // report trace and debug messages without reducing the limit
@@ -146,14 +146,14 @@ inline auto Logger::enabled(MessageCode code) const -> bool {
     if (code >= MessageCode::error) {
         return true;
     }
-    if (code < static_cast<MessageCode>(level_) || disabled_[static_cast<int>(code)]) {
+    if (code < static_cast<MessageCode>(level_) || disabled_[static_cast<size_t>(code)]) {
         return false;
     }
     return code < MessageCode::info || cur_limit_ > 0;
 }
 
 inline void Logger::enable(MessageCode code, bool enabled) {
-    disabled_[static_cast<int>(code)] = !enabled;
+    disabled_[static_cast<size_t>(code)] = !enabled;
 }
 
 inline void Logger::set_level(LogLevel level) {

--- a/lib/core/src/fstring.cc
+++ b/lib/core/src/fstring.cc
@@ -20,7 +20,7 @@ auto is_ascii(char c) -> bool {
 auto match_pred(std::string_view &sv, auto pred) {
     auto ib = sv.begin(); // NOLINT
     auto it = std::ranges::find_if_not(sv, pred);
-    sv.remove_prefix(std::distance(ib, it));
+    sv.remove_prefix(static_cast<size_t>(std::distance(ib, it)));
     return std::string_view{ib, it};
 };
 
@@ -44,7 +44,7 @@ template <class T> auto match_num(std::string_view &sv) -> std::optional<T> {
         if (ec != std::errc{}) {
             return std::nullopt;
         }
-        sv.remove_prefix(std::distance(ib, it));
+        sv.remove_prefix(static_cast<size_t>(std::distance(ib, it)));
         return ret;
     }
     return std::nullopt;

--- a/lib/core/src/number.cc
+++ b/lib/core/src/number.cc
@@ -7,6 +7,7 @@
 
 #include <atomic>
 #include <memory>
+#include <utility>
 
 namespace CppClingo {
 
@@ -283,10 +284,10 @@ class mp_int_ptr {
 
 auto to_binary(mp_int z, int len, int limit) -> std::unique_ptr<unsigned char[]> {
     auto msb = limit - len;
-    auto buf = std::make_unique<unsigned char[]>(limit);
+    auto buf = std::make_unique<unsigned char[]>(static_cast<size_t>(limit));
     mp_int_to_binary(z, buf.get() + msb, len);
-    if (len < limit && (buf[msb] & 128) == 128) {
-        for (int i = 0; i < msb; ++i) {
+    if (len < limit && (buf[static_cast<size_t>(msb)] & 128) == 128) {
+        for (size_t i = 0; std::cmp_less(i, msb); ++i) {
             buf[i] = 255;
         }
     }
@@ -302,7 +303,7 @@ template <char op> auto mp_int_binop(mp_int a, mp_int b, mp_int c) -> mp_result 
         auto limit = std::max(len_a, len_b);
         auto buf_a = to_binary(a, len_a, limit);
         auto buf_b = to_binary(b, len_b, limit);
-        for (int i = 0; i < limit; ++i) {
+        for (size_t i = 0; std::cmp_less(i, limit); ++i) {
             if constexpr (op == '&') {
                 buf_a[i] = buf_a[i] & buf_b[i];
             }
@@ -326,10 +327,10 @@ template <char op> auto mp_int_binop_value(mp_int a, mp_small b, mp_int c) -> mp
         auto limit = std::max(len_a, len_b);
         auto buf_a = to_binary(a, len_a, limit);
         auto *buf_b = reinterpret_cast<unsigned char *>(&b);
-        for (int i = 0; i < limit; ++i) {
-            auto j = limit - i - 1;
+        for (size_t i = 0; std::cmp_less(i, limit); ++i) {
+            auto j = static_cast<size_t>(limit) - i - 1;
             unsigned char char_b = 0;
-            if (j < len_b) {
+            if (std::cmp_less(j, len_b)) {
                 char_b = buf_b[j];
             } else if (b < 0) {
                 char_b = 255; // NOLINT(readability-magic-numbers)
@@ -653,7 +654,7 @@ Number::~Number() noexcept {
     std::string ret;
     auto *z = repr_to_bigint(repr_);
     auto len = mp_int_string_len(&z->num, BASE);
-    ret.resize(len, '\0');
+    ret.resize(static_cast<size_t>(len), '\0');
     handle_error(mp_int_to_string(&z->num, BASE, ret.data(), len));
     // NOTE: The mp_int library sometimes reports too large length for numbers,
     // which requires the while loop below.
@@ -1085,9 +1086,9 @@ void append(Util::OutputBuffer &out, Number const &num, int base) {
         out.append(repr_to_int(num.repr_), base);
     } else {
         auto *z = repr_to_bigint(num.repr_);
-        auto len = mp_int_string_len(&z->num, base);
+        auto len = mp_int_string_len(&z->num, static_cast<mp_size>(base));
         auto target = out.reserve(len);
-        handle_error(mp_int_to_string(&z->num, base, target.data(), len));
+        handle_error(mp_int_to_string(&z->num, static_cast<mp_size>(base), target.data(), len));
         out.trim_zero(len);
     }
 }

--- a/lib/cxx-api/include/clingo/base.hh
+++ b/lib/cxx-api/include/clingo/base.hh
@@ -309,7 +309,8 @@ class TheoryTerm {
     //!
     //! @param base the C theory base
     //! @param index the index of the term
-    explicit TheoryTerm(clingo_theory_base_t const &base, size_t index) : base_{&base}, index_{index} {}
+    explicit TheoryTerm(clingo_theory_base_t const &base, size_t index)
+        : base_{&base}, index_{static_cast<clingo_id_t>(index)} {}
 
     //! Get the type of the theory term.
     [[nodiscard]] auto type() const -> TheoryTermType {
@@ -378,7 +379,7 @@ class TheoryTerm {
 
   private:
     clingo_theory_base_t const *base_;
-    size_t index_;
+    clingo_id_t index_;
 };
 
 class TheoryElement;
@@ -392,7 +393,8 @@ class TheoryElement {
     //!
     //! @param base the C theory base
     //! @param index the index of the element
-    explicit TheoryElement(clingo_theory_base_t const &base, size_t index) : base_{&base}, index_{index} {}
+    explicit TheoryElement(clingo_theory_base_t const &base, size_t index)
+        : base_{&base}, index_{static_cast<clingo_id_t>(index)} {}
 
     //! Get the tuple of the theory element.
     //!
@@ -468,7 +470,7 @@ class TheoryElement {
 
   private:
     clingo_theory_base_t const *base_;
-    size_t index_;
+    clingo_id_t index_;
 };
 
 //! Class to provide access to theory atoms.
@@ -478,7 +480,8 @@ class TheoryAtom {
     //!
     //! @param base the C theory base
     //! @param index the index of the atom
-    explicit TheoryAtom(clingo_theory_base_t const &base, size_t index) : base_{&base}, index_{index} {}
+    explicit TheoryAtom(clingo_theory_base_t const &base, size_t index)
+        : base_{&base}, index_{static_cast<clingo_id_t>(index)} {}
 
     //! Get the name of the theory atom.
     //!
@@ -557,7 +560,7 @@ class TheoryAtom {
 
   private:
     clingo_theory_base_t const *base_;
-    size_t index_;
+    clingo_id_t index_;
 };
 
 //! A theory base that maps theory atoms.

--- a/lib/cxx-api/include/clingo/core.hh
+++ b/lib/cxx-api/include/clingo/core.hh
@@ -238,7 +238,7 @@ template <class T, auto F> using unique_handle = std::unique_ptr<T, Free<F>>;
 //! Use std::transform to build a vector.
 template <std::input_iterator It, std::sentinel_for<It> S, class Pred> auto transform(It begin, S end, Pred pred) {
     auto p = std::vector<std::invoke_result_t<Pred, std::iter_reference_t<It>>>{};
-    p.reserve(std::distance(begin, end));
+    p.reserve(static_cast<size_t>(std::distance(begin, end)));
     std::transform(begin, end, std::back_inserter(p), pred);
     return p;
 }

--- a/lib/cxx-api/include/clingo/propagate.hh
+++ b/lib/cxx-api/include/clingo/propagate.hh
@@ -77,7 +77,8 @@ class Trail {
     //!
     //! @return the literal at the index
     [[nodiscard]] auto at(size_type index) const -> value_type {
-        return Detail::call<clingo_assignment_trail_at>(assignment_, index);
+        // trail index fits in the C API's 32-bit id type
+        return Detail::call<clingo_assignment_trail_at>(assignment_, static_cast<uint32_t>(index));
     }
 
     //! @copydoc Trail::at()

--- a/lib/cxx-api/tests/propagate.cc
+++ b/lib/cxx-api/tests/propagate.cc
@@ -347,7 +347,7 @@ TEST_CASE_METHOD(Fixture, "propagate a iff b", "[cxx][propagate]") {
     ctl.parse_string("1 { a; b }.");
     ctl.ground();
 
-    for (ProgramId n : {1, 3}) {
+    for (ProgramId n : {1U, 3U}) {
 #ifdef __EMSCRIPTEN__
         if (n > 1) {
             continue;
@@ -371,7 +371,7 @@ TEST_CASE_METHOD(Fixture, "propagate exception", "[cxx][propagate][exception]") 
     ctl.parse_string("1 { a; b }.");
     ctl.ground();
 
-    for (ProgramId n : {8, 1}) {
+    for (ProgramId n : {8U, 1U}) {
 #ifdef __EMSCRIPTEN__
         if (n > 1) {
             continue;

--- a/lib/ground/include/clingo/ground/base.hh
+++ b/lib/ground/include/clingo/ground/base.hh
@@ -247,7 +247,8 @@ class AtomBase : public BaseImpl<Symbol, AtomBase> {
     template <class Gen> auto add(Symbol atom, StateAtom state, Gen &&gen) -> std::pair<MapAtom::iterator, AtomUpdate> {
         auto [it, ins] = atoms_.try_emplace(atom, 0, state);
         if (ins) {
-            it.value().id = std::invoke(std::forward<Gen>(gen));
+            // FIXME(P3): AtomInfo::id conflates a fresh uid and a signed literal; strong types should replace this cast
+            it.value().id = static_cast<uint64_t>(std::invoke(std::forward<Gen>(gen)));
             if (state != StateAtom::unknown) {
                 derived_.add(atom_index_(it));
             }
@@ -326,7 +327,8 @@ class AtomBase : public BaseImpl<Symbol, AtomBase> {
                 ++rem;
                 return true;
             }
-            auto tv = pred(item.second.id);
+            // FIXME(P3): AtomInfo::id conflates a fresh uid and a signed literal; strong types should replace this cast
+            auto tv = pred(static_cast<int32_t>(item.second.id));
             if (tv == TruthValue::bot) {
                 ++rem;
                 return true;

--- a/lib/ground/include/clingo/ground/condlit.hh
+++ b/lib/ground/include/clingo/ground/condlit.hh
@@ -154,7 +154,7 @@ class BaseCondLitEmpty : public BaseImpl<Symbol const *, BaseCondLitEmpty> {
 
     //! Map a key to its index in the base.
     [[nodiscard]] auto index(Key const &key) const -> size_t {
-        return std::distance(atoms_->begin(), atoms_->find(key));
+        return static_cast<size_t>(std::distance(atoms_->begin(), atoms_->find(key)));
     }
     //! Get the number of atoms in the base.
     [[nodiscard]] auto size() const -> size_t { return atoms_->size(); }

--- a/lib/ground/include/clingo/ground/matcher.hh
+++ b/lib/ground/include/clingo/ground/matcher.hh
@@ -213,7 +213,7 @@ struct BindVals {
         if (begin > 0) {
             auto n = static_cast<std::ptrdiff_t>(vars + 1);
             std::advance(it, offset_);
-            for (; it != symbols_.end() && Symbol::to_rep(*it) < begin; it += n, offset_ += n) {
+            for (; it != symbols_.end() && Symbol::to_rep(*it) < begin; it += n, offset_ += static_cast<size_t>(n)) {
             }
         }
     }
@@ -308,7 +308,8 @@ template <IsBase Base> class HashIndex {
     struct KeyEqual {
         auto operator()(Key const &a, Key const &b) const {
             if (a.marked() || b.marked()) {
-                return std::equal(a.symbols(), std::next(a.symbols(), size), b.symbols(), std::next(b.symbols(), size));
+                return std::equal(a.symbols(), std::next(a.symbols(), static_cast<std::ptrdiff_t>(size)), b.symbols(),
+                                  std::next(b.symbols(), static_cast<std::ptrdiff_t>(size)));
             }
             return a.symbols() == b.symbols();
         }

--- a/lib/ground/src/assignment_aggregate.cc
+++ b/lib/ground/src/assignment_aggregate.cc
@@ -76,7 +76,7 @@ void AtomAssignAggr::accumulate(AggregateFunction fun, SymbolSpan tup, bool fact
                         m = std::ssize(vals);
                     }
                     // the value to insert
-                    auto iv = vals[i] + num;
+                    auto iv = vals[static_cast<size_t>(i)] + num;
                     // there are 4 sorted ranges:
                     // - [ib, ip) : values already propagated
                     // - [ip, in) : values previously inserted
@@ -156,7 +156,7 @@ auto BaseAssignAggr::size() const -> size_t {
 }
 
 auto BaseAssignAggr::index(Key sym) const -> size_t {
-    return derived_.find(sym) - derived_.begin();
+    return static_cast<size_t>(derived_.find(sym) - derived_.begin());
 }
 
 auto BaseAssignAggr::nth(size_t i) const -> AtomSet::const_iterator {
@@ -368,7 +368,7 @@ void StateAssignAggr::insert_elem(EvalContext const &ctx, AtomMap::iterator it, 
         auto [jt, jns] = tuples_.try_emplace(elem.key_);
         if (jns) {
             elem.key_ = nullptr;
-            it.value().add_elem(jt - tuples_.begin());
+            it.value().add_elem(static_cast<size_t>(jt - tuples_.begin()));
             enqueue_(it);
         }
 
@@ -383,7 +383,7 @@ void StateAssignAggr::insert_elem(EvalContext const &ctx, AtomMap::iterator it, 
 }
 
 auto StateAssignAggr::atom_index(AtomMap::iterator it) -> size_t {
-    return it - base_.atoms().begin();
+    return static_cast<size_t>(it - base_.atoms().begin());
 }
 
 void StateAssignAggr::print(std::ostream &out, bool print_index) {

--- a/lib/ground/src/body_aggregate.cc
+++ b/lib/ground/src/body_aggregate.cc
@@ -421,7 +421,7 @@ void StateBdAggr::insert_elem(EvalContext const &ctx, AtomMap::iterator it, StmB
         auto [jt, jns] = tuples_.try_emplace(elem.elem_key_);
         if (jns) {
             elem.elem_key_ = nullptr;
-            it.value().add_elem(jt - tuples_.begin());
+            it.value().add_elem(static_cast<size_t>(jt - tuples_.begin()));
             enqueue_(it);
         }
 
@@ -439,7 +439,7 @@ void StateBdAggr::insert_elem(EvalContext const &ctx, AtomMap::iterator it, StmB
 }
 
 auto StateBdAggr::atom_index_(AtomMap::iterator it) -> size_t {
-    return it - base_.atoms().begin();
+    return static_cast<size_t>(it - base_.atoms().begin());
 }
 
 void StateBdAggr::print(std::ostream &out, bool print_index) {
@@ -740,7 +740,7 @@ class MatcherBdAggrStrat : public OnceMatcher {
     }
     auto do_once(EvalContext const &ctx) -> bool override {
         if (auto it = state_->insert_atom(ctx)) {
-            *offset_ = it->first - state_->base().atoms().begin();
+            *offset_ = static_cast<size_t>(it->first - state_->base().atoms().begin());
             if (it->second) {
                 // bind global variables
                 auto &ass = ctx.ass();

--- a/lib/ground/src/condlit.cc
+++ b/lib/ground/src/condlit.cc
@@ -102,7 +102,7 @@ auto StateCondLit::add_premise(EvalContext const &ctx, ULitVec const &premise) -
     auto &ass = ctx.ass();
     auto *syms_elem = static_cast<Symbol *>(mbr_->allocate((local_.size() + 1) * sizeof(Symbol), alignof(Symbol)));
     auto *kt = syms_elem;
-    *kt = Symbol::from_rep(std::distance(atoms_.begin(), it));
+    *kt = Symbol::from_rep(static_cast<uint64_t>(std::distance(atoms_.begin(), it)));
     for (auto var : local_) {
         kt = std::next(kt);
         // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
@@ -116,7 +116,7 @@ auto StateCondLit::add_premise(EvalContext const &ctx, ULitVec const &premise) -
     auto &atom = it.value();
     auto &elem = jt.value();
 
-    atom.add_elem(std::distance(elems_.begin(), jt));
+    atom.add_elem(static_cast<size_t>(std::distance(elems_.begin(), jt)));
     // Note: in principle, we only need to ground if the conclusion is a fact.
     // We still add to the base here to gather the conclusion for the output.
     if (has_conclusion_) {
@@ -187,11 +187,11 @@ auto StateCondLit::atom_nth(size_t index) -> MapAtomCondLit::iterator {
 }
 
 auto StateCondLit::atom_index(MapAtomCondLit::const_iterator it) const -> size_t {
-    return std::distance(atoms_.begin(), it);
+    return static_cast<size_t>(std::distance(atoms_.begin(), it));
 }
 
 auto StateCondLit::elem_index(MapElemCondLit::const_iterator it) const -> size_t {
-    return std::distance(elems_.begin(), it);
+    return static_cast<size_t>(std::distance(elems_.begin(), it));
 }
 
 auto StateCondLit::atom_find(Assignment const &ass) -> MapAtomCondLit::iterator {

--- a/lib/ground/src/disjunction.cc
+++ b/lib/ground/src/disjunction.cc
@@ -66,7 +66,7 @@ auto BaseDisjunction::size() const -> size_t {
 }
 
 auto BaseDisjunction::index(Symbol const *sym) const -> size_t {
-    return atoms_.find(sym) - atoms_.begin();
+    return static_cast<size_t>(atoms_.find(sym) - atoms_.begin());
 }
 
 auto BaseDisjunction::nth(size_t i) const -> AtomMap::const_iterator {
@@ -208,7 +208,7 @@ void StateDisjunction::insert_elem(EvalContext const &ctx, AtomMap::iterator it,
     if (auto opt = head->eval(ctx); opt) {
         auto [jt, jns] = elems_.try_emplace(ElementKey{*opt, atom_index_(it)});
         if (jns) {
-            it.value().add_elem(jt - elems_.begin());
+            it.value().add_elem(static_cast<size_t>(jt - elems_.begin()));
             enqueue_(it);
         }
         auto [cond_id, fact] = get_cond();
@@ -225,7 +225,7 @@ void StateDisjunction::insert_elem(EvalContext const &ctx, AtomMap::iterator it,
 }
 
 auto StateDisjunction::atom_index_(AtomMap::iterator it) -> size_t {
-    return it - base_.atoms().begin();
+    return static_cast<size_t>(it - base_.atoms().begin());
 }
 
 void StateDisjunction::print(std::ostream &out, bool print_index) {

--- a/lib/ground/src/head_aggregate.cc
+++ b/lib/ground/src/head_aggregate.cc
@@ -143,7 +143,7 @@ auto BaseHdAggr::size() const -> size_t {
 }
 
 auto BaseHdAggr::index(Symbol const *sym) const -> size_t {
-    return atoms_.find(sym) - atoms_.begin();
+    return static_cast<size_t>(atoms_.find(sym) - atoms_.begin());
 }
 
 auto BaseHdAggr::nth(size_t i) const -> AtomMap::const_iterator {
@@ -414,7 +414,7 @@ void StateHdAggr::insert_elem(EvalContext const &ctx, AtomMap::iterator it, StmH
         auto [jt, jns] = tuples_.try_emplace(elem.elem_key_);
         if (jns) {
             elem.elem_key_ = nullptr;
-            it.value().add_elem(jt - tuples_.begin());
+            it.value().add_elem(static_cast<size_t>(jt - tuples_.begin()));
             enqueue_(it);
         }
 
@@ -441,7 +441,7 @@ void StateHdAggr::insert_elem(EvalContext const &ctx, AtomMap::iterator it, StmH
 }
 
 auto StateHdAggr::atom_index_(AtomMap::iterator it) -> size_t {
-    return it - base_.atoms().begin();
+    return static_cast<size_t>(it - base_.atoms().begin());
 }
 
 void StateHdAggr::print(std::ostream &out, bool print_index) {

--- a/lib/ground/src/instantiator.cc
+++ b/lib/ground/src/instantiator.cc
@@ -28,7 +28,7 @@ class ProfileTimer {
 
     static auto now() -> TimePoint { return std::chrono::high_resolution_clock::now(); }
     static auto diff(TimePoint start, TimePoint finish) -> uint64_t {
-        return std::chrono::duration_cast<std::chrono::nanoseconds>(finish - start).count();
+        return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::nanoseconds>(finish - start).count());
     }
 
     uint64_t *target_;

--- a/lib/ground/src/term.cc
+++ b/lib/ground/src/term.cc
@@ -223,7 +223,7 @@ auto insert_sep(Util::OutputBuffer &tmp, size_t start, char sep, FormatSpec::Typ
     if (std::cmp_less_equal(digits, width)) {
         return;
     }
-    auto seps = (digits - 1) / width;
+    auto seps = (digits - 1) / static_cast<size_t>(width);
     tmp.reserve(static_cast<ptrdiff_t>(seps));
 
     auto span = tmp.span();
@@ -417,7 +417,8 @@ auto TermFormatString::do_eval(EvalContext const &ctx) const -> std::optional<Sy
                             tmp_.reserve(padding);
                             auto span = tmp_.span();
                             std::ranges::copy_backward(span.subspan(start, digits), span.end());
-                            std::ranges::fill(span.subspan(start, padding), spec.fill.value_or(' '));
+                            std::ranges::fill(span.subspan(start, static_cast<size_t>(padding)),
+                                              spec.fill.value_or(' '));
                         }
 
                         align(buf_, tmp_.view(), spec, FormatSpec::Align::right);

--- a/lib/ground/src/theory_atom.cc
+++ b/lib/ground/src/theory_atom.cc
@@ -32,7 +32,7 @@ auto BaseTheory::size() const -> size_t {
 }
 
 auto BaseTheory::index(Symbol const *sym) const -> size_t {
-    return atoms_.find(sym) - atoms_.begin();
+    return static_cast<size_t>(atoms_.find(sym) - atoms_.begin());
 }
 
 auto BaseTheory::nth(size_t i) const -> AtomMap::const_iterator {
@@ -162,11 +162,12 @@ auto StateTheory::insert_atom(Symbol name, std::optional<size_t> rhs, Assignment
 
 void StateTheory::insert_elem(EvalContext const &ctx, AtomMap::iterator it, UTheoryTermVec const &tuple,
                               ElementKey *&elem_key, auto const &get_cond) {
-    ElementKey::construct(*mbr_, ctx, ctx.out().theory(), it - base().atoms().begin(), tuple, elem_key);
+    ElementKey::construct(*mbr_, ctx, ctx.out().theory(), static_cast<size_t>(it - base().atoms().begin()), tuple,
+                          elem_key);
     auto [jt, jns] = tuples_.try_emplace(elem_key);
     if (jns) {
         elem_key = nullptr;
-        it.value().add_elem(jt - tuples_.begin());
+        it.value().add_elem(static_cast<size_t>(jt - tuples_.begin()));
     }
     jt.value().emplace_back(get_cond());
 }

--- a/lib/input/src/parse/aspif.cc
+++ b/lib/input/src/parse/aspif.cc
@@ -597,7 +597,8 @@ class AspifParser {
         expect_(AspifToken::space);
         auto terms = expect_ids_();
         if (type >= 0) {
-            state_->thy_backend()->fun(id, type, terms);
+            // type >= 0 (guarded above)
+            state_->thy_backend()->fun(id, static_cast<prg_id_t>(type), terms);
         } else {
             state_->thy_backend()->tup(id, theory_compound_type_(type), terms);
         }

--- a/lib/input/src/parse/lexer_state.hh
+++ b/lib/input/src/parse/lexer_state.hh
@@ -164,7 +164,7 @@ inline auto LexerState::fill(size_t n, size_t padding) -> bool {
 
     auto *buffer = buffer_.data();
     auto shift = token_ - buffer;
-    auto used = limit_ - token_;
+    auto used = static_cast<size_t>(limit_ - token_);
 
     if (shift > 0) {
         // make room to read more characters

--- a/lib/input/src/parse/parser_state.cc
+++ b/lib/input/src/parse/parser_state.cc
@@ -1,2 +1,10 @@
 #include "parser_state.hh"
+
+// The re2c-generated lexer reads a `char const*` buffer as `unsigned char`
+// (YYCTYPE), which trips the strict conversion gate. Exempt only the generated
+// include; hand-written code in this TU stays under the gate.
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wsign-conversion"
+#pragma GCC diagnostic ignored "-Wconversion"
 #include "parse/lexer_impl.hh"
+#pragma GCC diagnostic pop

--- a/lib/input/src/rewrite/compute_bounds.cc
+++ b/lib/input/src/rewrite/compute_bounds.cc
@@ -320,7 +320,7 @@ class ApplyBounds {
                 t->value().type() != SymbolType::number) {
                 return {true};
             }
-            auto &state = states_->operator[](std::distance(dom_->begin(), it));
+            auto &state = states_->operator[](static_cast<size_t>(std::distance(dom_->begin(), it)));
             if (state.both == 1) {
                 return {false};
             }
@@ -353,7 +353,7 @@ class ApplyBounds {
             if (it == dom_->end()) {
                 return {true};
             }
-            auto &state = states_->operator[](std::distance(dom_->begin(), it));
+            auto &state = states_->operator[](static_cast<size_t>(std::distance(dom_->begin(), it)));
             auto bound_type = IEInterval::Lower;
             switch (rel) {
                 case Relation::greater:

--- a/lib/input/src/rewrite/project.cc
+++ b/lib/input/src/rewrite/project.cc
@@ -204,8 +204,8 @@ class Project : public Transformer<Project> {
         // do not project projection-like rules
         if (is_atom(stm.head())) {
             auto has_atom = std::ranges::any_of(stm.body(), [](auto const &lit) { return is_atom(lit); });
-            size_t n_test =
-                std::count_if(stm.body().begin(), stm.body().end(), [](auto const &lit) { return is_test(lit); });
+            auto n_test = static_cast<size_t>(
+                std::count_if(stm.body().begin(), stm.body().end(), [](auto const &lit) { return is_test(lit); }));
             if (has_atom && n_test == stm.body().size() - 1) {
                 return std::nullopt;
             }

--- a/lib/input/src/rewrite/unpool.hh
+++ b/lib/input/src/rewrite/unpool.hh
@@ -63,7 +63,7 @@ auto unpool_crossproduct(Span const &elems, auto unpool)
             has_value = true;
             pool.reserve(elems.size());
             offsets.reserve(elems.size());
-            for (auto it = elems.begin(), ie = it + n; it != ie; ++it) {
+            for (auto it = elems.begin(), ie = it + static_cast<std::ptrdiff_t>(n); it != ie; ++it) {
                 offsets.emplace_back(pool.size(), pool.size(), pool.size() + 1);
                 pool.emplace_back(*it);
             }

--- a/lib/output/src/backend.cc
+++ b/lib/output/src/backend.cc
@@ -324,10 +324,10 @@ class BuilderBase {
         auto [it, ins] = clauses_.emplace(std::pair{lits_, type}, 0);
         if (ins) {
             it.value() = next_lit();
-            info(it.value()).clause = std::distance(clauses_.begin(), it);
+            info(it.value()).clause = static_cast<size_t>(std::distance(clauses_.begin(), it));
             for (auto const &lit : it->first.first) {
                 if (add_edges && lit > 0) {
-                    graph_.add_edge(it.value(), lit);
+                    graph_.add_edge(static_cast<size_t>(it.value()), static_cast<size_t>(lit));
                 }
             }
         }
@@ -363,7 +363,7 @@ class BuilderBase {
         while (std::cmp_less(infos_.size(), lit)) {
             infos_.emplace_back();
         }
-        return infos_[lit - 1];
+        return infos_[static_cast<size_t>(lit - 1)];
     }
 
     //! Check if the literals occur in the same positive cycle.
@@ -414,7 +414,7 @@ class BuilderRule {
                 hd_.emplace_back(hlit);
                 for (auto const &blit : body) {
                     if (blit > 0) {
-                        bld.add_edge(hlit, blit);
+                        bld.add_edge(static_cast<size_t>(hlit), static_cast<size_t>(blit));
                     }
                 }
             } else if (!choice) {
@@ -484,7 +484,8 @@ template <class Sym> class BuilderMinMax {
             bld.mark(clit, EQType::implication);
         }
         auto get_span = [this](auto it) {
-            return std::span{std::next(lits_.begin(), *it), std::next(lits_.begin(), *(it + 1))};
+            return std::span{std::next(lits_.begin(), static_cast<std::ptrdiff_t>(*it)),
+                             std::next(lits_.begin(), static_cast<std::ptrdiff_t>(*(it + 1)))};
         };
         if (ids_.size() <= 2 || (ids_.size() == 3 && !start)) {
             // translate constant, monotone, antimontone, and convex cases
@@ -496,7 +497,8 @@ template <class Sym> class BuilderMinMax {
                 if (state) {
                     for (auto const &clit : get_span(it)) {
                         if (clit > 0) {
-                            bld.add_edge(lit, clit);
+                            // lit asserted > 0; clit > 0 (guarded)
+                            bld.add_edge(static_cast<size_t>(lit), static_cast<size_t>(clit));
                         }
                     }
                 }
@@ -628,7 +630,8 @@ template <class Sym> class BuilderMinMax {
     void tr_(BuilderBase &bld, prg_lit_t lit, bool start, PrgLitVec const &lits, IndexVec const &ids, bool delayed) {
         assert(!ids.empty() && lits.size() == ids.back() && lit > 0);
         auto get_span = [&lits = lits](auto it) {
-            return std::span{std::next(lits.begin(), *it), std::next(lits.begin(), *(it + 1))};
+            return std::span{std::next(lits.begin(), static_cast<std::ptrdiff_t>(*it)),
+                             std::next(lits.begin(), static_cast<std::ptrdiff_t>(*(it + 1)))};
         };
         tr_lits_.clear();
         tr_lits_.reserve(lits.size());
@@ -645,7 +648,8 @@ template <class Sym> class BuilderMinMax {
                     }
                     tr_lits_.emplace_back(clit);
                     if (!delayed && clit > 0) {
-                        bld.add_edge(lit, clit);
+                        // lit asserted > 0; clit > 0 (guarded)
+                        bld.add_edge(static_cast<size_t>(lit), static_cast<size_t>(clit));
                     }
                     bld.backend().rule(std::array{lit}, tr_lits_, false);
                     tr_lits_.pop_back();
@@ -710,7 +714,8 @@ class BuilderSum {
             for (auto const &[num, clit] : elems_) {
                 if (clit > 0 && ((intersects(type, CycleType::positive) && num > 0) ||
                                  (intersects(type, CycleType::negative) && num < 0))) {
-                    bld.add_edge(lit, clit);
+                    // lit asserted > 0; clit > 0 (guarded)
+                    bld.add_edge(static_cast<size_t>(lit), static_cast<size_t>(clit));
                 }
             }
         }
@@ -1012,7 +1017,8 @@ class BuilderCondLit {
         bool simple = true;
         for (auto const &elem : elems) {
             if (auto const &[id_conc, id_prem] = elem; id_conc && lit > 0 && *id_conc > 0) {
-                bld.add_edge(lit, *id_conc);
+                // lit > 0 and *id_conc > 0 (both guarded above)
+                bld.add_edge(static_cast<size_t>(lit), static_cast<size_t>(*id_conc));
                 simple = false;
             }
             elems_.emplace_back(Util::transform(elem.first, uid_to_lit), uid_to_lit(elem.second));
@@ -1519,7 +1525,8 @@ class OutputBackend : public OutputStm, OutputTheory {
         return cond_;
     }
 
-    auto do_cond_id() -> size_t override { return bld_.cond(cond_.literals()); }
+    // cond() returns a fresh positive condition id
+    auto do_cond_id() -> size_t override { return static_cast<size_t>(bld_.cond(cond_.literals())); }
 
     auto do_uid(bool fact) -> size_t override {
         if (fact) {
@@ -1527,9 +1534,11 @@ class OutputBackend : public OutputStm, OutputTheory {
                 fact_ = bld_.next_lit();
                 bld_.backend().rule(std::array{fact_}, {}, false);
             }
-            return fact_;
+            // fresh positive literal (or the fact literal)
+            return static_cast<size_t>(fact_);
         }
-        return bld_.next_lit();
+        // fresh positive literal
+        return static_cast<size_t>(bld_.next_lit());
     }
 
     void do_cond_lit(size_t uid, CondLitSpan elems) override { cond_lit_.add(bld_, uid_to_lit(uid), elems); }
@@ -1586,7 +1595,8 @@ class OutputBackend : public OutputStm, OutputTheory {
                         auto hlit = uid_to_lit(huid);
                         auto elit = bld_.clause(std::array{hlit, clit}, ClauseType::conjunctive);
                         bd_conds.back().emplace_back(elit);
-                        bld_.mark(uid_to_lit(elit), EQType::implication);
+                        // elit is a fresh positive clause literal
+                        bld_.mark(uid_to_lit(static_cast<size_t>(elit)), EQType::implication);
                         bld_.mark(clit, EQType::implication);
                         rule_.add(bld_, std::array{hlit}, std::array{blit, clit}, true);
                     } else {
@@ -1597,7 +1607,8 @@ class OutputBackend : public OutputStm, OutputTheory {
             }
         }
         auto lit = bld_.next_lit();
-        bd_aggr(lit, fun, bd_elems, guards);
+        // fresh positive literal
+        bd_aggr(static_cast<size_t>(lit), fun, bd_elems, guards);
         rule_.add(bld_, {}, std::array{-lit, blit}, false);
     }
 

--- a/lib/output/src/text.cc
+++ b/lib/output/src/text.cc
@@ -332,9 +332,9 @@ class OutputText : public OutputStm, OutputTheory {
         return cond_;
     }
 
-    template <class T> auto str_id_(T &&str) {
+    template <class T> auto str_id_(T &&str) -> size_t {
         auto it = strs_.emplace(std::forward<T>(str)).first;
-        return it - strs_.begin();
+        return static_cast<size_t>(it - strs_.begin());
     }
 
     auto do_cond_id() -> size_t override { return str_id_(cond_.end()); }

--- a/lib/util/include/clingo/util/algorithm.hh
+++ b/lib/util/include/clingo/util/algorithm.hh
@@ -14,7 +14,7 @@ namespace CppClingo::Util {
 template <class Rng> auto copy_n(Rng const &rng, size_t n) -> std::vector<typename Rng::value_type> {
     std::vector<std::remove_const_t<typename Rng::value_type>> ret;
     ret.reserve(rng.size());
-    for (auto it = rng.begin(), ie = it + n; it != ie; ++it) {
+    for (auto it = rng.begin(), ie = it + static_cast<std::ptrdiff_t>(n); it != ie; ++it) {
         ret.emplace_back(*it);
     }
     return ret;
@@ -32,8 +32,8 @@ template <class T, class... Ts> auto make_vec(Ts &&...args) -> std::vector<T> {
 template <class Container, std::input_iterator It, std::sentinel_for<It> Sent, typename Pred>
 void into_vec(Container &vec, It first, Sent last, Pred &&pred) {
     vec.clear();
-    if constexpr (requires { vec.reserve(std::distance(first, last)); }) {
-        vec.reserve(std::distance(first, last));
+    if constexpr (requires { vec.reserve(static_cast<size_t>(std::distance(first, last))); }) {
+        vec.reserve(static_cast<size_t>(std::distance(first, last)));
     }
     std::ranges::transform(first, last, std::back_inserter(vec), std::forward<Pred>(pred));
 }
@@ -47,8 +47,8 @@ template <class Container, class Rng, class Pred> void into_vec(Container &vec, 
 template <class Container, std::input_iterator It, std::sentinel_for<It> Sent, typename Pred, typename... Args>
 auto to_vec(It begin, Sent end, Pred &&pred, Args &&...args) {
     Container p(std::forward<Args>(args)...);
-    if constexpr (requires { p.reserve(std::distance(begin, end)); }) {
-        p.reserve(std::distance(begin, end));
+    if constexpr (requires { p.reserve(static_cast<size_t>(std::distance(begin, end))); }) {
+        p.reserve(static_cast<size_t>(std::distance(begin, end)));
     }
     std::transform(begin, end, std::back_inserter(p), std::forward<Pred>(pred));
     return p;

--- a/lib/util/include/clingo/util/immutable_array.hh
+++ b/lib/util/include/clingo/util/immutable_array.hh
@@ -83,7 +83,7 @@ template <typename T> class immutable_array {
     template <class It, class Pred> immutable_array(It first, It last, Pred conv) {
         if (first != last) {
             auto vec = vector_type{};
-            vec.reserve(std::distance(first, last));
+            vec.reserve(static_cast<size_t>(std::distance(first, last)));
             for (auto it = first; it != last; ++it) {
                 vec.emplace_back(conv(*it));
             }

--- a/lib/util/include/clingo/util/optional.hh
+++ b/lib/util/include/clingo/util/optional.hh
@@ -186,14 +186,14 @@ template <class T, bool UseSpan = true> class ResultVec {
     //! Remove the current element.
     void remove() {
         if (!result_) {
-            result_ = Util::copy_n(source_, std::distance(source_.begin(), current_));
+            result_ = Util::copy_n(source_, static_cast<size_t>(std::distance(source_.begin(), current_)));
         }
         ++current_;
     }
     //! Replace the current element.
     template <class... Args> void replace(Args &&...args) {
         if (!result_) {
-            result_ = Util::copy_n(source_, std::distance(source_.begin(), current_));
+            result_ = Util::copy_n(source_, static_cast<size_t>(std::distance(source_.begin(), current_)));
         }
         result_->emplace_back(std::forward<Args>(args)...);
         ++current_;
@@ -209,14 +209,14 @@ template <class T, bool UseSpan = true> class ResultVec {
     //! Append fresh elements.
     template <class... Args> void append(Args &&...args) {
         if (!result_) {
-            result_ = Util::copy_n(source_, std::distance(source_.begin(), current_));
+            result_ = Util::copy_n(source_, static_cast<size_t>(std::distance(source_.begin(), current_)));
         }
         result_->emplace_back(std::forward<Args>(args)...);
     }
     //! Append fresh elements.
     template <class It> void extend(It begin, It end) {
         if (!result_) {
-            result_ = Util::copy_n(source_, std::distance(source_.begin(), current_));
+            result_ = Util::copy_n(source_, static_cast<size_t>(std::distance(source_.begin(), current_)));
         }
         result_->insert(result_->end(), begin, end);
     }

--- a/lib/util/include/clingo/util/print.hh
+++ b/lib/util/include/clingo/util/print.hh
@@ -36,7 +36,7 @@ class OutputBuffer {
     //! This function is a noop if there is no associated file.
     void flush() {
         if (out_ != nullptr) {
-            fwrite(buf_.data(), sizeof(char), size_, out_);
+            fwrite(buf_.data(), sizeof(char), static_cast<size_t>(size_), out_);
             fflush(out_);
             size_ = 0;
         }
@@ -48,7 +48,7 @@ class OutputBuffer {
     void endl() {
         constexpr auto n = 8192;
         if (out_ != nullptr && size_ > n) {
-            fwrite(buf_.data(), sizeof(char), size_, out_);
+            fwrite(buf_.data(), sizeof(char), static_cast<size_t>(size_), out_);
             size_ = 0;
         }
     }
@@ -84,7 +84,7 @@ class OutputBuffer {
 
     //! Empty the buffer and return a vector with the previous content.
     auto release() -> std::vector<char> {
-        buf_.resize(size_);
+        buf_.resize(static_cast<size_t>(size_));
         buf_.emplace_back('\0');
         auto ret = std::move(buf_);
         buf_.clear();

--- a/lib/util/include/clingo/util/small_vector.hh
+++ b/lib/util/include/clingo/util/small_vector.hh
@@ -59,10 +59,10 @@ class small_vector {
     template <std::input_iterator It, std::sentinel_for<It> Is> void assign(It first, Is last) {
         clear();
         if constexpr (std::sized_sentinel_for<Is, It>) {
-            size_t n = std::ranges::distance(first, last);
+            auto n = static_cast<size_t>(std::ranges::distance(first, last));
             reserve(n);
             auto ib = begin();
-            auto ie = std::next(ib, n);
+            auto ie = std::next(ib, static_cast<std::ptrdiff_t>(n));
             std::ranges::uninitialized_copy(first, last, ib, ie);
             if (is_small_()) {
                 size_small_(n);
@@ -90,7 +90,7 @@ class small_vector {
             clear();
             if (other.is_small_()) {
                 std::uninitialized_move_n(other.begin_small_(), other.size_small_(), begin_small_());
-                std::ranges::destroy_n(other.begin_small_(), other.size_small_());
+                std::ranges::destroy_n(other.begin_small_(), static_cast<std::ptrdiff_t>(other.size_small_()));
                 std::ranges::swap(other.begin_, begin_);
             } else {
                 std::ranges::swap(begin_, other.begin_);
@@ -123,7 +123,7 @@ class small_vector {
         if (is_small_()) {
             return size_small_();
         }
-        return std::ranges::distance(begin_large_(), end_large_());
+        return static_cast<size_t>(std::ranges::distance(begin_large_(), end_large_()));
     }
 
     //! Check if the vector is empty.
@@ -138,7 +138,7 @@ class small_vector {
         if (is_small_()) {
             return N;
         }
-        return std::ranges::distance(begin_large_(), cap_large_());
+        return static_cast<size_t>(std::ranges::distance(begin_large_(), cap_large_()));
     }
 
     //! Get an iterator to the beginning of the vector.
@@ -156,7 +156,7 @@ class small_vector {
     //! Get an iterator to the end of the vector.
     [[nodiscard]] auto end() -> iterator {
         if (is_small_()) {
-            return std::ranges::next(begin(), size_small_());
+            return std::ranges::next(begin(), static_cast<std::ptrdiff_t>(size_small_()));
         }
         return end_large_();
     }
@@ -182,13 +182,13 @@ class small_vector {
     //! Get the element at the given index.
     [[nodiscard]] auto operator[](size_t i) -> reference {
         assert(i < size());
-        return *std::ranges::next(begin(), i);
+        return *std::ranges::next(begin(), static_cast<std::ptrdiff_t>(i));
     }
 
     //! Get the element at the given index.
     [[nodiscard]] auto operator[](size_t i) const -> const_reference {
         assert(i < size());
-        return *std::ranges::next(begin(), i);
+        return *std::ranges::next(begin(), static_cast<std::ptrdiff_t>(i));
     }
 
     //! Reserve space for at least n elements.
@@ -203,8 +203,8 @@ class small_vector {
             destroy_();
             // NOLINTNEXTLINE(cppcoreguidelines-pro-type-reinterpret-cast)
             begin_ = reinterpret_cast<uintptr_t>(data);
-            end_large_() = std::ranges::next(begin_large_(), l);
-            cap_large_() = std::ranges::next(begin_large_(), n);
+            end_large_() = std::ranges::next(begin_large_(), static_cast<std::ptrdiff_t>(l));
+            cap_large_() = std::ranges::next(begin_large_(), static_cast<std::ptrdiff_t>(n));
         }
         assert(check_());
     }
@@ -252,7 +252,7 @@ class small_vector {
         if (auto n = std::ranges::distance(first, last); n > 0) {
             std::ranges::destroy(std::move(last, end(), first), end());
             if (is_small_()) {
-                size_small_(size_small_() - n);
+                size_small_(size_small_() - static_cast<size_t>(n));
             } else {
                 std::ranges::advance(end_large_(), -n);
                 std::ranges::advance(last, -n);

--- a/lib/util/include/clingo/util/string.hh
+++ b/lib/util/include/clingo/util/string.hh
@@ -12,13 +12,13 @@ namespace Detail {
 
 inline auto hex_val(char c) -> uint32_t {
     if (c >= '0' && c <= '9') {
-        return c - '0';
+        return static_cast<uint32_t>(c - '0');
     }
     if (c >= 'A' && c <= 'F') {
-        return 10 + (c - 'A');
+        return static_cast<uint32_t>(10 + (c - 'A'));
     }
     if (c >= 'a' && c <= 'f') {
-        return 10 + (c - 'a');
+        return static_cast<uint32_t>(10 + (c - 'a'));
     }
     throw std::invalid_argument("invalid hex character");
 }


### PR DESCRIPTION
This cleans up the implicit signed/unsigned conversions in clingo's own code under `lib/` and `app/`, so the whole tree builds cleanly under `-Wconversion -Wsign-conversion`.

**Why.** Each instance compiles just fine, but it makes the code difficult to both understand and reason about since each conversion requires a kind of mental reset, and it feels error prone in the long term. Making each conversion explicit removes that cost.

**What it does.** One uniform discipline, applied site by site rather than with a blanket cast:

- unsigned index/size types, and `std::cmp_*` for mixed-sign comparisons, where that's the right fix;
- at the real signedness boundaries — a `std::distance` used as a size, a literal known positive by an `assert`, a freshly minted id — an explicit `static_cast` with a one-line comment naming the invariant that makes it safe;
- the re2c-generated lexer include is wrapped in a diagnostic pragma, since the generated scanner reads a `char` buffer as `unsigned char` and isn't hand-maintained; the rest of that TU stays covered.

Representative before/after:

```cpp
// lib/ground/src/disjunction.cc — distance used as an index
-    return atoms_.find(sym) - atoms_.begin();
+    return static_cast<size_t>(atoms_.find(sym) - atoms_.begin());

// lib/control/src/solver.cc — literal known positive by the assert above it
     assert(lit > 0 && lit <= prg_lit_max);
-    return lit;
+    // lit > 0 (asserted above)
+    return static_cast<Potassco::Atom_t>(lit);
```

**Scope.** Behavior-preserving; every conversion here already happened implicitly and in range. It touches only `lib/` and `app/` (clingo's own code) — no public C API/ABI change, and it does **not** turn on any warning flag in the build; verifying the claim is just configuring with `-Wconversion -Wsign-conversion`. Two atom-id/literal casts are left with a `FIXME`: that pair is a genuine type conflation, and I'd rather fix it with distinct atom/literal types in a separate change than bury it in a cast here.

**Heads-up on where this goes.** This is deliberately just the mechanical cleanup. As a self-contained follow-up I'd like to give program atoms and literals small distinct value-types (a positive atom id vs. a signed literal, modelled on clingo's own `Symbol`), so the atom/literal conversions this PR makes *explicit* become named, total operations — and the two `FIXME`-marked id casts go away by construction rather than by comment. Roughly the shape, on one of the `std::abs` bridges in this diff:

```cpp
// this PR — explicit, but still bridges a literal to an atom by magnitude:
*is_fact = get_program(atoms).isFact(static_cast<clingo_atom_t>(std::abs(literal)));

// the follow-up — the conversion names what it means, and the raw form stays quarantined:
*is_fact = get_program(atoms).isFact(Literal::from_rep(literal).atom().index());
```

That's a separate PR on top of this one, not a dependency of it — I kept this change purely to the signedness pass so each stands on its own.

Tested with a clean `-Wconversion -Wsign-conversion` build and the full test suite.
