### PR TITLE
Estimate empty recursive domains when ordering a rule body

### DIFF
--- a/lib/c-api/src/control.cc
+++ b/lib/c-api/src/control.cc
@@ -83,7 +83,7 @@ extern "C" auto clingo_control_new(clingo_lib_t *lib, clingo_string_t const *arg
             clasp->startAsp(*slv_cfg, !opts.solver_options().single_shot);
         }
         auto slv = std::make_unique<CppClingo::Control::Solver>(*clasp, *slv_cfg, lib->log, *lib->store, lib->scripts,
-                                                                opts.rewrite_options(), opts.solver_options(), nullptr);
+                                                                opts.solver_options(), nullptr);
         opts.apply(*slv);
         *control = new clingo_control{lib, std::move(slv), std::move(slv_cfg), std::move(clasp)};
     }

--- a/lib/c-api/src/main.cc
+++ b/lib/c-api/src/main.cc
@@ -230,14 +230,8 @@ class ClingoApp : public Clasp::Cli::ClaspAppBase {
             if (opts_.mode() == AppMode::solve) {
                 clasp.startAsp(config(), false);
             }
-            auto slv = CppClingo::Control::Solver{clasp,
-                                                  config(),
-                                                  ctl_->lib->log,
-                                                  *ctl_->lib->store,
-                                                  ctl_->lib->scripts,
-                                                  opts_.rewrite_options(),
-                                                  opts_.solver_options(),
-                                                  stdout};
+            auto slv = CppClingo::Control::Solver{
+                clasp, config(), ctl_->lib->log, *ctl_->lib->store, ctl_->lib->scripts, opts_.solver_options(), stdout};
             opts_.apply(slv);
             // NOTE: member for createTextOutput
             ctl_->bind(&slv, &slv.config().clasp(), &slv.clasp_facade());

--- a/lib/c-api/src/opts.hh
+++ b/lib/c-api/src/opts.hh
@@ -245,7 +245,7 @@ class ClingoOptions {
             ("@1,project-anonymous", flag(solver_opts_.ropts.project_anonymous = false),
              "Project anonymous variables in negative literals") //
             ("@1,estimate-function",
-             storeTo(solver_opts_.gopts.fun = EstimateFunction::minimum, values<EstimateFunction>({
+             storeTo(solver_opts_.gopts.fun = EstimateFunction::average, values<EstimateFunction>({
                                                                              {"min", EstimateFunction::minimum},
                                                                              {"max", EstimateFunction::maximum},
                                                                              {"avg", EstimateFunction::average},

--- a/lib/c-api/src/opts.hh
+++ b/lib/c-api/src/opts.hh
@@ -141,7 +141,7 @@ class ClingoOptions {
                        });
             };
 
-            rewrite_opts_.profile = Input::ProfileFlags::off;
+            solver_opts_.ropts.profile = Input::ProfileFlags::off;
             auto x = split(str, ",");
             if (x.empty() || x.size() >= 3) {
                 return false;
@@ -150,25 +150,25 @@ class ClingoOptions {
                 return x.size() == 1;
             }
             if (ieq(x[0], "detailed")) {
-                rewrite_opts_.profile |= Input::ProfileFlags::detailed;
+                solver_opts_.ropts.profile |= Input::ProfileFlags::detailed;
             } else if (ieq(x[0], "compact")) {
-                rewrite_opts_.profile -= Input::ProfileFlags::detailed;
+                solver_opts_.ropts.profile -= Input::ProfileFlags::detailed;
             } else {
                 return false;
             }
             if (x.size() >= 2) {
                 if (ieq(x[1], "step")) {
-                    rewrite_opts_.profile |= Input::ProfileFlags::step;
+                    solver_opts_.ropts.profile |= Input::ProfileFlags::step;
                 } else if (ieq(x[1], "accu")) {
-                    rewrite_opts_.profile |= Input::ProfileFlags::accu;
+                    solver_opts_.ropts.profile |= Input::ProfileFlags::accu;
                 } else if (ieq(x[1], "both")) {
-                    rewrite_opts_.profile |= Input::ProfileFlags::step;
-                    rewrite_opts_.profile |= Input::ProfileFlags::accu;
+                    solver_opts_.ropts.profile |= Input::ProfileFlags::step;
+                    solver_opts_.ropts.profile |= Input::ProfileFlags::accu;
                 } else {
                     return false;
                 }
             } else {
-                rewrite_opts_.profile |= Input::ProfileFlags::accu;
+                solver_opts_.ropts.profile |= Input::ProfileFlags::accu;
             }
             return true;
         };
@@ -235,15 +235,28 @@ class ClingoOptions {
 
              "Stop when {none|sat|unsat|unknown} in incmode") //
             ("@1,projection-mode",
-             storeTo(rewrite_opts_.project_mode = Input::ProjectionMode::pure,
+             storeTo(solver_opts_.ropts.project_mode = Input::ProjectionMode::pure,
                      values<Input::ProjectionMode>({
                          {"none", Input::ProjectionMode::disabled},
                          {"anonymous", Input::ProjectionMode::anonymous},
                          {"pure", Input::ProjectionMode::pure},
                      })),
              "Project {none|anonymous|pure} variables") //
-            ("@1,project-anonymous", flag(rewrite_opts_.project_anonymous = false),
-             "Project anonymous variables in negative literals")                      //
+            ("@1,project-anonymous", flag(solver_opts_.ropts.project_anonymous = false),
+             "Project anonymous variables in negative literals") //
+            ("@1,estimate-function",
+             storeTo(solver_opts_.gopts.fun = EstimateFunction::minimum, values<EstimateFunction>({
+                                                                             {"min", EstimateFunction::minimum},
+                                                                             {"max", EstimateFunction::maximum},
+                                                                             {"avg", EstimateFunction::average},
+                                                                         })),
+             "Use {min|max|avg} to combine estimates for recursive domains.") //
+            ("@1,estimate-selector",
+             storeTo(solver_opts_.gopts.sel = EstimateSelector::pred, values<EstimateSelector>({
+                                                                          {"predicate", EstimateSelector::pred},
+                                                                          {"all", EstimateSelector::all},
+                                                                      })),
+             "Use {predicate|all} literals for recursive domain estimation.")         //
             ("show", parse(parse_sigs), "Comma-separated list of predicates to show") //
             ("profile", parse(parse_profile).implicit("detailed").arg("off|<detail>[,<type>]"),
              R"(Enable profiling of grounding
@@ -326,14 +339,12 @@ class ClingoOptions {
     auto mode() -> Control::AppMode & { return solver_opts_.mode; }
     auto backend_type() -> Control::BackendType & { return solver_opts_.backend_type; }
 
-    auto rewrite_options() -> Input::RewriteOptions const & { return rewrite_opts_; }
     auto solver_options() -> Control::SolverOptions const & { return solver_opts_; }
 
   private:
     Logger *log_;
     SymbolStore *store_;
     Input::Parser parser_;
-    Input::RewriteOptions rewrite_opts_;
     Control::SolverOptions solver_opts_;
     std::vector<CppClingo::Input::SharedSig> show_;
     std::optional<Control::ProgramParamVec> parts_;

--- a/lib/control/include/clingo/control/grounder.hh
+++ b/lib/control/include/clingo/control/grounder.hh
@@ -12,8 +12,11 @@ namespace CppClingo::Control {
 //! @addtogroup control
 //! @{
 
+//! Options to fine-tune the grounding process.
 struct GroundOptions {
+    //! Function to combine estimates for recursive domains.
     EstimateFunction fun = EstimateFunction::average;
+    //! Selector to choose what kind of literals to use for recursive domains.
     EstimateSelector sel = EstimateSelector::pred;
 };
 
@@ -22,9 +25,15 @@ struct GroundOptions {
 //! Takes care of parsing, grounding, and output.
 class Grounder {
   public:
+    Grounder(Grounder const &) = delete;
+    Grounder(Grounder &&) = delete;
+    auto operator=(Grounder const &) -> Grounder & = delete;
+    auto operator=(Grounder &&) -> Grounder & = delete;
+
     struct Impl;
     //! Create a grounder object.
-    Grounder(Logger &log, SymbolStore &store, Input::RewriteOptions opts, GroundOptions gopts, OutputStm &out);
+    Grounder(Logger &log, SymbolStore &store, Input::RewriteOptions const &opts, GroundOptions const &gopts,
+             OutputStm &out);
     //! Destroy grounder.
     ~Grounder() noexcept;
     //! Join with the given program.

--- a/lib/control/include/clingo/control/grounder.hh
+++ b/lib/control/include/clingo/control/grounder.hh
@@ -12,6 +12,11 @@ namespace CppClingo::Control {
 //! @addtogroup control
 //! @{
 
+struct GroundOptions {
+    EstimateFunction fun = EstimateFunction::average;
+    EstimateSelector sel = EstimateSelector::pred;
+};
+
 //! A grounder for logic programs.
 //!
 //! Takes care of parsing, grounding, and output.
@@ -19,7 +24,7 @@ class Grounder {
   public:
     struct Impl;
     //! Create a grounder object.
-    Grounder(Logger &log, SymbolStore &store, Input::RewriteOptions opts, OutputStm &out);
+    Grounder(Logger &log, SymbolStore &store, Input::RewriteOptions opts, GroundOptions gopts, OutputStm &out);
     //! Destroy grounder.
     ~Grounder() noexcept;
     //! Join with the given program.

--- a/lib/control/include/clingo/control/solver.hh
+++ b/lib/control/include/clingo/control/solver.hh
@@ -87,6 +87,10 @@ CLINGO_ENABLE_BITSET_ENUM(ReifyFlags);
 
 //! Options for the solver.
 struct SolverOptions {
+    //! The rewrite options.
+    Input::RewriteOptions ropts;
+    //! Options to fine tune grounding.
+    GroundOptions gopts;
     //! Operation mode of the solver.
     AppMode mode = AppMode::solve;
     //! Output format to use when in solving mode.
@@ -688,9 +692,14 @@ class GroundHandle {
 //! Takes care of parsing, grounding, and solving.
 class Solver : public BaseView {
   public:
+    Solver(Solver const &) = delete;
+    Solver(Solver &&) = delete;
+    auto operator=(Solver const &) -> Solver & = delete;
+    auto operator=(Solver &&) -> Solver & = delete;
+
     //! Create a solver object.
     Solver(Clasp::ClaspFacade &clasp, Clasp::Cli::ClaspCliConfig &config, Logger &log, SymbolStore &store,
-           Scripts &scripts, Input::RewriteOptions ropts, SolverOptions sopts, FILE *out = stdout);
+           Scripts &scripts, SolverOptions opts, FILE *out = stdout);
 
     //! Parse, ground, and solve a program.
     void main(std::span<std::string_view const> const &files);

--- a/lib/control/include/clingo/control/solver.hh
+++ b/lib/control/include/clingo/control/solver.hh
@@ -887,13 +887,13 @@ class Solver : public BaseView {
     std::unique_ptr<Output::TheoryData> theory_;
     std::unique_ptr<Potassco::AbstractProgram> output_program_;
     std::unique_ptr<Potassco::AbstractProgram> program_;
+    SolverOptions opts_;
     UOutputStm out_;
     UModel mdl_;
     USymbolTable sym_tab_;
     Grounder grd_;
     Scripts *scripts_;
     State state_ = State::initial;
-    SolverOptions opts_;
     BuiltinIncludes includes_ = BuiltinIncludes::empty;
     void *data_ = nullptr;
     bool block_main_ = false;

--- a/lib/control/src/grounder.cc
+++ b/lib/control/src/grounder.cc
@@ -42,9 +42,9 @@ class Builder : public Input::DependencyBuilder {
     //! Construct the builder.
     Builder(std::pmr::monotonic_buffer_resource &mbr, Logger &log, SymbolStore &store, TheorySigVec theory_directives,
             Ground::Bases &base, Ground::ScriptCallback *context, OutputStm &out, ProfileProgram &profile,
-            Util::StopFlag *stop)
+            GroundOptions const &opts, Util::StopFlag *stop)
         : mbr_{&mbr}, log_{&log}, store_{&store}, theory_directives_{std::move(theory_directives)}, bases_{&base},
-          context_{context}, out_{&out}, profile_{&profile}, stop_{stop} {}
+          context_{context}, out_{&out}, opts_{&opts}, profile_{&profile}, stop_{stop} {}
 
   private:
     //! Handle program parameters.
@@ -71,7 +71,7 @@ class Builder : public Input::DependencyBuilder {
 
     //! Translate components.
     auto do_components(Input::Components const &comps) -> GroundResult override {
-        auto lin = Ground::Linearizer{*mbr_};
+        auto lin = Ground::Linearizer{*mbr_, opts_->fun, opts_->sel};
         for (auto const &ref_comps : comps) {
             CLINGO_REPORT(*log_, debug) << "  component";
             for (auto const &ref_comp : ref_comps) {
@@ -134,6 +134,7 @@ class Builder : public Input::DependencyBuilder {
     Ground::Bases *bases_;
     Ground::ScriptCallback *context_;
     OutputStm *out_;
+    GroundOptions const *opts_;
     ProfileProgram *profile_;
     Util::StopFlag *stop_;
     std::ostringstream buf_;
@@ -144,8 +145,8 @@ class Builder : public Input::DependencyBuilder {
 //! Class storing/hiding relevant state for grounding.
 struct Grounder::Impl : CppClingo::SymbolOwner {
     //! Construct the grounder implementation.
-    Impl(Logger &log, SymbolStore &store, Input::RewriteOptions opts, OutputStm &out)
-        : log{&log}, store{&store}, prg{opts}, out{&out} {
+    Impl(Logger &log, SymbolStore &store, Input::RewriteOptions ropts, GroundOptions gopts, OutputStm &out)
+        : log{&log}, store{&store}, prg{ropts}, opts{gopts}, out{&out} {
         this->store->gc_add_owner(*this);
     }
     //! Destroy the grounder implementation.
@@ -281,6 +282,8 @@ struct Grounder::Impl : CppClingo::SymbolOwner {
     Input::UnprocessedProgram unprocessed_prg;
     //! The program stored in the grounder.
     Input::Program prg;
+    //! Options to fine ture grounding.
+    GroundOptions opts;
     //! The atom and term bases.
     Ground::Bases bases;
     //! Profiling data.
@@ -291,8 +294,8 @@ struct Grounder::Impl : CppClingo::SymbolOwner {
     GroundResult status = GroundResult::ok;
 };
 
-Grounder::Grounder(Logger &log, SymbolStore &store, Input::RewriteOptions opts, OutputStm &out)
-    : impl_{std::make_unique<Impl>(log, store, opts, out)} {
+Grounder::Grounder(Logger &log, SymbolStore &store, Input::RewriteOptions opts, GroundOptions gopts, OutputStm &out)
+    : impl_{std::make_unique<Impl>(log, store, opts, gopts, out)} {
 }
 
 Grounder::~Grounder() noexcept = default;
@@ -399,9 +402,9 @@ auto Grounder::ground(Input::ProgramParamVec const &params, Ground::ScriptCallba
     if (impl_->status == GroundResult::ok) {
         impl_->prg.check(*impl_->log);
         impl_->bases.clear_aux();
-        auto bld =
-            Builder{impl_->mbr,  *impl_->log,    *impl_->store, impl_->prg.theory_directives(), impl_->bases, context,
-                    *impl_->out, impl_->profile, stop};
+        auto bld = Builder{impl_->mbr,   *impl_->log, *impl_->store, impl_->prg.theory_directives(),
+                           impl_->bases, context,     *impl_->out,   impl_->profile,
+                           impl_->opts,  stop};
         impl_->status = impl_->prg.analyze(*impl_->store, params, bld);
         impl_->meta();
         impl_->project();

--- a/lib/control/src/grounder.cc
+++ b/lib/control/src/grounder.cc
@@ -145,8 +145,9 @@ class Builder : public Input::DependencyBuilder {
 //! Class storing/hiding relevant state for grounding.
 struct Grounder::Impl : CppClingo::SymbolOwner {
     //! Construct the grounder implementation.
-    Impl(Logger &log, SymbolStore &store, Input::RewriteOptions ropts, GroundOptions gopts, OutputStm &out)
-        : log{&log}, store{&store}, prg{ropts}, opts{gopts}, out{&out} {
+    Impl(Logger &log, SymbolStore &store, Input::RewriteOptions const &ropts, GroundOptions const &gopts,
+         OutputStm &out)
+        : log{&log}, store{&store}, prg{ropts}, opts{&gopts}, out{&out} {
         this->store->gc_add_owner(*this);
     }
     //! Destroy the grounder implementation.
@@ -283,7 +284,7 @@ struct Grounder::Impl : CppClingo::SymbolOwner {
     //! The program stored in the grounder.
     Input::Program prg;
     //! Options to fine ture grounding.
-    GroundOptions opts;
+    GroundOptions const *opts;
     //! The atom and term bases.
     Ground::Bases bases;
     //! Profiling data.
@@ -294,7 +295,8 @@ struct Grounder::Impl : CppClingo::SymbolOwner {
     GroundResult status = GroundResult::ok;
 };
 
-Grounder::Grounder(Logger &log, SymbolStore &store, Input::RewriteOptions opts, GroundOptions gopts, OutputStm &out)
+Grounder::Grounder(Logger &log, SymbolStore &store, Input::RewriteOptions const &opts, GroundOptions const &gopts,
+                   OutputStm &out)
     : impl_{std::make_unique<Impl>(log, store, opts, gopts, out)} {
 }
 
@@ -404,7 +406,7 @@ auto Grounder::ground(Input::ProgramParamVec const &params, Ground::ScriptCallba
         impl_->bases.clear_aux();
         auto bld = Builder{impl_->mbr,   *impl_->log, *impl_->store, impl_->prg.theory_directives(),
                            impl_->bases, context,     *impl_->out,   impl_->profile,
-                           impl_->opts,  stop};
+                           *impl_->opts, stop};
         impl_->status = impl_->prg.analyze(*impl_->store, params, bld);
         impl_->meta();
         impl_->project();

--- a/lib/control/src/solver.cc
+++ b/lib/control/src/solver.cc
@@ -1142,10 +1142,10 @@ auto SymbolTable::output(CppClingo::Symbol const &sym) -> State & {
 }
 
 Solver::Solver(Clasp::ClaspFacade &clasp, Clasp::Cli::ClaspCliConfig &clasp_config, Logger &log, SymbolStore &store,
-               Scripts &scripts, SolverOptions sopts, FILE *out)
-    : clasp_{&clasp}, config_{clasp_config}, stream_{out},
-      out_{make_output_(store, sopts.mode, sopts.backend_type, sopts.reify_flags)},
-      grd_{log, store, sopts.ropts, sopts.gopts, *out_}, scripts_{&scripts}, opts_{std::move(sopts)} {
+               Scripts &scripts, SolverOptions opts, FILE *out)
+    : clasp_{&clasp}, config_{clasp_config}, stream_{out}, opts_{std::move(opts)},
+      out_{make_output_(store, opts_.mode, opts_.backend_type, opts_.reify_flags)},
+      grd_{log, store, opts_.ropts, opts_.gopts, *out_}, scripts_{&scripts} {
 }
 
 auto Solver::make_output_(SymbolStore &store, AppMode mode, BackendType backend_type, ReifyFlags reify_flags)

--- a/lib/control/src/solver.cc
+++ b/lib/control/src/solver.cc
@@ -1142,10 +1142,10 @@ auto SymbolTable::output(CppClingo::Symbol const &sym) -> State & {
 }
 
 Solver::Solver(Clasp::ClaspFacade &clasp, Clasp::Cli::ClaspCliConfig &clasp_config, Logger &log, SymbolStore &store,
-               Scripts &scripts, Input::RewriteOptions ropts, SolverOptions sopts, FILE *out)
+               Scripts &scripts, SolverOptions sopts, FILE *out)
     : clasp_{&clasp}, config_{clasp_config}, stream_{out},
-      out_{make_output_(store, sopts.mode, sopts.backend_type, sopts.reify_flags)}, grd_{log, store, ropts, *out_},
-      scripts_{&scripts}, opts_{std::move(sopts)} {
+      out_{make_output_(store, sopts.mode, sopts.backend_type, sopts.reify_flags)},
+      grd_{log, store, sopts.ropts, sopts.gopts, *out_}, scripts_{&scripts}, opts_{std::move(sopts)} {
 }
 
 auto Solver::make_output_(SymbolStore &store, AppMode mode, BackendType backend_type, ReifyFlags reify_flags)

--- a/lib/control/tests/logger.cc
+++ b/lib/control/tests/logger.cc
@@ -14,11 +14,12 @@ TEST_CASE("logger_test") {
     auto ground = [&](char const *str) {
         auto msgs = V{};
         auto opts = Input::RewriteOptions{};
+        auto gopts = Control::GroundOptions{};
         auto log = Logger{[&msgs]([[maybe_unused]] MessageCode code, std::string_view msg) { msgs.emplace_back(msg); }};
         log.set_level(LogLevel::info);
         auto buf = Util::OutputBuffer{};
         auto out = Output::make_text_output(buf);
-        Control::Grounder grd{log, *store, opts, *out};
+        Control::Grounder grd{log, *store, opts, gopts, *out};
         grd.parse(str);
         auto params = Input::ProgramParamVec{{store->string("base"), {}}};
         REQUIRE(grd.ground(params) == GroundResult::ok);

--- a/lib/control/tests/text.cc
+++ b/lib/control/tests/text.cc
@@ -14,11 +14,12 @@ TEST_CASE("grounder_text") {
     auto store = make_symbol_store(true, false);
     SECTION("ground") {
         auto opts = Input::RewriteOptions{};
+        auto gopts = Control::GroundOptions{};
         auto log = Logger{};
         log.set_level(LogLevel::error);
         auto buf = Util::OutputBuffer{};
         auto out = Output::make_text_output(buf);
-        auto grd = Control::Grounder{log, *store, opts, *out};
+        auto grd = Control::Grounder{log, *store, opts, gopts, *out};
         auto params = Input::ProgramParamVec{{store->string("base"), {}}};
         SECTION("fact") {
             grd.parse("#show. a.");
@@ -686,11 +687,12 @@ TEST_CASE("grounder_text") {
             using SV = std::vector<std::string>;
             auto ground = [&store](std::string_view prg) {
                 auto opts = Input::RewriteOptions{};
+                auto gopts = Control::GroundOptions{};
                 auto log = Logger{};
                 log.set_level(LogLevel::error);
                 auto buf = Util::OutputBuffer{};
                 auto out = Output::make_text_output(buf);
-                auto grd = Control::Grounder{log, *store, opts, *out};
+                auto grd = Control::Grounder{log, *store, opts, gopts, *out};
                 auto params = Input::ProgramParamVec{{store->string("base"), {}}};
                 grd.parse(R"(
                     p(12345).

--- a/lib/core/include/clingo/core/core.hh
+++ b/lib/core/include/clingo/core/core.hh
@@ -190,6 +190,21 @@ enum class GroundResult : uint8_t {
     interrupted,   //!< The grounding was interrupted.
 };
 
+//! Estimate to use if no other values are at hand.
+static constexpr double default_estimate_size = 10000.0;
+
+//! Function to combine domain size estimates.
+enum class EstimateFunction : uint8_t {
+    maximum, //!< Use the maximum of the estimates.
+    minimum, //!< Use the minimum of the estimates.
+    average, //!< Use the average of the estimates.
+};
+
+enum class EstimateSelector : uint8_t {
+    pred, //!< Only consider predicates.
+    all,  //!< Consider all literals.
+};
+
 //! @}
 
 } // namespace CppClingo

--- a/lib/core/include/clingo/core/core.hh
+++ b/lib/core/include/clingo/core/core.hh
@@ -200,6 +200,7 @@ enum class EstimateFunction : uint8_t {
     average, //!< Use the average of the estimates.
 };
 
+//! Selector for which estimates to consider.
 enum class EstimateSelector : uint8_t {
     pred, //!< Only consider predicates.
     all,  //!< Consider all literals.

--- a/lib/ground/include/clingo/ground/assignment_aggregate.hh
+++ b/lib/ground/include/clingo/ground/assignment_aggregate.hh
@@ -279,7 +279,8 @@ class LitAssignAggr : public Lit, private MatchAssignAggr {
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
 
-    [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound) const -> double override;
+    [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound,
+                                [[maybe_unused]] double recursive_estimate) const -> double override;
 
     void do_print(std::ostream &out) const override;
 
@@ -375,7 +376,8 @@ class LitAssignAggrStrat : public Lit, private MatchAssignAggr {
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
 
-    [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound) const -> double override;
+    [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound,
+                                [[maybe_unused]] double recursive_estimate) const -> double override;
 
     void do_print(std::ostream &out) const override;
 

--- a/lib/ground/include/clingo/ground/assignment_aggregate.hh
+++ b/lib/ground/include/clingo/ground/assignment_aggregate.hh
@@ -279,8 +279,8 @@ class LitAssignAggr : public Lit, private MatchAssignAggr {
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
 
-    [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound,
-                                [[maybe_unused]] double recursive_estimate) const -> double override;
+    [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
+        -> double override;
 
     void do_print(std::ostream &out) const override;
 
@@ -376,8 +376,8 @@ class LitAssignAggrStrat : public Lit, private MatchAssignAggr {
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
 
-    [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound,
-                                [[maybe_unused]] double recursive_estimate) const -> double override;
+    [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
+        -> double override;
 
     void do_print(std::ostream &out) const override;
 

--- a/lib/ground/include/clingo/ground/assignment_aggregate.hh
+++ b/lib/ground/include/clingo/ground/assignment_aggregate.hh
@@ -281,6 +281,7 @@ class LitAssignAggr : public Lit, private MatchAssignAggr {
 
     [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
+    [[nodiscard]] auto do_domain_size(EstimateSelector sel) const -> std::optional<double> override;
 
     void do_print(std::ostream &out) const override;
 
@@ -378,6 +379,8 @@ class LitAssignAggrStrat : public Lit, private MatchAssignAggr {
 
     [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
+
+    [[nodiscard]] auto do_domain_size(EstimateSelector sel) const -> std::optional<double> override;
 
     void do_print(std::ostream &out) const override;
 

--- a/lib/ground/include/clingo/ground/body_aggregate.hh
+++ b/lib/ground/include/clingo/ground/body_aggregate.hh
@@ -327,7 +327,8 @@ class LitBdAggr : public Lit, private MatchBdAggr {
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
 
-    [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound) const -> double override;
+    [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound,
+                                [[maybe_unused]] double recursive_estimate) const -> double override;
 
     void do_print(std::ostream &out) const override;
 
@@ -429,7 +430,8 @@ class LitBdAggrStrat : public Lit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound) const -> double override;
+    [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound,
+                                [[maybe_unused]] double recursive_estimate) const -> double override;
     void do_print(std::ostream &out) const override;
     auto do_output([[maybe_unused]] EvalContext const &ctx, OutputLit &out) const -> bool override;
     [[nodiscard]] auto do_copy() const -> ULit override;

--- a/lib/ground/include/clingo/ground/body_aggregate.hh
+++ b/lib/ground/include/clingo/ground/body_aggregate.hh
@@ -327,8 +327,8 @@ class LitBdAggr : public Lit, private MatchBdAggr {
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
 
-    [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound,
-                                [[maybe_unused]] double recursive_estimate) const -> double override;
+    [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
+        -> double override;
 
     void do_print(std::ostream &out) const override;
 
@@ -430,8 +430,8 @@ class LitBdAggrStrat : public Lit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound,
-                                [[maybe_unused]] double recursive_estimate) const -> double override;
+    [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
+        -> double override;
     void do_print(std::ostream &out) const override;
     auto do_output([[maybe_unused]] EvalContext const &ctx, OutputLit &out) const -> bool override;
     [[nodiscard]] auto do_copy() const -> ULit override;

--- a/lib/ground/include/clingo/ground/body_aggregate.hh
+++ b/lib/ground/include/clingo/ground/body_aggregate.hh
@@ -329,6 +329,7 @@ class LitBdAggr : public Lit, private MatchBdAggr {
 
     [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
+    [[nodiscard]] auto do_domain_size([[maybe_unused]] EstimateSelector sel) const -> std::optional<double> override;
 
     void do_print(std::ostream &out) const override;
 
@@ -432,6 +433,7 @@ class LitBdAggrStrat : public Lit {
         -> std::pair<UMatcher, std::optional<size_t>> override;
     [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
+    [[nodiscard]] auto do_domain_size([[maybe_unused]] EstimateSelector sel) const -> std::optional<double> override;
     void do_print(std::ostream &out) const override;
     auto do_output([[maybe_unused]] EvalContext const &ctx, OutputLit &out) const -> bool override;
     [[nodiscard]] auto do_copy() const -> ULit override;

--- a/lib/ground/include/clingo/ground/condlit.hh
+++ b/lib/ground/include/clingo/ground/condlit.hh
@@ -408,7 +408,8 @@ class LitCondLit : public Lit, private MatchCondLit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound) const -> double override;
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+        -> double override;
     void do_print(std::ostream &out) const override;
     [[nodiscard]] auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
     [[nodiscard]] auto do_copy() const -> ULit override;
@@ -435,7 +436,8 @@ class LitCondLitStrat : public Lit, private InstanceCallback {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound) const -> double override;
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+        -> double override;
     void do_print(std::ostream &out) const override;
     [[nodiscard]] auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
     [[nodiscard]] auto do_copy() const -> ULit override;

--- a/lib/ground/include/clingo/ground/condlit.hh
+++ b/lib/ground/include/clingo/ground/condlit.hh
@@ -410,6 +410,7 @@ class LitCondLit : public Lit, private MatchCondLit {
         -> std::pair<UMatcher, std::optional<size_t>> override;
     [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
+    [[nodiscard]] auto do_domain_size(EstimateSelector sel) const -> std::optional<double> override;
     void do_print(std::ostream &out) const override;
     [[nodiscard]] auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
     [[nodiscard]] auto do_copy() const -> ULit override;
@@ -438,6 +439,7 @@ class LitCondLitStrat : public Lit, private InstanceCallback {
         -> std::pair<UMatcher, std::optional<size_t>> override;
     [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
+    [[nodiscard]] auto do_domain_size(EstimateSelector sel) const -> std::optional<double> override;
     void do_print(std::ostream &out) const override;
     [[nodiscard]] auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
     [[nodiscard]] auto do_copy() const -> ULit override;

--- a/lib/ground/include/clingo/ground/condlit.hh
+++ b/lib/ground/include/clingo/ground/condlit.hh
@@ -408,7 +408,7 @@ class LitCondLit : public Lit, private MatchCondLit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
     void do_print(std::ostream &out) const override;
     [[nodiscard]] auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
@@ -436,7 +436,7 @@ class LitCondLitStrat : public Lit, private InstanceCallback {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
     void do_print(std::ostream &out) const override;
     [[nodiscard]] auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;

--- a/lib/ground/include/clingo/ground/disjunction.hh
+++ b/lib/ground/include/clingo/ground/disjunction.hh
@@ -270,7 +270,8 @@ class LitDisjunction : public Lit, private MatchDisjunction {
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
 
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound) const -> double override;
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+        -> double override;
 
     void do_print(std::ostream &out) const override;
 

--- a/lib/ground/include/clingo/ground/disjunction.hh
+++ b/lib/ground/include/clingo/ground/disjunction.hh
@@ -272,6 +272,7 @@ class LitDisjunction : public Lit, private MatchDisjunction {
 
     [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
+    [[nodiscard]] auto do_domain_size(EstimateSelector sel) const -> std::optional<double> override;
 
     void do_print(std::ostream &out) const override;
 

--- a/lib/ground/include/clingo/ground/disjunction.hh
+++ b/lib/ground/include/clingo/ground/disjunction.hh
@@ -270,7 +270,7 @@ class LitDisjunction : public Lit, private MatchDisjunction {
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
 
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
 
     void do_print(std::ostream &out) const override;

--- a/lib/ground/include/clingo/ground/head_aggregate.hh
+++ b/lib/ground/include/clingo/ground/head_aggregate.hh
@@ -366,7 +366,8 @@ class LitHdAggr : public Lit, private MatchHdAggr {
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
 
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound) const -> double override;
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+        -> double override;
 
     void do_print(std::ostream &out) const override;
 

--- a/lib/ground/include/clingo/ground/head_aggregate.hh
+++ b/lib/ground/include/clingo/ground/head_aggregate.hh
@@ -369,6 +369,8 @@ class LitHdAggr : public Lit, private MatchHdAggr {
     [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
 
+    [[nodiscard]] auto do_domain_size(EstimateSelector sel) const -> std::optional<double> override;
+
     void do_print(std::ostream &out) const override;
 
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;

--- a/lib/ground/include/clingo/ground/head_aggregate.hh
+++ b/lib/ground/include/clingo/ground/head_aggregate.hh
@@ -366,7 +366,7 @@ class LitHdAggr : public Lit, private MatchHdAggr {
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
 
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
 
     void do_print(std::ostream &out) const override;

--- a/lib/ground/include/clingo/ground/literal.hh
+++ b/lib/ground/include/clingo/ground/literal.hh
@@ -54,7 +54,17 @@ class Lit {
         return do_matcher(mbr, type, bound);
     }
     //! Compute a score used to order rule bodies.
-    [[nodiscard]] auto score(std::vector<bool> const &bound) const -> double { return do_score(bound); }
+    //!
+    //! A not-yet-grounded recursive domain reads as size 0 at linearization; `recursive_estimate`
+    //! is the size to score such a literal at instead. Literals without such a domain ignore it.
+    [[nodiscard]] auto score(std::vector<bool> const &bound, double recursive_estimate) const -> double {
+        return do_score(bound, recursive_estimate);
+    }
+    //! The size of the literal's own domain, or 0 for a literal without one.
+    //!
+    //! `order_` takes the largest of these over a body as the size to score a not-yet-grounded
+    //! recursive literal at (see `score`).
+    [[nodiscard]] auto domain_size() const -> double { return do_domain_size(); }
 
     //! Output the literal.
     //!
@@ -85,7 +95,8 @@ class Lit {
     [[nodiscard]] virtual auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                           std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> = 0;
-    [[nodiscard]] virtual auto do_score(std::vector<bool> const &bound) const -> double = 0;
+    [[nodiscard]] virtual auto do_score(std::vector<bool> const &bound, double recursive_estimate) const -> double = 0;
+    [[nodiscard]] virtual auto do_domain_size() const -> double { return 0; }
     virtual void do_print(std::ostream &out) const = 0;
     virtual auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool = 0;
     [[nodiscard]] virtual auto do_copy() const -> ULit = 0;
@@ -107,7 +118,8 @@ class LitComparison : public Lit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound) const -> double override;
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+        -> double override;
 
     void do_print(std::ostream &out) const override;
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
@@ -137,7 +149,8 @@ class LitExternal : public Lit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound) const -> double override;
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+        -> double override;
 
     void do_print(std::ostream &out) const override;
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
@@ -169,7 +182,8 @@ class LitInterval : public Lit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound) const -> double override;
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+        -> double override;
 
     void do_print(std::ostream &out) const override;
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
@@ -202,7 +216,8 @@ class LitSymbolic : public Lit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound) const -> double override;
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, double recursive_estimate) const -> double override;
+    [[nodiscard]] auto do_domain_size() const -> double override;
 
     void do_print(std::ostream &out) const override;
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
@@ -247,7 +262,8 @@ class LitProject : public Lit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound) const -> double override;
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, double recursive_estimate) const -> double override;
+    [[nodiscard]] auto do_domain_size() const -> double override;
     void do_print(std::ostream &out) const override;
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
 
@@ -282,7 +298,8 @@ class LitTuple : public Lit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound) const -> double override;
+    [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound,
+                                [[maybe_unused]] double recursive_estimate) const -> double override;
     void do_print(std::ostream &out) const override;
     auto do_output([[maybe_unused]] EvalContext const &ctx, OutputLit &out) const -> bool override;
     [[nodiscard]] auto do_copy() const -> ULit override;
@@ -304,7 +321,8 @@ class LitCheck : public Lit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound) const -> double override;
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+        -> double override;
 
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
 
@@ -385,7 +403,8 @@ class LitSimpleAggr : public Lit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound) const -> double override;
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+        -> double override;
 
     void do_print(std::ostream &out) const override;
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;

--- a/lib/ground/include/clingo/ground/literal.hh
+++ b/lib/ground/include/clingo/ground/literal.hh
@@ -63,9 +63,9 @@ class Lit {
     }
     //! The size of the literal's domain.
     //!
-    //! This value might be inaccurate for recursive domains, in which case the
-    //! current domain size at the point of calling this function is returned.
-    [[nodiscard]] auto domain_size() const -> double { return do_domain_size(); }
+    //! This function only returns a value that matche the given selector and
+    //! that have know sizes.
+    [[nodiscard]] auto domain_size(EstimateSelector sel) const -> std::optional<double> { return do_domain_size(sel); }
 
     //! Output the literal.
     //!
@@ -97,7 +97,7 @@ class Lit {
                                           std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> = 0;
     [[nodiscard]] virtual auto do_score(std::vector<bool> const &bound, double estimate) const -> double = 0;
-    [[nodiscard]] virtual auto do_domain_size() const -> double { return 0; }
+    [[nodiscard]] virtual auto do_domain_size(EstimateSelector sel) const -> std::optional<double> = 0;
     virtual void do_print(std::ostream &out) const = 0;
     virtual auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool = 0;
     [[nodiscard]] virtual auto do_copy() const -> ULit = 0;
@@ -121,6 +121,7 @@ class LitComparison : public Lit {
         -> std::pair<UMatcher, std::optional<size_t>> override;
     [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
+    [[nodiscard]] auto do_domain_size(EstimateSelector sel) const -> std::optional<double> override;
 
     void do_print(std::ostream &out) const override;
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
@@ -152,6 +153,7 @@ class LitExternal : public Lit {
         -> std::pair<UMatcher, std::optional<size_t>> override;
     [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
+    [[nodiscard]] auto do_domain_size(EstimateSelector sel) const -> std::optional<double> override;
 
     void do_print(std::ostream &out) const override;
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
@@ -185,6 +187,7 @@ class LitInterval : public Lit {
         -> std::pair<UMatcher, std::optional<size_t>> override;
     [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
+    [[nodiscard]] auto do_domain_size(EstimateSelector sel) const -> std::optional<double> override;
 
     void do_print(std::ostream &out) const override;
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
@@ -218,7 +221,7 @@ class LitSymbolic : public Lit {
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
     [[nodiscard]] auto do_score(std::vector<bool> const &bound, double estimate) const -> double override;
-    [[nodiscard]] auto do_domain_size() const -> double override;
+    [[nodiscard]] auto do_domain_size(EstimateSelector sel) const -> std::optional<double> override;
 
     void do_print(std::ostream &out) const override;
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
@@ -264,7 +267,7 @@ class LitProject : public Lit {
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
     [[nodiscard]] auto do_score(std::vector<bool> const &bound, double estimate) const -> double override;
-    [[nodiscard]] auto do_domain_size() const -> double override;
+    [[nodiscard]] auto do_domain_size(EstimateSelector sel) const -> std::optional<double> override;
     void do_print(std::ostream &out) const override;
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
 
@@ -301,6 +304,7 @@ class LitTuple : public Lit {
         -> std::pair<UMatcher, std::optional<size_t>> override;
     [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
+    [[nodiscard]] auto do_domain_size(EstimateSelector sel) const -> std::optional<double> override;
     void do_print(std::ostream &out) const override;
     auto do_output([[maybe_unused]] EvalContext const &ctx, OutputLit &out) const -> bool override;
     [[nodiscard]] auto do_copy() const -> ULit override;
@@ -324,6 +328,7 @@ class LitCheck : public Lit {
         -> std::pair<UMatcher, std::optional<size_t>> override;
     [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
+    [[nodiscard]] auto do_domain_size(EstimateSelector sel) const -> std::optional<double> override;
 
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
 
@@ -406,6 +411,7 @@ class LitSimpleAggr : public Lit {
         -> std::pair<UMatcher, std::optional<size_t>> override;
     [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
+    [[nodiscard]] auto do_domain_size(EstimateSelector sel) const -> std::optional<double> override;
 
     void do_print(std::ostream &out) const override;
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;

--- a/lib/ground/include/clingo/ground/literal.hh
+++ b/lib/ground/include/clingo/ground/literal.hh
@@ -55,15 +55,16 @@ class Lit {
     }
     //! Compute a score used to order rule bodies.
     //!
-    //! A not-yet-grounded recursive domain reads as size 0 at linearization; `recursive_estimate`
-    //! is the size to score such a literal at instead. Literals without such a domain ignore it.
-    [[nodiscard]] auto score(std::vector<bool> const &bound, double recursive_estimate) const -> double {
-        return do_score(bound, recursive_estimate);
+    //! A not-yet-grounded recursive domain reads as size 0 at linearization;
+    //! `estimate` is the size to score such a literal at instead. Literals
+    //! without such a domain ignore it.
+    [[nodiscard]] auto score(std::vector<bool> const &bound, double estimate) const -> double {
+        return do_score(bound, estimate);
     }
-    //! The size of the literal's own domain, or 0 for a literal without one.
+    //! The size of the literal's domain.
     //!
-    //! `order_` takes the largest of these over a body as the size to score a not-yet-grounded
-    //! recursive literal at (see `score`).
+    //! This value might be inaccurate for recursive domains, in which case the
+    //! current domain size at the point of calling this function is returned.
     [[nodiscard]] auto domain_size() const -> double { return do_domain_size(); }
 
     //! Output the literal.
@@ -95,7 +96,7 @@ class Lit {
     [[nodiscard]] virtual auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                           std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> = 0;
-    [[nodiscard]] virtual auto do_score(std::vector<bool> const &bound, double recursive_estimate) const -> double = 0;
+    [[nodiscard]] virtual auto do_score(std::vector<bool> const &bound, double estimate) const -> double = 0;
     [[nodiscard]] virtual auto do_domain_size() const -> double { return 0; }
     virtual void do_print(std::ostream &out) const = 0;
     virtual auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool = 0;
@@ -118,7 +119,7 @@ class LitComparison : public Lit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
 
     void do_print(std::ostream &out) const override;
@@ -149,7 +150,7 @@ class LitExternal : public Lit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
 
     void do_print(std::ostream &out) const override;
@@ -182,7 +183,7 @@ class LitInterval : public Lit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
 
     void do_print(std::ostream &out) const override;
@@ -216,7 +217,7 @@ class LitSymbolic : public Lit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound, double recursive_estimate) const -> double override;
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, double estimate) const -> double override;
     [[nodiscard]] auto do_domain_size() const -> double override;
 
     void do_print(std::ostream &out) const override;
@@ -262,7 +263,7 @@ class LitProject : public Lit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound, double recursive_estimate) const -> double override;
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, double estimate) const -> double override;
     [[nodiscard]] auto do_domain_size() const -> double override;
     void do_print(std::ostream &out) const override;
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
@@ -298,8 +299,8 @@ class LitTuple : public Lit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound,
-                                [[maybe_unused]] double recursive_estimate) const -> double override;
+    [[nodiscard]] auto do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
+        -> double override;
     void do_print(std::ostream &out) const override;
     auto do_output([[maybe_unused]] EvalContext const &ctx, OutputLit &out) const -> bool override;
     [[nodiscard]] auto do_copy() const -> ULit override;
@@ -321,7 +322,7 @@ class LitCheck : public Lit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
 
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
@@ -403,7 +404,7 @@ class LitSimpleAggr : public Lit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
 
     void do_print(std::ostream &out) const override;

--- a/lib/ground/include/clingo/ground/statement.hh
+++ b/lib/ground/include/clingo/ground/statement.hh
@@ -48,7 +48,8 @@ using UStmVec = std::vector<UStm>;
 class Linearizer {
   public:
     //! Construct the linearizer.
-    Linearizer(std::pmr::monotonic_buffer_resource &mbr) : mbr_{&mbr} {}
+    Linearizer(std::pmr::monotonic_buffer_resource &mbr, EstimateFunction fun, EstimateSelector sel)
+        : mbr_{&mbr}, fun_{fun}, sel_{sel} {}
     //! Indicate that a new domain is being prepared.
     void start(Queue &queue);
     //! Prepare a statement for grounding.
@@ -70,6 +71,8 @@ class Linearizer {
     std::vector<std::tuple<size_t, std::vector<size_t>, std::vector<size_t>>> lit_map_;
     //! A map from variables to provided literals.
     std::vector<std::vector<size_t>> var_map_;
+    EstimateFunction fun_;
+    EstimateSelector sel_;
 };
 
 //! Enumeration of available rule types.

--- a/lib/ground/include/clingo/ground/theory_atom.hh
+++ b/lib/ground/include/clingo/ground/theory_atom.hh
@@ -244,7 +244,8 @@ class LitMatchTheory : public Lit, private MatchTheory {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound) const -> double override;
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+        -> double override;
     void do_print(std::ostream &out) const override;
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
     [[nodiscard]] auto do_copy() const -> ULit override;
@@ -293,7 +294,8 @@ class LitBdTheory : public Lit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound) const -> double override;
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+        -> double override;
     void do_print(std::ostream &out) const override;
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
     [[nodiscard]] auto do_copy() const -> ULit override;

--- a/lib/ground/include/clingo/ground/theory_atom.hh
+++ b/lib/ground/include/clingo/ground/theory_atom.hh
@@ -244,7 +244,7 @@ class LitMatchTheory : public Lit, private MatchTheory {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
     void do_print(std::ostream &out) const override;
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
@@ -294,7 +294,7 @@ class LitBdTheory : public Lit {
     [[nodiscard]] auto do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                   std::vector<bool> const &bound)
         -> std::pair<UMatcher, std::optional<size_t>> override;
-    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+    [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
     void do_print(std::ostream &out) const override;
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;

--- a/lib/ground/include/clingo/ground/theory_atom.hh
+++ b/lib/ground/include/clingo/ground/theory_atom.hh
@@ -246,6 +246,7 @@ class LitMatchTheory : public Lit, private MatchTheory {
         -> std::pair<UMatcher, std::optional<size_t>> override;
     [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
+    [[nodiscard]] auto do_domain_size(EstimateSelector sel) const -> std::optional<double> override;
     void do_print(std::ostream &out) const override;
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
     [[nodiscard]] auto do_copy() const -> ULit override;
@@ -296,6 +297,7 @@ class LitBdTheory : public Lit {
         -> std::pair<UMatcher, std::optional<size_t>> override;
     [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
         -> double override;
+    [[nodiscard]] auto do_domain_size(EstimateSelector sel) const -> std::optional<double> override;
     void do_print(std::ostream &out) const override;
     auto do_output(EvalContext const &ctx, OutputLit &out) const -> bool override;
     [[nodiscard]] auto do_copy() const -> ULit override;

--- a/lib/ground/src/assignment_aggregate.cc
+++ b/lib/ground/src/assignment_aggregate.cc
@@ -504,7 +504,8 @@ auto LitAssignAggr::do_matcher(std::pmr::monotonic_buffer_resource &mbr, Matcher
     return {make_atom_matcher(mbr, bound, state().base(), match, type, offset_), index};
 }
 
-auto LitAssignAggr::do_score([[maybe_unused]] std::vector<bool> const &bound) const -> double {
+auto LitAssignAggr::do_score([[maybe_unused]] std::vector<bool> const &bound,
+                             [[maybe_unused]] double recursive_estimate) const -> double {
     // Note: at the time of score computation the aggregate is still empty.
     // Since we decided to split earlier, matching them should always be
     // better than using their body prefix.
@@ -703,7 +704,8 @@ auto LitAssignAggrStrat::do_matcher(std::pmr::monotonic_buffer_resource &mbr, Ma
             std::nullopt};
 }
 
-auto LitAssignAggrStrat::do_score([[maybe_unused]] std::vector<bool> const &bound) const -> double {
+auto LitAssignAggrStrat::do_score([[maybe_unused]] std::vector<bool> const &bound,
+                                  [[maybe_unused]] double recursive_estimate) const -> double {
     // Note: at the time of score computation the aggregate is still empty.
     // Since we decided to split earlier, matching them should always be
     // better than using their body prefix.

--- a/lib/ground/src/assignment_aggregate.cc
+++ b/lib/ground/src/assignment_aggregate.cc
@@ -512,6 +512,10 @@ auto LitAssignAggr::do_score([[maybe_unused]] std::vector<bool> const &bound, [[
     return 0;
 }
 
+auto LitAssignAggr::do_domain_size([[maybe_unused]] EstimateSelector sel) const -> std::optional<double> {
+    return std::nullopt;
+}
+
 void LitAssignAggr::do_print(std::ostream &out) const {
     state().print(out, true);
 }
@@ -692,7 +696,7 @@ auto LitAssignAggrStrat::do_single_pass() const -> bool {
 auto LitAssignAggrStrat::do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType type,
                                     std::vector<bool> const &bound) -> std::pair<UMatcher, std::optional<size_t>> {
     offset_ = invalid_offset;
-    auto lin = Linearizer{mbr};
+    auto lin = Linearizer{mbr, EstimateFunction::average, EstimateSelector::pred};
     auto queue = Queue{};
     lin.start(queue);
     for (auto &elem : elems_) {
@@ -735,6 +739,10 @@ auto LitAssignAggrStrat::do_output([[maybe_unused]] EvalContext const &ctx, Outp
 
 auto LitAssignAggrStrat::do_copy() const -> ULit {
     return std::make_unique<LitAssignAggrStrat>(state(), elems_);
+}
+
+auto LitAssignAggrStrat::do_domain_size([[maybe_unused]] EstimateSelector sel) const -> std::optional<double> {
+    return std::nullopt;
 }
 
 auto LitAssignAggrStrat::do_hash() const -> size_t {

--- a/lib/ground/src/assignment_aggregate.cc
+++ b/lib/ground/src/assignment_aggregate.cc
@@ -504,8 +504,8 @@ auto LitAssignAggr::do_matcher(std::pmr::monotonic_buffer_resource &mbr, Matcher
     return {make_atom_matcher(mbr, bound, state().base(), match, type, offset_), index};
 }
 
-auto LitAssignAggr::do_score([[maybe_unused]] std::vector<bool> const &bound,
-                             [[maybe_unused]] double recursive_estimate) const -> double {
+auto LitAssignAggr::do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
+    -> double {
     // Note: at the time of score computation the aggregate is still empty.
     // Since we decided to split earlier, matching them should always be
     // better than using their body prefix.
@@ -705,7 +705,7 @@ auto LitAssignAggrStrat::do_matcher(std::pmr::monotonic_buffer_resource &mbr, Ma
 }
 
 auto LitAssignAggrStrat::do_score([[maybe_unused]] std::vector<bool> const &bound,
-                                  [[maybe_unused]] double recursive_estimate) const -> double {
+                                  [[maybe_unused]] double estimate) const -> double {
     // Note: at the time of score computation the aggregate is still empty.
     // Since we decided to split earlier, matching them should always be
     // better than using their body prefix.

--- a/lib/ground/src/body_aggregate.cc
+++ b/lib/ground/src/body_aggregate.cc
@@ -584,7 +584,8 @@ auto LitBdAggr::do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType
     return {make_atom_matcher(mbr, bound, state().base(), match, type, offset_), index};
 }
 
-auto LitBdAggr::do_score([[maybe_unused]] std::vector<bool> const &bound) const -> double {
+auto LitBdAggr::do_score([[maybe_unused]] std::vector<bool> const &bound,
+                         [[maybe_unused]] double recursive_estimate) const -> double {
     // Note: at the time of score computation the aggregate is still empty.
     // Since we decided to split earlier, matching them should always be
     // better than using their body prefix.
@@ -803,7 +804,8 @@ auto LitBdAggrStrat::do_matcher(std::pmr::monotonic_buffer_resource &mbr, [[mayb
     return {std::make_unique<MatcherBdAggrStrat>(*state_, queue.release(), offset_, sign_ != Sign::once), std::nullopt};
 }
 
-auto LitBdAggrStrat::do_score([[maybe_unused]] std::vector<bool> const &bound) const -> double {
+auto LitBdAggrStrat::do_score([[maybe_unused]] std::vector<bool> const &bound,
+                              [[maybe_unused]] double recursive_estimate) const -> double {
     // Note: grounding the aggregate might be expensive. Maybe implement a
     // better estimate. An estimate is possible because elements are
     // stratified.

--- a/lib/ground/src/body_aggregate.cc
+++ b/lib/ground/src/body_aggregate.cc
@@ -592,6 +592,10 @@ auto LitBdAggr::do_score([[maybe_unused]] std::vector<bool> const &bound, [[mayb
     return 0;
 }
 
+auto LitBdAggr::do_domain_size([[maybe_unused]] EstimateSelector sel) const -> std::optional<double> {
+    return std::nullopt;
+}
+
 void LitBdAggr::do_print(std::ostream &out) const {
     state().print(out, true);
 }
@@ -795,7 +799,7 @@ auto LitBdAggrStrat::do_single_pass() const -> bool {
 auto LitBdAggrStrat::do_matcher(std::pmr::monotonic_buffer_resource &mbr, [[maybe_unused]] MatcherType type,
                                 [[maybe_unused]] std::vector<bool> const &bound)
     -> std::pair<UMatcher, std::optional<size_t>> {
-    auto lin = Linearizer{mbr};
+    auto lin = Linearizer{mbr, EstimateFunction::average, EstimateSelector::pred};
     auto queue = Queue{};
     lin.start(queue);
     for (auto &elem : elems_) {
@@ -811,6 +815,11 @@ auto LitBdAggrStrat::do_score([[maybe_unused]] std::vector<bool> const &bound, [
     // stratified.
     // NOLINTNEXTLINE(readability-magic-numbers)
     return 100;
+}
+
+auto LitBdAggrStrat::do_domain_size([[maybe_unused]] EstimateSelector sel) const -> std::optional<double> {
+    // same note as above
+    return std::nullopt;
 }
 
 void LitBdAggrStrat::do_print(std::ostream &out) const {

--- a/lib/ground/src/body_aggregate.cc
+++ b/lib/ground/src/body_aggregate.cc
@@ -584,8 +584,8 @@ auto LitBdAggr::do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType
     return {make_atom_matcher(mbr, bound, state().base(), match, type, offset_), index};
 }
 
-auto LitBdAggr::do_score([[maybe_unused]] std::vector<bool> const &bound,
-                         [[maybe_unused]] double recursive_estimate) const -> double {
+auto LitBdAggr::do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
+    -> double {
     // Note: at the time of score computation the aggregate is still empty.
     // Since we decided to split earlier, matching them should always be
     // better than using their body prefix.
@@ -804,8 +804,8 @@ auto LitBdAggrStrat::do_matcher(std::pmr::monotonic_buffer_resource &mbr, [[mayb
     return {std::make_unique<MatcherBdAggrStrat>(*state_, queue.release(), offset_, sign_ != Sign::once), std::nullopt};
 }
 
-auto LitBdAggrStrat::do_score([[maybe_unused]] std::vector<bool> const &bound,
-                              [[maybe_unused]] double recursive_estimate) const -> double {
+auto LitBdAggrStrat::do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
+    -> double {
     // Note: grounding the aggregate might be expensive. Maybe implement a
     // better estimate. An estimate is possible because elements are
     // stratified.

--- a/lib/ground/src/condlit.cc
+++ b/lib/ground/src/condlit.cc
@@ -352,7 +352,8 @@ auto LitCondLit::do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherTyp
     return {make_atom_matcher(mbr, bound, state().base_lit(), match, type, offset_), index};
 }
 
-auto LitCondLit::do_score([[maybe_unused]] std::vector<bool> const &bound) const -> double {
+auto LitCondLit::do_score([[maybe_unused]] std::vector<bool> const &bound,
+                          [[maybe_unused]] double recursive_estimate) const -> double {
     return 1;
 }
 
@@ -502,7 +503,8 @@ auto LitCondLitStrat::do_matcher(std::pmr::monotonic_buffer_resource &mbr, [[may
     return {std::make_unique<MatcherCondLitStrat>(*state_, std::move(insts.front())), std::nullopt};
 }
 
-auto LitCondLitStrat::do_score([[maybe_unused]] std::vector<bool> const &bound) const -> double {
+auto LitCondLitStrat::do_score([[maybe_unused]] std::vector<bool> const &bound,
+                               [[maybe_unused]] double recursive_estimate) const -> double {
     return 1;
 }
 

--- a/lib/ground/src/condlit.cc
+++ b/lib/ground/src/condlit.cc
@@ -352,8 +352,8 @@ auto LitCondLit::do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherTyp
     return {make_atom_matcher(mbr, bound, state().base_lit(), match, type, offset_), index};
 }
 
-auto LitCondLit::do_score([[maybe_unused]] std::vector<bool> const &bound,
-                          [[maybe_unused]] double recursive_estimate) const -> double {
+auto LitCondLit::do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
+    -> double {
     return 1;
 }
 
@@ -503,8 +503,8 @@ auto LitCondLitStrat::do_matcher(std::pmr::monotonic_buffer_resource &mbr, [[may
     return {std::make_unique<MatcherCondLitStrat>(*state_, std::move(insts.front())), std::nullopt};
 }
 
-auto LitCondLitStrat::do_score([[maybe_unused]] std::vector<bool> const &bound,
-                               [[maybe_unused]] double recursive_estimate) const -> double {
+auto LitCondLitStrat::do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
+    -> double {
     return 1;
 }
 

--- a/lib/ground/src/condlit.cc
+++ b/lib/ground/src/condlit.cc
@@ -357,6 +357,10 @@ auto LitCondLit::do_score([[maybe_unused]] std::vector<bool> const &bound, [[may
     return 1;
 }
 
+auto LitCondLit::do_domain_size([[maybe_unused]] EstimateSelector sel) const -> std::optional<double> {
+    return std::nullopt;
+}
+
 void LitCondLit::do_print(std::ostream &out) const {
     out << "#cond_lit(" << type();
     for (auto var : state().vars_global()) {
@@ -494,7 +498,7 @@ auto LitCondLitStrat::do_single_pass() const -> bool {
 auto LitCondLitStrat::do_matcher(std::pmr::monotonic_buffer_resource &mbr, [[maybe_unused]] MatcherType type,
                                  [[maybe_unused]] std::vector<bool> const &bound)
     -> std::pair<UMatcher, std::optional<size_t>> {
-    auto lin = Linearizer{mbr};
+    auto lin = Linearizer{mbr, EstimateFunction::average, EstimateSelector::pred};
     auto queue = Queue{};
     lin.start(queue);
     lin.prepare(static_cast<InstanceCallback &>(*this), premise_, state_->vars(true));
@@ -506,6 +510,10 @@ auto LitCondLitStrat::do_matcher(std::pmr::monotonic_buffer_resource &mbr, [[may
 auto LitCondLitStrat::do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
     -> double {
     return 1;
+}
+
+auto LitCondLitStrat::do_domain_size([[maybe_unused]] EstimateSelector sel) const -> std::optional<double> {
+    return std::nullopt;
 }
 
 void LitCondLitStrat::do_print(std::ostream &out) const {

--- a/lib/ground/src/disjunction.cc
+++ b/lib/ground/src/disjunction.cc
@@ -444,7 +444,8 @@ auto LitDisjunction::do_matcher(std::pmr::monotonic_buffer_resource &mbr, Matche
     return {make_atom_matcher(mbr, bound, state().base(), match, type, offset_), index};
 }
 
-auto LitDisjunction::do_score([[maybe_unused]] std::vector<bool> const &bound) const -> double {
+auto LitDisjunction::do_score([[maybe_unused]] std::vector<bool> const &bound,
+                              [[maybe_unused]] double recursive_estimate) const -> double {
     // Note: at the time of score computation the aggregate is still empty.
     // Scoring low should be fine here.
     return 0;

--- a/lib/ground/src/disjunction.cc
+++ b/lib/ground/src/disjunction.cc
@@ -444,8 +444,8 @@ auto LitDisjunction::do_matcher(std::pmr::monotonic_buffer_resource &mbr, Matche
     return {make_atom_matcher(mbr, bound, state().base(), match, type, offset_), index};
 }
 
-auto LitDisjunction::do_score([[maybe_unused]] std::vector<bool> const &bound,
-                              [[maybe_unused]] double recursive_estimate) const -> double {
+auto LitDisjunction::do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
+    -> double {
     // Note: at the time of score computation the aggregate is still empty.
     // Scoring low should be fine here.
     return 0;

--- a/lib/ground/src/disjunction.cc
+++ b/lib/ground/src/disjunction.cc
@@ -451,6 +451,10 @@ auto LitDisjunction::do_score([[maybe_unused]] std::vector<bool> const &bound, [
     return 0;
 }
 
+auto LitDisjunction::do_domain_size([[maybe_unused]] EstimateSelector sel) const -> std::optional<double> {
+    return std::nullopt;
+}
+
 void LitDisjunction::do_print(std::ostream &out) const {
     state().print(out, true);
 }

--- a/lib/ground/src/head_aggregate.cc
+++ b/lib/ground/src/head_aggregate.cc
@@ -682,7 +682,8 @@ auto LitHdAggr::do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType
     return {make_atom_matcher(mbr, bound, state().base(), match, type, offset_), index};
 }
 
-auto LitHdAggr::do_score([[maybe_unused]] std::vector<bool> const &bound) const -> double {
+auto LitHdAggr::do_score([[maybe_unused]] std::vector<bool> const &bound,
+                         [[maybe_unused]] double recursive_estimate) const -> double {
     // Note: at the time of score computation the aggregate is still empty.
     // Scoring low should be fine here.
     return 0;

--- a/lib/ground/src/head_aggregate.cc
+++ b/lib/ground/src/head_aggregate.cc
@@ -682,8 +682,8 @@ auto LitHdAggr::do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherType
     return {make_atom_matcher(mbr, bound, state().base(), match, type, offset_), index};
 }
 
-auto LitHdAggr::do_score([[maybe_unused]] std::vector<bool> const &bound,
-                         [[maybe_unused]] double recursive_estimate) const -> double {
+auto LitHdAggr::do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
+    -> double {
     // Note: at the time of score computation the aggregate is still empty.
     // Scoring low should be fine here.
     return 0;

--- a/lib/ground/src/head_aggregate.cc
+++ b/lib/ground/src/head_aggregate.cc
@@ -689,6 +689,10 @@ auto LitHdAggr::do_score([[maybe_unused]] std::vector<bool> const &bound, [[mayb
     return 0;
 }
 
+auto LitHdAggr::do_domain_size([[maybe_unused]] EstimateSelector sel) const -> std::optional<double> {
+    return std::nullopt;
+}
+
 void LitHdAggr::do_print(std::ostream &out) const {
     state().print(out, true);
 }

--- a/lib/ground/src/literal.cc
+++ b/lib/ground/src/literal.cc
@@ -56,7 +56,7 @@ auto LitInterval::do_matcher([[maybe_unused]] std::pmr::monotonic_buffer_resourc
     return {make_interval_matcher(bound, *lhs_, *lower_, *upper_), std::nullopt};
 }
 
-auto LitInterval::do_score(std::vector<bool> const &bound) const -> double {
+auto LitInterval::do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const -> double {
     if (auto *l = dynamic_cast<TermSymbol *>(lower_.get()), *r = dynamic_cast<TermSymbol *>(lower_.get());
         l != nullptr && r != nullptr) {
         VariableSet vars;
@@ -160,7 +160,8 @@ auto LitComparison::do_matcher([[maybe_unused]] std::pmr::monotonic_buffer_resou
     return {make_comp_matcher(bound, *lhs_, cmp_, *rhs_), std::nullopt};
 }
 
-auto LitComparison::do_score([[maybe_unused]] std::vector<bool> const &bound) const -> double {
+auto LitComparison::do_score([[maybe_unused]] std::vector<bool> const &bound,
+                             [[maybe_unused]] double recursive_estimate) const -> double {
     return score_fast;
 }
 
@@ -297,7 +298,8 @@ auto LitExternal::do_matcher([[maybe_unused]] std::pmr::monotonic_buffer_resourc
     return {std::make_unique<ExternalMatcher>(*this, vars.release()), std::nullopt};
 }
 
-auto LitExternal::do_score([[maybe_unused]] std::vector<bool> const &bound) const -> double {
+auto LitExternal::do_score([[maybe_unused]] std::vector<bool> const &bound,
+                           [[maybe_unused]] double recursive_estimate) const -> double {
     return score_maybe_fast;
 }
 
@@ -406,15 +408,21 @@ auto LitSymbolic::do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherTy
     return {make_atom_matcher(mbr, bound, *base_, *atom_, type, offset_), index};
 }
 
-auto LitSymbolic::do_score(std::vector<bool> const &bound) const -> double {
+auto LitSymbolic::do_score(std::vector<bool> const &bound, double recursive_estimate) const -> double {
     if (sign_ != Sign::once) {
         auto size = base_->size();
         if (single_pass() && size == 0) {
             return -1;
         }
-        return atom_->score(static_cast<double>(size), bound);
+        // A not-yet-grounded recursive domain reads as 0 here; use the estimate in its place.
+        auto estimated = size == 0 ? recursive_estimate : static_cast<double>(size);
+        return atom_->score(estimated, bound);
     }
     return 0;
+}
+
+auto LitSymbolic::do_domain_size() const -> double {
+    return static_cast<double>(base_->size());
 }
 
 auto LitSymbolic::do_hash() const -> size_t {
@@ -516,15 +524,21 @@ auto LitProject::do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherTyp
     return {m(make_atom_matcher(mbr, bound, state_->p_base(), *p_atom_, type, offset_)), index};
 }
 
-auto LitProject::do_score(std::vector<bool> const &bound) const -> double {
+auto LitProject::do_score(std::vector<bool> const &bound, double recursive_estimate) const -> double {
     if (sign_ != Sign::once) {
         auto size = state_->base().size();
         if (single_pass() && size == 0) {
             return -1;
         }
-        return atom_->score(static_cast<double>(size), bound);
+        // A not-yet-grounded recursive domain reads as 0 here; use the estimate in its place.
+        auto estimated = size == 0 ? recursive_estimate : static_cast<double>(size);
+        return atom_->score(estimated, bound);
     }
     return 0;
+}
+
+auto LitProject::do_domain_size() const -> double {
+    return static_cast<double>(state_->base().size());
 }
 
 auto LitProject::do_hash() const -> size_t {
@@ -603,7 +617,8 @@ auto LitTuple::do_matcher([[maybe_unused]] std::pmr::monotonic_buffer_resource &
     return {std::make_unique<MatcherLitTuple>(std::move(bind), vars_, *syms_), std::nullopt};
 }
 
-auto LitTuple::do_score([[maybe_unused]] std::vector<bool> const &bound) const -> double {
+auto LitTuple::do_score([[maybe_unused]] std::vector<bool> const &bound,
+                        [[maybe_unused]] double recursive_estimate) const -> double {
     return 0;
 }
 
@@ -666,7 +681,8 @@ auto LitCheck::do_matcher([[maybe_unused]] std::pmr::monotonic_buffer_resource &
     return {std::make_unique<CheckMatcher>(*this), std::nullopt};
 }
 
-auto LitCheck::do_score([[maybe_unused]] std::vector<bool> const &bound) const -> double {
+auto LitCheck::do_score([[maybe_unused]] std::vector<bool> const &bound,
+                        [[maybe_unused]] double recursive_estimate) const -> double {
     // we give a high score here because most of these checks will match anyway
     // their purpose is mostly to set the member storing the evaluation result
     return std::numeric_limits<double>::max();
@@ -909,7 +925,8 @@ auto LitSimpleAggr::do_matcher([[maybe_unused]] std::pmr::monotonic_buffer_resou
     return {std::make_unique<AggrMatcher>(*this, std::move(free)), std::nullopt};
 }
 
-auto LitSimpleAggr::do_score([[maybe_unused]] std::vector<bool> const &bound) const -> double {
+auto LitSimpleAggr::do_score([[maybe_unused]] std::vector<bool> const &bound,
+                             [[maybe_unused]] double recursive_estimate) const -> double {
     return score_fast;
 }
 

--- a/lib/ground/src/literal.cc
+++ b/lib/ground/src/literal.cc
@@ -84,6 +84,32 @@ auto LitInterval::do_score(std::vector<bool> const &bound, [[maybe_unused]] doub
     return 100;
 }
 
+auto LitInterval::do_domain_size(EstimateSelector sel) const -> std::optional<double> {
+    if (sel != EstimateSelector::all) {
+        return std::nullopt;
+    }
+    if (auto *l = dynamic_cast<TermSymbol *>(lower_.get()), *r = dynamic_cast<TermSymbol *>(lower_.get());
+        l != nullptr && r != nullptr) {
+        auto sl = l->symbol();
+        auto sr = r->symbol();
+        if (sl.type() != SymbolType::number || sr.type() != SymbolType::number) {
+            return std::nullopt;
+        }
+        auto const &nl = sl.num();
+        auto const &nr = sr.num();
+        if (nl > nr) {
+            return std::nullopt;
+        }
+        auto d = nr - nl;
+        if (auto id = d.as_int(); id) {
+            return *id;
+        }
+        return std::numeric_limits<double>::max();
+    }
+    // NOLINTNEXTLINE(readability-magic-numbers)
+    return std::nullopt;
+}
+
 auto LitInterval::do_hash() const -> size_t {
     return Util::value_hash_record<LitInterval>(lhs_, lower_, upper_);
 }
@@ -163,6 +189,13 @@ auto LitComparison::do_matcher([[maybe_unused]] std::pmr::monotonic_buffer_resou
 auto LitComparison::do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
     -> double {
     return score_fast;
+}
+
+auto LitComparison::do_domain_size(EstimateSelector sel) const -> std::optional<double> {
+    if (sel != EstimateSelector::all) {
+        return std::nullopt;
+    }
+    return std::nullopt;
 }
 
 auto LitComparison::do_hash() const -> size_t {
@@ -303,6 +336,10 @@ auto LitExternal::do_score([[maybe_unused]] std::vector<bool> const &bound, [[ma
     return score_maybe_fast;
 }
 
+auto LitExternal::do_domain_size([[maybe_unused]] EstimateSelector sel) const -> std::optional<double> {
+    return std::nullopt;
+}
+
 auto LitExternal::do_hash() const -> size_t {
     return Util::value_hash(std::hash<LitExternal const *>{}(this));
 }
@@ -410,19 +447,21 @@ auto LitSymbolic::do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherTy
 
 auto LitSymbolic::do_score(std::vector<bool> const &bound, double estimate) const -> double {
     if (sign_ != Sign::once) {
-        auto size = domain_size();
+        auto size = static_cast<double>(base_->size());
         if (single_pass() && size == 0) {
             return -1;
         }
-        // A not-yet-grounded recursive domain reads as 0 here; use the estimate in its place.
         auto estimated = single_pass() ? size : std::max(size, estimate);
         return atom_->score(estimated, bound);
     }
     return 0;
 }
 
-auto LitSymbolic::do_domain_size() const -> double {
-    return static_cast<double>(base_->size());
+auto LitSymbolic::do_domain_size([[maybe_unused]] EstimateSelector sel) const -> std::optional<double> {
+    if (single_pass()) {
+        return static_cast<double>(base_->size());
+    }
+    return std::nullopt;
 }
 
 auto LitSymbolic::do_hash() const -> size_t {
@@ -526,7 +565,7 @@ auto LitProject::do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherTyp
 
 auto LitProject::do_score(std::vector<bool> const &bound, double estimate) const -> double {
     if (sign_ != Sign::once) {
-        auto size = domain_size();
+        auto size = static_cast<double>(state_->base().size());
         if (single_pass() && size == 0) {
             return -1;
         }
@@ -536,8 +575,11 @@ auto LitProject::do_score(std::vector<bool> const &bound, double estimate) const
     return 0;
 }
 
-auto LitProject::do_domain_size() const -> double {
-    return static_cast<double>(state_->base().size());
+auto LitProject::do_domain_size([[maybe_unused]] EstimateSelector sel) const -> std::optional<double> {
+    if (single_pass()) {
+        return static_cast<double>(state_->base().size());
+    }
+    return std::nullopt;
 }
 
 auto LitProject::do_hash() const -> size_t {
@@ -621,6 +663,10 @@ auto LitTuple::do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe
     return 0;
 }
 
+auto LitTuple::do_domain_size([[maybe_unused]] EstimateSelector sel) const -> std::optional<double> {
+    return std::nullopt;
+}
+
 void LitTuple::do_print(std::ostream &out) const {
     out << "#once(" << Util::p_range(vars_, [](std::ostream &out, auto var) { out << "X_" << var; }) << ")";
 }
@@ -685,6 +731,10 @@ auto LitCheck::do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe
     // we give a high score here because most of these checks will match anyway
     // their purpose is mostly to set the member storing the evaluation result
     return std::numeric_limits<double>::max();
+}
+
+auto LitCheck::do_domain_size([[maybe_unused]] EstimateSelector sel) const -> std::optional<double> {
+    return std::nullopt;
 }
 
 auto LitCheck::do_hash() const -> size_t {
@@ -927,6 +977,10 @@ auto LitSimpleAggr::do_matcher([[maybe_unused]] std::pmr::monotonic_buffer_resou
 auto LitSimpleAggr::do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
     -> double {
     return score_fast;
+}
+
+auto LitSimpleAggr::do_domain_size([[maybe_unused]] EstimateSelector sel) const -> std::optional<double> {
+    return std::nullopt;
 }
 
 auto LitSimpleAggr::do_hash() const -> size_t {

--- a/lib/ground/src/literal.cc
+++ b/lib/ground/src/literal.cc
@@ -56,7 +56,7 @@ auto LitInterval::do_matcher([[maybe_unused]] std::pmr::monotonic_buffer_resourc
     return {make_interval_matcher(bound, *lhs_, *lower_, *upper_), std::nullopt};
 }
 
-auto LitInterval::do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const -> double {
+auto LitInterval::do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const -> double {
     if (auto *l = dynamic_cast<TermSymbol *>(lower_.get()), *r = dynamic_cast<TermSymbol *>(lower_.get());
         l != nullptr && r != nullptr) {
         VariableSet vars;
@@ -160,8 +160,8 @@ auto LitComparison::do_matcher([[maybe_unused]] std::pmr::monotonic_buffer_resou
     return {make_comp_matcher(bound, *lhs_, cmp_, *rhs_), std::nullopt};
 }
 
-auto LitComparison::do_score([[maybe_unused]] std::vector<bool> const &bound,
-                             [[maybe_unused]] double recursive_estimate) const -> double {
+auto LitComparison::do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
+    -> double {
     return score_fast;
 }
 
@@ -298,8 +298,8 @@ auto LitExternal::do_matcher([[maybe_unused]] std::pmr::monotonic_buffer_resourc
     return {std::make_unique<ExternalMatcher>(*this, vars.release()), std::nullopt};
 }
 
-auto LitExternal::do_score([[maybe_unused]] std::vector<bool> const &bound,
-                           [[maybe_unused]] double recursive_estimate) const -> double {
+auto LitExternal::do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
+    -> double {
     return score_maybe_fast;
 }
 
@@ -408,14 +408,14 @@ auto LitSymbolic::do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherTy
     return {make_atom_matcher(mbr, bound, *base_, *atom_, type, offset_), index};
 }
 
-auto LitSymbolic::do_score(std::vector<bool> const &bound, double recursive_estimate) const -> double {
+auto LitSymbolic::do_score(std::vector<bool> const &bound, double estimate) const -> double {
     if (sign_ != Sign::once) {
-        auto size = base_->size();
+        auto size = domain_size();
         if (single_pass() && size == 0) {
             return -1;
         }
         // A not-yet-grounded recursive domain reads as 0 here; use the estimate in its place.
-        auto estimated = size == 0 ? recursive_estimate : static_cast<double>(size);
+        auto estimated = single_pass() ? size : std::max(size, estimate);
         return atom_->score(estimated, bound);
     }
     return 0;
@@ -524,14 +524,13 @@ auto LitProject::do_matcher(std::pmr::monotonic_buffer_resource &mbr, MatcherTyp
     return {m(make_atom_matcher(mbr, bound, state_->p_base(), *p_atom_, type, offset_)), index};
 }
 
-auto LitProject::do_score(std::vector<bool> const &bound, double recursive_estimate) const -> double {
+auto LitProject::do_score(std::vector<bool> const &bound, double estimate) const -> double {
     if (sign_ != Sign::once) {
-        auto size = state_->base().size();
+        auto size = domain_size();
         if (single_pass() && size == 0) {
             return -1;
         }
-        // A not-yet-grounded recursive domain reads as 0 here; use the estimate in its place.
-        auto estimated = size == 0 ? recursive_estimate : static_cast<double>(size);
+        auto estimated = single_pass() ? size : std::max(size, estimate);
         return atom_->score(estimated, bound);
     }
     return 0;
@@ -617,8 +616,8 @@ auto LitTuple::do_matcher([[maybe_unused]] std::pmr::monotonic_buffer_resource &
     return {std::make_unique<MatcherLitTuple>(std::move(bind), vars_, *syms_), std::nullopt};
 }
 
-auto LitTuple::do_score([[maybe_unused]] std::vector<bool> const &bound,
-                        [[maybe_unused]] double recursive_estimate) const -> double {
+auto LitTuple::do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
+    -> double {
     return 0;
 }
 
@@ -681,8 +680,8 @@ auto LitCheck::do_matcher([[maybe_unused]] std::pmr::monotonic_buffer_resource &
     return {std::make_unique<CheckMatcher>(*this), std::nullopt};
 }
 
-auto LitCheck::do_score([[maybe_unused]] std::vector<bool> const &bound,
-                        [[maybe_unused]] double recursive_estimate) const -> double {
+auto LitCheck::do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
+    -> double {
     // we give a high score here because most of these checks will match anyway
     // their purpose is mostly to set the member storing the evaluation result
     return std::numeric_limits<double>::max();
@@ -925,8 +924,8 @@ auto LitSimpleAggr::do_matcher([[maybe_unused]] std::pmr::monotonic_buffer_resou
     return {std::make_unique<AggrMatcher>(*this, std::move(free)), std::nullopt};
 }
 
-auto LitSimpleAggr::do_score([[maybe_unused]] std::vector<bool> const &bound,
-                             [[maybe_unused]] double recursive_estimate) const -> double {
+auto LitSimpleAggr::do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
+    -> double {
     return score_fast;
 }
 

--- a/lib/ground/src/statement.cc
+++ b/lib/ground/src/statement.cc
@@ -209,6 +209,12 @@ auto Linearizer::order_(InstanceCallback &cb, std::vector<MatcherType> const &to
             analyzer.add(prv, dep);
         }
     }
+    // Estimate not-yet-grounded recursive domains at the largest known domain size in the body, so a
+    // size-0 recursive literal is not mistaken for a trivially cheap one when ordering.
+    double body_max = 0;
+    for (auto const &lit : lits) {
+        body_max = std::max(body_max, lit->domain_size());
+    }
     for (size_t k = 0; !queue_.empty();) {
         // recompute score
         for (auto &[idx, gen, score] : queue_) {
@@ -216,7 +222,7 @@ auto Linearizer::order_(InstanceCallback &cb, std::vector<MatcherType> const &to
             // compute the assignments propagated by this choice of literal
             auto const &[cur, dep, prv] = lit_map_[idx];
             if (!std::ranges::all_of(prv, [&bound](auto idx) { return bound[idx]; })) {
-                score = lits[idx]->score(bound);
+                score = lits[idx]->score(bound, body_max);
                 if (score > 0) {
                     auto extra = analyzer.propagate(prv);
                     if (!extra.empty()) {
@@ -665,7 +671,8 @@ void StmHeuristic::init_() {
             return {make_atom_matcher(mbr, bound, *stm_->base_, *stm_->atom_, type, stm_->offset_), std::nullopt};
         }
 
-        [[nodiscard]] auto do_score(std::vector<bool> const &bound) const -> double override {
+        [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+            -> double override {
             return stm_->atom_->score(static_cast<double>(stm_->base_->size()), bound);
         }
 
@@ -901,7 +908,8 @@ void StmProject::init_() {
             return {make_atom_matcher(mbr, bound, *stm_->base_, *stm_->atom_, type, stm_->offset_), std::nullopt};
         }
 
-        [[nodiscard]] auto do_score(std::vector<bool> const &bound) const -> double override {
+        [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+            -> double override {
             return stm_->atom_->score(static_cast<double>(stm_->base_->size()), bound);
         }
 

--- a/lib/ground/src/statement.cc
+++ b/lib/ground/src/statement.cc
@@ -671,7 +671,7 @@ void StmHeuristic::init_() {
             return {make_atom_matcher(mbr, bound, *stm_->base_, *stm_->atom_, type, stm_->offset_), std::nullopt};
         }
 
-        [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+        [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
             -> double override {
             return stm_->atom_->score(static_cast<double>(stm_->base_->size()), bound);
         }
@@ -908,7 +908,7 @@ void StmProject::init_() {
             return {make_atom_matcher(mbr, bound, *stm_->base_, *stm_->atom_, type, stm_->offset_), std::nullopt};
         }
 
-        [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double recursive_estimate) const
+        [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
             -> double override {
             return stm_->atom_->score(static_cast<double>(stm_->base_->size()), bound);
         }

--- a/lib/ground/src/statement.cc
+++ b/lib/ground/src/statement.cc
@@ -211,9 +211,31 @@ auto Linearizer::order_(InstanceCallback &cb, std::vector<MatcherType> const &to
     }
     // Estimate not-yet-grounded recursive domains at the largest known domain size in the body, so a
     // size-0 recursive literal is not mistaken for a trivially cheap one when ordering.
-    double body_max = 0;
+    double estimate = 0;
+    size_t num_selected = 0;
+
     for (auto const &lit : lits) {
-        body_max = std::max(body_max, lit->domain_size());
+        // TODO: it is also possible to combine the score and domain_size functions
+        if (auto size = lit->domain_size(sel_)) {
+            if (*size <= 0) {
+                continue;
+            }
+            ++num_selected;
+            if (fun_ == EstimateFunction::maximum) {
+                estimate = std::max(estimate, *size);
+            } else if (fun_ == EstimateFunction::minimum) {
+                estimate = std::min(estimate, *size);
+            } else if (fun_ == EstimateFunction::average) {
+                estimate += *size;
+            }
+        }
+    }
+    if (num_selected == 0) {
+        // We set the estimate to a large fixed value to at least exploit some
+        // structural information among the literals.
+        estimate = default_estimate_size;
+    } else if (fun_ == EstimateFunction::average) {
+        estimate /= static_cast<double>(num_selected);
     }
     for (size_t k = 0; !queue_.empty();) {
         // recompute score
@@ -222,7 +244,7 @@ auto Linearizer::order_(InstanceCallback &cb, std::vector<MatcherType> const &to
             // compute the assignments propagated by this choice of literal
             auto const &[cur, dep, prv] = lit_map_[idx];
             if (!std::ranges::all_of(prv, [&bound](auto idx) { return bound[idx]; })) {
-                score = lits[idx]->score(bound, body_max);
+                score = lits[idx]->score(bound, estimate);
                 if (score > 0) {
                     auto extra = analyzer.propagate(prv);
                     if (!extra.empty()) {
@@ -676,6 +698,11 @@ void StmHeuristic::init_() {
             return stm_->atom_->score(static_cast<double>(stm_->base_->size()), bound);
         }
 
+        [[nodiscard]] auto do_domain_size([[maybe_unused]] EstimateSelector sel) const
+            -> std::optional<double> override {
+            return stm_->base_->size();
+        }
+
         [[nodiscard]] auto do_hash() const -> size_t override { return std::hash<LitAtom const *>{}(this); }
 
         [[nodiscard]] auto do_equal_to(Lit const &other) const -> bool override { return this == &other; }
@@ -911,6 +938,11 @@ void StmProject::init_() {
         [[nodiscard]] auto do_score(std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
             -> double override {
             return stm_->atom_->score(static_cast<double>(stm_->base_->size()), bound);
+        }
+
+        [[nodiscard]] auto do_domain_size([[maybe_unused]] EstimateSelector sel) const
+            -> std::optional<double> override {
+            return stm_->base_->size();
         }
 
         [[nodiscard]] auto do_hash() const -> size_t override { return std::hash<LitProject const *>{}(this); }

--- a/lib/ground/src/theory_atom.cc
+++ b/lib/ground/src/theory_atom.cc
@@ -275,7 +275,8 @@ auto LitMatchTheory::do_matcher(std::pmr::monotonic_buffer_resource &mbr, Matche
     return {make_atom_matcher(mbr, bound, state().base(), match, type, offset_), index};
 }
 
-auto LitMatchTheory::do_score([[maybe_unused]] std::vector<bool> const &bound) const -> double {
+auto LitMatchTheory::do_score([[maybe_unused]] std::vector<bool> const &bound,
+                              [[maybe_unused]] double recursive_estimate) const -> double {
     // Note: at the time of score computation the aggregate is still empty.
     // Scoring low should be fine here.
     return 0;
@@ -382,7 +383,8 @@ auto LitBdTheory::do_matcher([[maybe_unused]] std::pmr::monotonic_buffer_resourc
     return {make_once_matcher(*state_->name(), name_), std::nullopt};
 }
 
-auto LitBdTheory::do_score([[maybe_unused]] std::vector<bool> const &bound) const -> double {
+auto LitBdTheory::do_score([[maybe_unused]] std::vector<bool> const &bound,
+                           [[maybe_unused]] double recursive_estimate) const -> double {
     return 0;
 }
 

--- a/lib/ground/src/theory_atom.cc
+++ b/lib/ground/src/theory_atom.cc
@@ -275,8 +275,8 @@ auto LitMatchTheory::do_matcher(std::pmr::monotonic_buffer_resource &mbr, Matche
     return {make_atom_matcher(mbr, bound, state().base(), match, type, offset_), index};
 }
 
-auto LitMatchTheory::do_score([[maybe_unused]] std::vector<bool> const &bound,
-                              [[maybe_unused]] double recursive_estimate) const -> double {
+auto LitMatchTheory::do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
+    -> double {
     // Note: at the time of score computation the aggregate is still empty.
     // Scoring low should be fine here.
     return 0;
@@ -383,8 +383,8 @@ auto LitBdTheory::do_matcher([[maybe_unused]] std::pmr::monotonic_buffer_resourc
     return {make_once_matcher(*state_->name(), name_), std::nullopt};
 }
 
-auto LitBdTheory::do_score([[maybe_unused]] std::vector<bool> const &bound,
-                           [[maybe_unused]] double recursive_estimate) const -> double {
+auto LitBdTheory::do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
+    -> double {
     return 0;
 }
 

--- a/lib/ground/src/theory_atom.cc
+++ b/lib/ground/src/theory_atom.cc
@@ -177,7 +177,7 @@ void StateTheory::output(Logger &log, SymbolStore &store, OutputStm &out) {
         CLINGO_REPORT(log, debug) << "      " << *stm;
     }
     auto ass = Assignment{};
-    auto lin = Linearizer{*mbr_};
+    auto lin = Linearizer{*mbr_, EstimateFunction::average, EstimateSelector::pred};
     auto queue = Queue{};
     lin.start(queue);
     for (auto &elem : elems_) {
@@ -280,6 +280,10 @@ auto LitMatchTheory::do_score([[maybe_unused]] std::vector<bool> const &bound, [
     // Note: at the time of score computation the aggregate is still empty.
     // Scoring low should be fine here.
     return 0;
+}
+
+auto LitMatchTheory::do_domain_size([[maybe_unused]] EstimateSelector sel) const -> std::optional<double> {
+    return std::nullopt;
 }
 
 void LitMatchTheory::do_print(std::ostream &out) const {
@@ -386,6 +390,10 @@ auto LitBdTheory::do_matcher([[maybe_unused]] std::pmr::monotonic_buffer_resourc
 auto LitBdTheory::do_score([[maybe_unused]] std::vector<bool> const &bound, [[maybe_unused]] double estimate) const
     -> double {
     return 0;
+}
+
+auto LitBdTheory::do_domain_size([[maybe_unused]] EstimateSelector sel) const -> std::optional<double> {
+    return std::nullopt;
 }
 
 void LitBdTheory::do_print(std::ostream &out) const {

--- a/lib/input/include/clingo/input/program.hh
+++ b/lib/input/include/clingo/input/program.hh
@@ -157,7 +157,7 @@ class Program {
     //! Initialize a program with a rewrite level.
     //!
     //! (The highest rewrite level has to be used for grounding.)
-    Program(RewriteOptions opts) : opts_{opts} {}
+    Program(RewriteOptions const &opts) : opts_{&opts} {}
     //! Join with the given unprocessed program.
     //!
     //! If fresh const statements are added, they will be merged with the previous ones.
@@ -229,7 +229,7 @@ class Program {
     [[nodiscard]] auto default_parts() -> std::optional<StmParts> & { return default_parts_; }
 
     //! Check whether profiling is enabled.
-    [[nodiscard]] auto profile() const -> ProfileFlags { return opts_.profile; }
+    [[nodiscard]] auto profile() const -> ProfileFlags { return opts_->profile; }
 
   private:
     //! The signature of a program part.
@@ -251,7 +251,7 @@ class Program {
     void fill_source(ProgramPart &part);
 
     //! The rewrite level of the program.
-    RewriteOptions opts_;
+    RewriteOptions const *opts_;
     //! The meta statements in the program.
     StmVec meta_stms_;
     //! Script statements.

--- a/lib/input/src/program.cc
+++ b/lib/input/src/program.cc
@@ -63,7 +63,7 @@ void UnprocessedProgram::add(SymbolStore &store, Stm stm) {
 }
 
 void Program::fill_source(ProgramPart &part) {
-    if (opts_.profile != ProfileFlags::off) {
+    if (opts_->profile != ProfileFlags::off) {
         assert(part.srcs.size() <= part.stms.size());
         for (auto it = part.stms.begin() + std::ssize(part.srcs), ie = part.stms.end(); ie != it; ++it) {
             last_source_ = sources_.insert_after(last_source_, *it);
@@ -110,7 +110,7 @@ void Program::join(Logger &log, SymbolStore &store, UnprocessedProgram const &pr
         parser.add_theory(log, stm);
     }
     auto param_map = ParamMap{};
-    auto ctx = RewriteContext{log, store, opts_, parser, param_map, const_map_};
+    auto ctx = RewriteContext{log, store, *opts_, parser, param_map, const_map_};
 
     // process program parts
     for (auto const &[program_stm, stms, srcs, facts] : prg.parts()) {
@@ -147,7 +147,7 @@ void Program::join(Logger &log, SymbolStore &store, UnprocessedProgram const &pr
                 if (auto fact = is_fact(store, rew); fact) {
                     res_part.facts.emplace_back(fact.value());
                 } else {
-                    if (opts_.profile != ProfileFlags::off) {
+                    if (opts_->profile != ProfileFlags::off) {
                         if (src == nullptr) {
                             last_source_ = sources_.insert_after(last_source_, stm);
                             src = &*last_source_;
@@ -237,7 +237,7 @@ auto Program::analyze(SymbolStore &store, ProgramParamVec const &params, Depende
             bld.fact(it->second.facts);
             if (it->first.second == 0) {
                 stms.insert(stms.end(), it->second.stms.begin(), it->second.stms.end());
-                if (opts_.profile != ProfileFlags::off) {
+                if (opts_->profile != ProfileFlags::off) {
                     srcs.insert(srcs.end(), it->second.srcs.begin(), it->second.srcs.end());
                     assert(srcs.size() == stms.size());
                 }
@@ -269,7 +269,7 @@ auto Program::analyze(SymbolStore &store, ProgramParamVec const &params, Depende
                                     body.emplace_back(lit);
                                     body.insert(body.end(), stm.body().begin(), stm.body().end());
                                     stms.emplace_back(stm.update(a_body = std::move(body)));
-                                    if (opts_.profile != ProfileFlags::off) {
+                                    if (opts_->profile != ProfileFlags::off) {
                                         srcs.emplace_back(*src_it++);
                                     }
                                 } else {
@@ -283,7 +283,8 @@ auto Program::analyze(SymbolStore &store, ProgramParamVec const &params, Depende
         }
     }
 
-    return bld.components(CppClingo::Input::analyze(store, stms, opts_.profile != ProfileFlags::off ? &srcs : nullptr));
+    return bld.components(
+        CppClingo::Input::analyze(store, stms, opts_->profile != ProfileFlags::off ? &srcs : nullptr));
 }
 
 void Program::mark(SymbolCollector &gc) const {


### PR DESCRIPTION
## What this fixes

Issue #583 reports that grounding a particular program is very slow — a large Spack dependency-resolution encoding that grounds far more slowly than the size of the result would suggest.

The slowness is in how the grounder chooses the order to evaluate the literals in a rule body. It picks the order greedily, using a cheap estimate of how much work each literal will produce. For a **recursive** predicate — one still being computed in the current component — the grounder holds no atoms for it yet, so its domain size reads as **0**. Scored at size 0, such a literal looks trivially cheap, so the greedy order puts it first and defers the *selective* literals that would have bound its key arguments. The recursive literal then fans out over its whole relation before anything constrains it, and that intermediate blow-up is the cost.

## The change

When a rule body is linearized, take the **largest known domain size among the body's other literals** as the size to score such a not-yet-grounded recursive literal at, instead of 0. That keeps it from being mistaken for a trivially cheap literal, so the selective literals are picked first and the join stays small.

Nothing else changes: the greedy ordering algorithm, the semi-naive machinery, the queue, and the instantiators are untouched — only the size handed to a size-0 recursive literal differs. Every score stays non-negative, so the instantiation order remains valid and **the ground program is identical**. The ordering only affects *how much intermediate work* grounding does, never *what* it produces.

## Effect

Grounding the program from #583, before and after:

| | Rules | Atoms | Literal matches | Grounding time |
|---|---|---|---|---|
| before | 1,841,337 | 811,727 | 11,654,696 | 1.53 s |
| after  | 1,841,337 | 811,727 |  8,003,234 | 0.99 s |

*Generated with `clingo *.lp --stats --profile=detailed --project-anonymous --projection-mode=none --models=1 --quiet=2` on the #583 instance. Rules/Atoms are from `--stats`; "literal matches" (the join work) is summed from the `--profile=detailed` grounding profile; grounding time is the summed per-rule instantiation time, best of three runs. Platform: Apple M4 Pro (arm64), macOS 26.6.2, clang 23.1 + libc++, optimized (RelWithDebInfo) build.*

The ground program is byte-identical (Rules/Atoms/Bodies unchanged), so this is purely a grounding-speed change: about a third less join work and a third less grounding time. On a corpus of other programs the ground program was likewise unchanged and the answer sets identical.

Offered as a candidate fix for #583.
