### PR TITLE
Add Atom and Literal types for program atom/literal ids

### DIFF
--- a/lib/c-api/src/base.cc
+++ b/lib/c-api/src/base.cc
@@ -1,5 +1,6 @@
 #include <clingo/base.h> // IWYU pragma: export
 
+#include <clingo/core/backend.hh>
 #include <clingo/ground/base.hh>
 
 #include <potassco/theory_data.h>
@@ -214,7 +215,7 @@ extern "C" auto clingo_base_is_fact(clingo_base_t const *atoms, clingo_literal_t
         if (atoms == nullptr || is_fact == nullptr) {
             return fail_arguments();
         }
-        *is_fact = get_program(atoms).isFact(std::abs(literal));
+        *is_fact = get_program(atoms).isFact(CppClingo::Literal::from_rep(literal).atom().index());
     }
     CLINGO_CATCH;
 }
@@ -224,7 +225,7 @@ extern "C" auto clingo_base_is_shown(clingo_base_t const *atoms, clingo_literal_
         if (atoms == nullptr || is_shown == nullptr) {
             return fail_arguments();
         }
-        *is_shown = get_program(atoms).isShown(std::abs(literal));
+        *is_shown = get_program(atoms).isShown(CppClingo::Literal::from_rep(literal).atom().index());
     }
     CLINGO_CATCH;
 }
@@ -235,7 +236,7 @@ extern "C" auto clingo_base_is_projected(clingo_base_t const *atoms, clingo_lite
         if (atoms == nullptr || is_projected == nullptr) {
             return fail_arguments();
         }
-        *is_projected = get_program(atoms).isProjected(std::abs(literal));
+        *is_projected = get_program(atoms).isProjected(CppClingo::Literal::from_rep(literal).atom().index());
     }
     CLINGO_CATCH;
 }
@@ -246,7 +247,7 @@ extern "C" auto clingo_base_is_external(clingo_base_t const *atoms, clingo_liter
         if (atoms == nullptr || is_external == nullptr) {
             return fail_arguments();
         }
-        *is_external = get_program(atoms).isExternal(std::abs(literal));
+        *is_external = get_program(atoms).isExternal(CppClingo::Literal::from_rep(literal).atom().index());
     }
     CLINGO_CATCH;
 }
@@ -256,7 +257,7 @@ extern "C" auto clingo_base_is_current(clingo_base_t const *atoms, clingo_litera
         if (atoms == nullptr || is_current == nullptr) {
             return fail_arguments();
         }
-        auto atom = static_cast<clingo_atom_t>(std::abs(literal));
+        auto atom = CppClingo::Literal::from_rep(literal).atom().index();
         *is_current = get_program(atoms).isNew(atom);
     }
     CLINGO_CATCH;

--- a/lib/c-api/src/base.cc
+++ b/lib/c-api/src/base.cc
@@ -284,7 +284,7 @@ extern "C" auto clingo_atom_base_literal(clingo_atom_base_t const *atoms, size_t
             return fail_arguments();
         }
         if (index < cpp_cast(atoms)->size()) {
-            *literal = static_cast<clingo_literal_t>(cpp_cast(atoms)->nth(index)->second.id);
+            *literal = static_cast<clingo_literal_t>(cpp_cast(atoms)->nth(index)->second.id.index());
         } else {
             return fail_with(clingo_result_range, "index out of range");
         }

--- a/lib/control/src/grounder.cc
+++ b/lib/control/src/grounder.cc
@@ -65,7 +65,7 @@ class Builder : public Input::DependencyBuilder {
         for (auto const &fact : facts) {
             auto &base = bases_->add_base(std::make_tuple(fact.name(), fact.args().size(), fact.has_sign()));
             auto [it, state] = base.add(fact, Ground::StateAtom::fact, [this]() { return out_->uid(true); });
-            out_->fact(fact, it->second.id);
+            out_->fact(fact, it->second.id.index());
         }
     }
 
@@ -180,7 +180,7 @@ struct Grounder::Impl : CppClingo::SymbolOwner {
             for (auto i = base.mark_shown(), n = base.size(); i != n; ++i) {
                 auto it = base.nth(i);
                 auto const &atom = it.key();
-                out->show_atom(atom, it.value().id);
+                out->show_atom(atom, it.value().id.index());
             }
         };
         auto hide = Util::unordered_set<Input::Sig>{};
@@ -191,7 +191,7 @@ struct Grounder::Impl : CppClingo::SymbolOwner {
                         if (auto *base = bases.get_base({stm.name(), stm.arity(), stm.sign()}); base != nullptr) {
                             for (auto i = base->mark_projected(), n = base->size(); i != n; ++i) {
                                 auto atom = base->nth(i);
-                                out->project(atom.key(), atom.value().id);
+                                out->project(atom.key(), atom.value().id.index());
                             }
                         }
                     } else if constexpr (Util::matches<T, Input::StmShowNothing>) {
@@ -230,7 +230,7 @@ struct Grounder::Impl : CppClingo::SymbolOwner {
                         auto jt = neg_base->nth(i);
                         // NOLINTNEXTLINE
                         if (auto kt = pos_base->find(*jt->first.flip_classical_sign()); kt) {
-                            out->classical_negation(jt->second.id, kt->value().id);
+                            out->classical_negation(jt->second.id.index(), kt->value().id.index());
                         }
                     }
                     // add constraints `:- -p, p.` for each fresh atom `p` and old atom `-p`
@@ -239,7 +239,7 @@ struct Grounder::Impl : CppClingo::SymbolOwner {
                             auto jt = pos_base->nth(i);
                             // NOLINTNEXTLINE
                             if (auto j = neg_base->index(*jt->first.flip_classical_sign()); j < old_neg) {
-                                out->classical_negation(jt->second.id, neg_base->nth(j).value().id);
+                                out->classical_negation(jt->second.id.index(), neg_base->nth(j).value().id.index());
                             }
                         }
                     }

--- a/lib/control/src/solver.cc
+++ b/lib/control/src/solver.cc
@@ -251,6 +251,7 @@ class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
     virtual void do_term_id(Symbol sym, prg_id_t id) = 0;
 
     auto as_atom_(Literal lit) -> Potassco::Atom_t {
+        assert(!lit.sign());
         auto atom = lit.atom();
         max_lit_ = std::max(max_lit_, static_cast<prg_lit_t>(atom.index()));
         return static_cast<Potassco::Atom_t>(atom.index());

--- a/lib/control/src/solver.cc
+++ b/lib/control/src/solver.cc
@@ -102,7 +102,9 @@ class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
                       static_cast<unsigned>(Clasp::DomModType::sign));
         static_assert(static_cast<unsigned>(CppClingo::HeuristicType::true_) ==
                       static_cast<unsigned>(Clasp::DomModType::true_));
-        prg_->heuristic(as_atom_(atom), static_cast<Clasp::DomModType>(type), weight, prio, as_lits_(body));
+        // heuristic priority is non-negative
+        prg_->heuristic(as_atom_(Literal::from_rep(atom)), static_cast<Clasp::DomModType>(type), weight,
+                        static_cast<unsigned>(prio), as_lits_(body));
     }
 
     void do_external(prg_lit_t atom, ExternalType type) override {
@@ -112,7 +114,7 @@ class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
                       static_cast<unsigned>(Potassco::TruthValue::false_));
         static_assert(static_cast<unsigned>(ExternalType::release) ==
                       static_cast<unsigned>(Potassco::TruthValue::release));
-        prg_->external(as_atom_(atom), static_cast<Potassco::TruthValue>(type));
+        prg_->external(as_atom_(Literal::from_rep(atom)), static_cast<Potassco::TruthValue>(type));
     }
 
     void do_project(PrgLitSpan atoms) override { prg_->project(as_atoms_(atoms)); }
@@ -138,7 +140,7 @@ class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
     void do_show_term(prg_id_t id, PrgLitSpan body) override { prg_->output(id, as_lits_(body)); }
 
     void do_show_atom(Symbol sym, prg_lit_t lit) override {
-        prg_->outputAtom(as_atom_(lit), as_str(sym));
+        prg_->outputAtom(as_atom_(Literal::from_rep(lit)), as_str(sym));
 #ifdef DEBUG_BACKEND
         std::cerr << "#show " << sym << " : " << lit << ".\n";
 #endif
@@ -223,7 +225,7 @@ class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
 
     void do_atom(prg_lit_t lit_or_zero, prg_id_t name, PrgIdSpan elems,
                  std::optional<std::pair<prg_id_t, prg_id_t>> guard) override {
-        auto atom_or_zero = lit_or_zero != 0 ? as_atom_(lit_or_zero) : 0;
+        auto atom_or_zero = lit_or_zero != 0 ? as_atom_(Literal::from_rep(lit_or_zero)) : 0;
         if (guard) {
             prg_->theoryAtom(atom_or_zero, name, elems, guard->first, guard->second);
         } else {
@@ -248,20 +250,21 @@ class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
 
     virtual void do_term_id(Symbol sym, prg_id_t id) = 0;
 
-    auto as_atom_(prg_lit_t lit) -> Potassco::Atom_t {
-        assert(lit > 0 && lit <= prg_lit_max);
-        max_lit_ = std::max(max_lit_, lit);
-        return lit;
+    auto as_atom_(Literal lit) -> Potassco::Atom_t {
+        auto atom = lit.atom();
+        max_lit_ = std::max(max_lit_, static_cast<prg_lit_t>(atom.index()));
+        return static_cast<Potassco::Atom_t>(atom.index());
     }
 
-    auto as_lit_(prg_lit_t lit) -> Potassco::Lit_t {
-        assert(lit != 0 && lit >= prg_lit_min && lit <= prg_lit_max);
-        max_lit_ = std::max(max_lit_, std::abs(lit));
-        return lit;
+    auto as_lit_(Literal lit) -> Potassco::Lit_t {
+        auto raw = Literal::to_rep(lit);
+        assert(raw != 0 && raw >= prg_lit_min && raw <= prg_lit_max);
+        max_lit_ = std::max(max_lit_, static_cast<prg_lit_t>(lit.atom().index()));
+        return Potassco::Lit_t{raw};
     }
     auto as_lits_(PrgLitSpan body) -> Potassco::LitSpan {
         for (auto lit : body) {
-            as_lit_(lit);
+            as_lit_(Literal::from_rep(lit));
         }
         return body;
     }
@@ -269,7 +272,7 @@ class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
     auto as_atoms_(PrgLitSpan lits) -> Potassco::AtomSpan {
         atoms_.clear();
         for (auto const &lit : lits) {
-            atoms_.push_back(as_atom_(lit));
+            atoms_.push_back(as_atom_(Literal::from_rep(lit)));
         }
         return atoms_;
     }
@@ -277,7 +280,7 @@ class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
     auto as_wlits_(WeightedPrgLitSpan wlits) -> Potassco::WeightLitSpan {
         wlits_.clear();
         for (auto const &[lit, weight] : wlits) {
-            wlits_.emplace_back(as_lit_(lit), weight);
+            wlits_.emplace_back(as_lit_(Literal::from_rep(lit)), weight);
         }
         return wlits_;
     }
@@ -1516,7 +1519,7 @@ void Solver::simplify_() {
         auto const &prg = *clasp->asp();
         // NOTE: Externals are not simplified because they must be available in
         // domains until released.
-        if (prg.isExternal(std::abs(lit))) {
+        if (prg.isExternal(static_cast<Potassco::Atom_t>(Literal::from_rep(lit).atom().index()))) {
             return TruthValue::unknown;
         }
         auto slit = Clasp::Asp::solverLiteral(prg, lit);

--- a/lib/control/src/solver.cc
+++ b/lib/control/src/solver.cc
@@ -102,9 +102,8 @@ class AbstractProgramBackendImpl : public ProgramBackend, public TheoryBackend {
                       static_cast<unsigned>(Clasp::DomModType::sign));
         static_assert(static_cast<unsigned>(CppClingo::HeuristicType::true_) ==
                       static_cast<unsigned>(Clasp::DomModType::true_));
-        // heuristic priority is non-negative
-        prg_->heuristic(as_atom_(Literal::from_rep(atom)), static_cast<Clasp::DomModType>(type), weight,
-                        static_cast<unsigned>(prio), as_lits_(body));
+        prg_->heuristic(as_atom_(Literal::from_rep(atom)), static_cast<Clasp::DomModType>(type), weight, prio,
+                        as_lits_(body));
     }
 
     void do_external(prg_lit_t atom, ExternalType type) override {
@@ -1525,7 +1524,7 @@ void Solver::simplify_() {
         auto const &prg = *clasp->asp();
         // NOTE: Externals are not simplified because they must be available in
         // domains until released.
-        if (prg.isExternal(static_cast<Potassco::Atom_t>(Literal::from_rep(lit).atom().index()))) {
+        if (prg.isExternal(Literal::from_rep(lit).atom().index())) {
             return TruthValue::unknown;
         }
         auto slit = Clasp::Asp::solverLiteral(prg, lit);

--- a/lib/control/src/solver.cc
+++ b/lib/control/src/solver.cc
@@ -428,7 +428,7 @@ class ModelImpl : public Model, private SolveControl {
             for (auto const &base : bases_->atoms()) {
                 for (size_t i = 0, e = show_a ? base.second->size() : base.second->num_shown(); i != e; ++i) {
                     auto [sym, state] = *base.second->nth(i);
-                    if (mdl_->isTrue(solver_literal(state.id))) {
+                    if (mdl_->isTrue(solver_literal(state.id.index()))) {
                         res.emplace_back(sym);
                     }
                 }
@@ -476,7 +476,7 @@ class ModelImpl : public Model, private SolveControl {
         if (!it) {
             return false;
         }
-        return mdl_->isTrue(solver_literal(it->value().id));
+        return mdl_->isTrue(solver_literal(it->value().id.index()));
     }
 
     void do_extend(SymbolSpan symbols) override { extend_.add(symbols); }
@@ -807,7 +807,7 @@ class BackendHandleImpl : public BackendHandle {
             auto ret = base.add(atom, Ground::StateAtom::derived,
                                 [this]() { return static_cast<size_t>(backend_->next_lit()); })
                            .first;
-            auto lit = static_cast<prg_lit_t>(ret.value().id);
+            auto lit = static_cast<prg_lit_t>(ret.value().id.index());
             if (ret.value().state != Ground::StateAtom::fact) {
                 added_.emplace_back(lit, ret.key());
             }
@@ -895,7 +895,7 @@ class Solver::AspifBackend : public ProgramBackend, public TheoryBackend {
         }
         auto &base = solver_->grd_.base().add_base(*sig);
         auto it = base.add(sym, Ground::StateAtom::derived, [lit]() { return lit; }).first;
-        if (std::cmp_not_equal(it->second.id, lit)) {
+        if (it->second.id != Atom::from_rep(static_cast<prg_atom_t>(lit))) {
             throw std::runtime_error{"redefinition of atom in aspif file"};
         }
         added_.emplace_back(lit, sym);

--- a/lib/control/src/solver.cc
+++ b/lib/control/src/solver.cc
@@ -893,12 +893,17 @@ class Solver::AspifBackend : public ProgramBackend, public TheoryBackend {
     //! just been added and received the same literal as the one given in the
     //! aspif output.
     void do_show_atom(Symbol sym, prg_lit_t lit) override {
+        // The aspif parser guarantees that shown atoms are given as positive
+        // literals; this is the sole signed literal fed into AtomBase::add
+        // (which mints an Atom from it), so make the invariant explicit here.
+        assert(lit > 0);
         auto sig = sym.signature();
         if (!sig) {
             throw std::runtime_error{"unexpected symbol for atom in aspif file"};
         }
         auto &base = solver_->grd_.base().add_base(*sig);
         auto it = base.add(sym, Ground::StateAtom::derived, [lit]() { return lit; }).first;
+        // Sign-safe: lit is validated positive above, so this is a plain atom-id comparison.
         if (it->second.id != Atom::from_rep(static_cast<prg_atom_t>(lit))) {
             throw std::runtime_error{"redefinition of atom in aspif file"};
         }

--- a/lib/core/CMakeLists.txt
+++ b/lib/core/CMakeLists.txt
@@ -28,6 +28,7 @@ set(source
 set(ide_test_group "Test Files")
 set(test-group
     "tests/number.cc"
+    "tests/roles.cc"
     "tests/symbol.cc")
 source_group("${ide_test_group}" FILES ${test-group})
 set(test

--- a/lib/core/include/clingo/core/backend.hh
+++ b/lib/core/include/clingo/core/backend.hh
@@ -3,7 +3,10 @@
 #include <clingo/core/core.hh>
 #include <clingo/core/symbol.hh>
 
+#include <clingo/util/hash.hh>
 #include <clingo/util/small_vector.hh>
+
+#include <ostream>
 
 namespace CppClingo {
 
@@ -48,6 +51,27 @@ static constexpr auto prg_id_max = std::numeric_limits<prg_id_t>::max() - 1;
 static constexpr auto prg_lit_max = std::numeric_limits<prg_lit_t>::max();
 //! The minimum literal.
 static constexpr auto prg_lit_min = -prg_lit_max;
+
+class Literal; // defined in the Literal task
+
+//! A program atom (positive by construction).
+class Atom {
+  public:
+    constexpr Atom() = default;
+    [[nodiscard]] constexpr auto index() const noexcept -> prg_atom_t { return rep_; }
+    [[nodiscard]] constexpr auto to_lit(bool sign = false) const noexcept -> Literal; // defined after Literal
+    [[nodiscard]] auto hash() const -> size_t { return Util::value_hash(rep_); }
+    friend constexpr auto operator==(Atom, Atom) noexcept -> bool = default;
+    friend constexpr auto operator<=>(Atom, Atom) noexcept = default;
+    static constexpr auto to_rep(Atom a) noexcept -> prg_atom_t { return a.rep_; }
+    static constexpr auto from_rep(prg_atom_t r) noexcept -> Atom { return Atom{r}; }
+    friend auto operator<<(std::ostream &out, Atom a) -> std::ostream & { return out << a.rep_; }
+  private:
+    constexpr explicit Atom(prg_atom_t r) noexcept : rep_{r} {}
+    prg_atom_t rep_ = 0;
+};
+static_assert(std::is_trivially_copyable_v<Atom>);
+static_assert(sizeof(Atom) == sizeof(prg_atom_t));
 
 //! Abstract class connecting grounder and solver.
 //!

--- a/lib/core/include/clingo/core/backend.hh
+++ b/lib/core/include/clingo/core/backend.hh
@@ -52,12 +52,15 @@ static constexpr auto prg_lit_max = std::numeric_limits<prg_lit_t>::max();
 //! The minimum literal.
 static constexpr auto prg_lit_min = -prg_lit_max;
 
-class Literal; // defined in the Literal task
+class Literal; // defined below
 
 //! A program atom (positive by construction).
 class Atom {
   public:
-    constexpr Atom() = default;
+    Atom() = delete;
+    //! Construct an explicit invalid atom, for use as a placeholder in a slot
+    //! that is assigned a valid atom before it is read.
+    static constexpr auto invalid() noexcept -> Atom { return Atom{0}; }
     [[nodiscard]] constexpr auto index() const noexcept -> prg_atom_t { return rep_; }
     [[nodiscard]] constexpr auto to_lit(bool sign = false) const noexcept -> Literal; // defined after Literal
     [[nodiscard]] auto hash() const -> size_t { return Util::value_hash(rep_); }
@@ -65,7 +68,7 @@ class Atom {
     friend constexpr auto operator<=>(Atom, Atom) noexcept = default;
     static constexpr auto to_rep(Atom a) noexcept -> prg_atom_t { return a.rep_; }
     static constexpr auto from_rep(prg_atom_t r) noexcept -> Atom {
-        assert(r <= static_cast<prg_atom_t>(prg_lit_max));
+        assert(r != 0 && r <= static_cast<prg_atom_t>(prg_lit_max));
         return Atom{r};
     }
     friend auto operator<<(std::ostream &out, Atom a) -> std::ostream & { return out << a.rep_; }
@@ -74,12 +77,13 @@ class Atom {
     prg_atom_t rep_ = 0;
 };
 static_assert(std::is_trivially_copyable_v<Atom>);
+static_assert(!std::is_default_constructible_v<Atom>);
 static_assert(sizeof(Atom) == sizeof(prg_atom_t));
 
 //! A program literal (signed atom; sign = polarity).
 class Literal {
   public:
-    constexpr Literal() = default;
+    Literal() = delete;
     [[nodiscard]] constexpr auto atom() const noexcept -> Atom {
         return Atom::from_rep(static_cast<prg_atom_t>(rep_ < 0 ? -rep_ : rep_));
     }
@@ -90,7 +94,7 @@ class Literal {
     friend constexpr auto operator<=>(Literal, Literal) noexcept = default;
     static constexpr auto to_rep(Literal l) noexcept -> prg_lit_t { return l.rep_; }
     static constexpr auto from_rep(prg_lit_t r) noexcept -> Literal {
-        assert(r >= prg_lit_min);
+        assert(r != 0 && r >= prg_lit_min);
         return Literal{r};
     }
     friend auto operator<<(std::ostream &out, Literal l) -> std::ostream & { return out << l.rep_; }
@@ -99,6 +103,7 @@ class Literal {
     prg_lit_t rep_ = 0;
 };
 static_assert(std::is_trivially_copyable_v<Literal>);
+static_assert(!std::is_default_constructible_v<Literal>);
 static_assert(sizeof(Literal) == sizeof(prg_lit_t));
 
 constexpr auto Atom::to_lit(bool sign) const noexcept -> Literal {

--- a/lib/core/include/clingo/core/backend.hh
+++ b/lib/core/include/clingo/core/backend.hh
@@ -73,6 +73,33 @@ class Atom {
 static_assert(std::is_trivially_copyable_v<Atom>);
 static_assert(sizeof(Atom) == sizeof(prg_atom_t));
 
+//! A program literal (signed atom; sign = polarity).
+class Literal {
+  public:
+    constexpr Literal() = default;
+    [[nodiscard]] constexpr auto atom() const noexcept -> Atom {
+        return Atom::from_rep(static_cast<prg_atom_t>(rep_ < 0 ? -rep_ : rep_));
+    }
+    [[nodiscard]] constexpr auto sign() const noexcept -> bool { return rep_ < 0; }
+    [[nodiscard]] constexpr auto operator~() const noexcept -> Literal { return Literal{static_cast<prg_lit_t>(-rep_)}; }
+    [[nodiscard]] auto hash() const -> size_t { return Util::value_hash(rep_); }
+    friend constexpr auto operator==(Literal, Literal) noexcept -> bool = default;
+    friend constexpr auto operator<=>(Literal, Literal) noexcept = default;
+    static constexpr auto to_rep(Literal l) noexcept -> prg_lit_t { return l.rep_; }
+    static constexpr auto from_rep(prg_lit_t r) noexcept -> Literal { return Literal{r}; }
+    friend auto operator<<(std::ostream &out, Literal l) -> std::ostream & { return out << l.rep_; }
+  private:
+    constexpr explicit Literal(prg_lit_t r) noexcept : rep_{r} {}
+    prg_lit_t rep_ = 0;
+};
+static_assert(std::is_trivially_copyable_v<Literal>);
+static_assert(sizeof(Literal) == sizeof(prg_lit_t));
+
+constexpr auto Atom::to_lit(bool sign) const noexcept -> Literal {
+    auto v = static_cast<prg_lit_t>(rep_);
+    return Literal::from_rep(sign ? static_cast<prg_lit_t>(-v) : v);
+}
+
 //! Abstract class connecting grounder and solver.
 //!
 //! The backend is responsible for passing grounded statements to the solver (or

--- a/lib/core/include/clingo/core/backend.hh
+++ b/lib/core/include/clingo/core/backend.hh
@@ -64,7 +64,10 @@ class Atom {
     friend constexpr auto operator==(Atom, Atom) noexcept -> bool = default;
     friend constexpr auto operator<=>(Atom, Atom) noexcept = default;
     static constexpr auto to_rep(Atom a) noexcept -> prg_atom_t { return a.rep_; }
-    static constexpr auto from_rep(prg_atom_t r) noexcept -> Atom { return Atom{r}; }
+    static constexpr auto from_rep(prg_atom_t r) noexcept -> Atom {
+        assert(r <= static_cast<prg_atom_t>(prg_lit_max));
+        return Atom{r};
+    }
     friend auto operator<<(std::ostream &out, Atom a) -> std::ostream & { return out << a.rep_; }
   private:
     constexpr explicit Atom(prg_atom_t r) noexcept : rep_{r} {}
@@ -86,7 +89,10 @@ class Literal {
     friend constexpr auto operator==(Literal, Literal) noexcept -> bool = default;
     friend constexpr auto operator<=>(Literal, Literal) noexcept = default;
     static constexpr auto to_rep(Literal l) noexcept -> prg_lit_t { return l.rep_; }
-    static constexpr auto from_rep(prg_lit_t r) noexcept -> Literal { return Literal{r}; }
+    static constexpr auto from_rep(prg_lit_t r) noexcept -> Literal {
+        assert(r >= prg_lit_min);
+        return Literal{r};
+    }
     friend auto operator<<(std::ostream &out, Literal l) -> std::ostream & { return out << l.rep_; }
   private:
     constexpr explicit Literal(prg_lit_t r) noexcept : rep_{r} {}

--- a/lib/core/tests/roles.cc
+++ b/lib/core/tests/roles.cc
@@ -1,0 +1,17 @@
+#include <clingo/core/backend.hh>
+
+#include <catch2/catch_test_macros.hpp>
+
+namespace CppClingo::Test {
+
+TEST_CASE("atom_basic") {
+    auto a = Atom::from_rep(5);
+    REQUIRE(a.index() == 5U);
+    REQUIRE(Atom::to_rep(a) == 5U);
+    REQUIRE(a == Atom::from_rep(5));
+    REQUIRE(a != Atom::from_rep(6));
+    STATIC_REQUIRE(std::is_trivially_copyable_v<Atom>);
+    STATIC_REQUIRE(sizeof(Atom) == sizeof(prg_atom_t));
+}
+
+} // namespace CppClingo::Test

--- a/lib/core/tests/roles.cc
+++ b/lib/core/tests/roles.cc
@@ -23,12 +23,88 @@ TEST_CASE("literal_negation") {
     REQUIRE((~l).atom() == Atom::from_rep(3));
     STATIC_REQUIRE(sizeof(Literal) == sizeof(prg_lit_t));
 }
+
+TEST_CASE("literal_double_negation") {
+    auto l = Literal::from_rep(3);
+    REQUIRE((~(~l)) == l);
+    auto n = Literal::from_rep(-3);
+    REQUIRE((~(~n)) == n);
+}
+
 TEST_CASE("atom_literal_roundtrip") {
     auto a = Atom::from_rep(7);
     REQUIRE(a.to_lit(false).sign() == false);
     REQUIRE(a.to_lit(true).sign() == true);
     REQUIRE(a.to_lit(false).atom() == a);
     REQUIRE(a.to_lit(true).atom() == a);
+    // Check the rep values directly, not just sign()/atom(), so that a
+    // regression that gets the sign of the underlying rep backwards (while
+    // still reporting correct sign()/atom() views) would be caught.
+    REQUIRE(Literal::to_rep(a.to_lit(false)) == 7);
+    REQUIRE(Literal::to_rep(a.to_lit(true)) == -7);
+}
+
+TEST_CASE("atom_ordering") {
+    auto a3 = Atom::from_rep(3);
+    auto a5 = Atom::from_rep(5);
+    REQUIRE(a3 < a5);
+    REQUIRE(a5 > a3);
+    REQUIRE(a3 <= a3);
+    REQUIRE(a3 <= a5);
+    REQUIRE(a5 >= a5);
+    REQUIRE_FALSE(a5 < a3);
+}
+
+TEST_CASE("literal_ordering") {
+    auto l3 = Literal::from_rep(3);
+    auto l5 = Literal::from_rep(5);
+    REQUIRE(l3 < l5);
+    REQUIRE(l5 > l3);
+    REQUIRE(l3 <= l3);
+    REQUIRE(l3 <= l5);
+    REQUIRE(l5 >= l5);
+    REQUIRE_FALSE(l5 < l3);
+    // negative literals order below positive ones, consistent with the
+    // underlying rep (this is the ordering that would be used e.g. as a map
+    // key), not just by atom.
+    auto neg = Literal::from_rep(-5);
+    REQUIRE(neg < l3);
+}
+
+TEST_CASE("atom_hash_consistency") {
+    auto a1 = Atom::from_rep(11);
+    auto a2 = Atom::from_rep(11);
+    REQUIRE(a1 == a2);
+    REQUIRE(a1.hash() == a2.hash());
+}
+
+TEST_CASE("literal_hash_consistency") {
+    auto l1 = Literal::from_rep(-11);
+    auto l2 = Literal::from_rep(-11);
+    REQUIRE(l1 == l2);
+    REQUIRE(l1.hash() == l2.hash());
+}
+
+TEST_CASE("atom_literal_valid_domain") {
+    // Atoms/literals are only meaningful for positive values in
+    // [1, prg_lit_max]; INT32_MIN cannot be exercised (it is UB per the
+    // type's documented contract), but round-tripping across a
+    // representative sample of the valid positive domain should hold,
+    // including the boundary values 1 and prg_lit_max.
+    for (prg_lit_t v : {prg_lit_t{1}, prg_lit_t{2}, prg_lit_t{42}, prg_lit_max}) {
+        auto a = Atom::from_rep(static_cast<prg_atom_t>(v));
+        REQUIRE(Atom::to_rep(a) == static_cast<prg_atom_t>(v));
+
+        auto pos = Literal::from_rep(v);
+        REQUIRE(pos.sign() == false);
+        REQUIRE(pos.atom() == a);
+        REQUIRE(Literal::to_rep(pos) == v);
+
+        auto neg = Literal::from_rep(-v);
+        REQUIRE(neg.sign() == true);
+        REQUIRE(neg.atom() == a);
+        REQUIRE(Literal::to_rep(neg) == -v);
+    }
 }
 
 } // namespace CppClingo::Test

--- a/lib/core/tests/roles.cc
+++ b/lib/core/tests/roles.cc
@@ -14,4 +14,21 @@ TEST_CASE("atom_basic") {
     STATIC_REQUIRE(sizeof(Atom) == sizeof(prg_atom_t));
 }
 
+TEST_CASE("literal_negation") {
+    auto l = Literal::from_rep(3);
+    REQUIRE((~l) == Literal::from_rep(-3));
+    REQUIRE(l.sign() == false);
+    REQUIRE((~l).sign() == true);
+    REQUIRE(l.atom() == Atom::from_rep(3));
+    REQUIRE((~l).atom() == Atom::from_rep(3));
+    STATIC_REQUIRE(sizeof(Literal) == sizeof(prg_lit_t));
+}
+TEST_CASE("atom_literal_roundtrip") {
+    auto a = Atom::from_rep(7);
+    REQUIRE(a.to_lit(false).sign() == false);
+    REQUIRE(a.to_lit(true).sign() == true);
+    REQUIRE(a.to_lit(false).atom() == a);
+    REQUIRE(a.to_lit(true).atom() == a);
+}
+
 } // namespace CppClingo::Test

--- a/lib/core/tests/roles.cc
+++ b/lib/core/tests/roles.cc
@@ -11,7 +11,9 @@ TEST_CASE("atom_basic") {
     REQUIRE(a == Atom::from_rep(5));
     REQUIRE(a != Atom::from_rep(6));
     STATIC_REQUIRE(std::is_trivially_copyable_v<Atom>);
+    STATIC_REQUIRE(!std::is_default_constructible_v<Atom>);
     STATIC_REQUIRE(sizeof(Atom) == sizeof(prg_atom_t));
+    REQUIRE(Atom::invalid().index() == 0U);
 }
 
 TEST_CASE("literal_negation") {
@@ -22,6 +24,7 @@ TEST_CASE("literal_negation") {
     REQUIRE(l.atom() == Atom::from_rep(3));
     REQUIRE((~l).atom() == Atom::from_rep(3));
     STATIC_REQUIRE(sizeof(Literal) == sizeof(prg_lit_t));
+    STATIC_REQUIRE(!std::is_default_constructible_v<Literal>);
 }
 
 TEST_CASE("literal_double_negation") {

--- a/lib/ground/include/clingo/ground/base.hh
+++ b/lib/ground/include/clingo/ground/base.hh
@@ -245,7 +245,9 @@ class AtomBase : public BaseImpl<Symbol, AtomBase> {
 
     //! Add an atom to the base.
     template <class Gen> auto add(Symbol atom, StateAtom state, Gen &&gen) -> std::pair<MapAtom::iterator, AtomUpdate> {
-        auto [it, ins] = atoms_.try_emplace(atom, Atom{}, state);
+        // The placeholder is overwritten with the minted id below on insert, and
+        // discarded by try_emplace otherwise, so it never reaches a read.
+        auto [it, ins] = atoms_.try_emplace(atom, Atom::invalid(), state);
         if (ins) {
             it.value().id = Atom::from_rep(static_cast<prg_atom_t>(std::invoke(std::forward<Gen>(gen))));
             if (state != StateAtom::unknown) {

--- a/lib/ground/include/clingo/ground/base.hh
+++ b/lib/ground/include/clingo/ground/base.hh
@@ -3,6 +3,7 @@
 #include <clingo/ground/instantiator.hh>
 #include <clingo/ground/term.hh>
 
+#include <clingo/core/backend.hh>
 #include <clingo/core/symbol.hh>
 
 #include <clingo/util/index_sequence.hh>
@@ -21,8 +22,7 @@ using VariableSet = Util::ordered_set<size_t>;
 using VariableVec = VariableSet::values_container_type;
 
 //! Enumeration to capture the state of an atom.
-// NOLINTNEXTLINE(performance-enum-size)
-enum class StateAtom : uint64_t {
+enum class StateAtom : uint8_t {
     //! Indicates that the atom is derived by a fact.
     fact = 0,
     //! Indicates that the atom is derived by some rule but not a fact.
@@ -41,8 +41,8 @@ enum class StateAtom : uint64_t {
 
 //! Capture the state of an atom.
 struct AtomInfo {
-    uint64_t id : 62;    //!< A unique id among all atoms.
-    StateAtom state : 2; //!< The atom state.
+    Atom id;         //!< A unique id among all atoms.
+    StateAtom state; //!< The atom state.
 };
 
 static_assert(sizeof(AtomInfo) == sizeof(uint64_t));
@@ -245,9 +245,9 @@ class AtomBase : public BaseImpl<Symbol, AtomBase> {
 
     //! Add an atom to the base.
     template <class Gen> auto add(Symbol atom, StateAtom state, Gen &&gen) -> std::pair<MapAtom::iterator, AtomUpdate> {
-        auto [it, ins] = atoms_.try_emplace(atom, 0, state);
+        auto [it, ins] = atoms_.try_emplace(atom, Atom{}, state);
         if (ins) {
-            it.value().id = std::invoke(std::forward<Gen>(gen));
+            it.value().id = Atom::from_rep(static_cast<prg_atom_t>(std::invoke(std::forward<Gen>(gen))));
             if (state != StateAtom::unknown) {
                 derived_.add(atom_index_(it));
             }
@@ -326,7 +326,7 @@ class AtomBase : public BaseImpl<Symbol, AtomBase> {
                 ++rem;
                 return true;
             }
-            auto tv = pred(item.second.id);
+            auto tv = pred(static_cast<prg_lit_t>(item.second.id.index()));
             if (tv == TruthValue::bot) {
                 ++rem;
                 return true;

--- a/lib/ground/src/base.cc
+++ b/lib/ground/src/base.cc
@@ -22,11 +22,12 @@ void ProjectState::init(InstantiationContext const &ctx, size_t gen) {
             if (auto sym = p_head_->eval(eval_ctx); sym) {
                 auto [it, res] = p_base_.add(*sym, atom->second.state, [&]() {
                     // if the atom is a fact we can simply use its uid here
-                    return atom.value().state == StateAtom::fact ? atom.value().id : ctx.out().uid();
+                    return atom.value().state == StateAtom::fact ? atom.value().id.index()
+                                                                  : static_cast<prg_atom_t>(ctx.out().uid());
                 });
                 // add projection rules (if not previously derived as a fact)
                 if (res == AtomUpdate::changed || it.value().state != StateAtom::fact) {
-                    ctx.out().project_atom(it.value().id, atom.value().id);
+                    ctx.out().project_atom(it.value().id.index(), atom.value().id.index());
                 }
             }
         }

--- a/lib/ground/src/disjunction.cc
+++ b/lib/ground/src/disjunction.cc
@@ -156,8 +156,10 @@ void StateDisjunction::propagate(OutputStm &out, Queue &queue) {
                 auto jt = std::ranges::lower_bound(bases_, sig, std::less<>{},
                                                    [](auto const &a) -> decltype(auto) { return std::get<0>(a); });
                 assert(jt != bases_.end());
-                elem.value().first =
-                    std::get<1>(*jt)->add(sym, StateAtom::derived, [&out]() { return out.uid(); }).first.value().id;
+                elem.value().first = std::get<1>(*jt)
+                                         ->add(sym, StateAtom::derived, [&out]() { return out.uid(); })
+                                         .first.value()
+                                         .id.index();
             }
 #ifdef DEBUG_AGGR
             std::cerr << "propagate: a: " << atom_idx << "\n";

--- a/lib/ground/src/head_aggregate.cc
+++ b/lib/ground/src/head_aggregate.cc
@@ -362,7 +362,8 @@ void StateHdAggr::propagate(OutputStm &out, Queue &queue) {
                                                      [](auto const &a) -> decltype(auto) { return std::get<0>(a); });
                         assert(it != bases_.end());
                         auto *base = std::get<1>(*it);
-                        head = base->add(sym, StateAtom::derived, [&out]() { return out.uid(); }).first.value().id;
+                        head =
+                            base->add(sym, StateAtom::derived, [&out]() { return out.uid(); }).first.value().id.index();
                     }
                 }
             }

--- a/lib/ground/src/literal.cc
+++ b/lib/ground/src/literal.cc
@@ -350,7 +350,7 @@ auto get_atom(AtomBase &base, OutputStm &out, Sign sign, size_t index, Symbol sy
 auto LitSymbolic::do_output([[maybe_unused]] EvalContext const &ctx, OutputLit &out) const -> bool {
     assert(offset_ != invalid_offset || Symbol::to_rep(symbol_) != 0);
     if (auto atom = get_atom(*base_, ctx.out(), sign_, index_, symbol_, offset_)) {
-        out.lit(sign_, atom->key(), atom->value().id);
+        out.lit(sign_, atom->key(), atom->value().id.index());
         return true;
     }
     return false;
@@ -441,7 +441,7 @@ auto LitProject::do_output(EvalContext const &ctx, OutputLit &out) const -> bool
         // evaluation cannot fail by construction
         auto sym = atom_->eval(ctx);
         assert(sym);
-        out.lit(sign_, *sym, atom->value().id);
+        out.lit(sign_, *sym, atom->value().id.index());
         return true;
     }
     return false;

--- a/lib/ground/src/statement.cc
+++ b/lib/ground/src/statement.cc
@@ -327,7 +327,7 @@ auto StmRule::do_report(EvalContext const &ctx) -> bool {
                       ->add(atom_, fact ? StateAtom::fact : StateAtom::derived,
                             [&ctx, fact]() { return ctx.out().uid(fact); })
                       .first;
-        ctx.out().rule(std::tuple{atom_, static_cast<size_t>(it.value().id), type_ == RuleType::choice});
+        ctx.out().rule(std::tuple{atom_, it.value().id.index(), type_ == RuleType::choice});
     } else if (type_ == RuleType::normal) {
         ctx.out().rule(std::nullopt);
     }
@@ -437,7 +437,7 @@ void StmExternal::do_init(size_t gen) {
 
 auto StmExternal::do_report(EvalContext const &ctx) -> bool {
     auto it = base_->add(res_atom_, StateAtom::derived, [&ctx]() { return ctx.out().uid(); }).first;
-    ctx.out().external(res_atom_, it.value().id, res_type_);
+    ctx.out().external(res_atom_, it.value().id.index(), res_type_);
     return true;
 }
 
@@ -721,7 +721,8 @@ auto StmHeuristic::do_report(EvalContext const &ctx) -> bool {
         std::ignore = lit->output(ctx, out);
     }
     auto atom = base_->nth(offset_);
-    ctx.out().heuristic(atom.key(), atom.value().id, res_weight_.num(), prio_ ? &res_prio_.num() : nullptr, res_type_);
+    ctx.out().heuristic(atom.key(), atom.value().id.index(), res_weight_.num(), prio_ ? &res_prio_.num() : nullptr,
+                        res_type_);
     return true;
 }
 
@@ -943,7 +944,7 @@ void StmProject::do_init([[maybe_unused]] size_t gen) {
 
 auto StmProject::do_report(EvalContext const &ctx) -> bool {
     auto atom = base_->nth(offset_);
-    ctx.out().project(atom.key(), atom.value().id);
+    ctx.out().project(atom.key(), atom.value().id.index());
     return true;
 }
 

--- a/lib/output/src/backend.cc
+++ b/lib/output/src/backend.cc
@@ -214,8 +214,8 @@ class BuilderBase {
             assert(lit > 0);
             if (auto &li = info(lit); li.type != EQType::none) {
                 for (auto const &clit : clauses_.nth(li.clause).key().first) {
-                    if (this->mark(clit, li.type)) {
-                        todo.emplace_back(std::abs(clit));
+                    if (this->mark(Literal::from_rep(clit), li.type)) {
+                        todo.emplace_back(static_cast<prg_lit_t>(Literal::from_rep(clit).atom().index()));
                     }
                 }
             }
@@ -293,12 +293,12 @@ class BuilderBase {
     //! @param lit the literal to mark
     //! @param type the type of the equivalence
     //! @return whether the literal has been marked with a stricter type
-    auto mark(prg_lit_t lit, EQType type) -> bool {
-        auto atm = std::abs(lit);
-        if (lit < 0) {
+    auto mark(Literal lit, EQType type) -> bool {
+        auto atm = lit.atom();
+        if (lit.sign()) {
             type = std::max(type, EQType::implication);
         }
-        if (auto &li = info(atm); li.clause != invalid_id && li.type < type) {
+        if (auto &li = info(static_cast<prg_lit_t>(atm.index())); li.clause != invalid_id && li.type < type) {
             li.type = type;
             return true;
         }
@@ -481,7 +481,7 @@ template <class Sym> class BuilderMinMax {
         }
         lits_.resize(ids_.back());
         for (auto const &clit : lits_) {
-            bld.mark(clit, EQType::implication);
+            bld.mark(Literal::from_rep(clit), EQType::implication);
         }
         auto get_span = [this](auto it) {
             return std::span{std::next(lits_.begin(), *it), std::next(lits_.begin(), *(it + 1))};
@@ -639,7 +639,7 @@ template <class Sym> class BuilderMinMax {
                     // lit :- clit, tr_lits_.
                     if (tr_lits_.size() > 1) {
                         auto nlit = bld.clause(tr_lits_, ClauseType::conjunctive, false);
-                        bld.mark(nlit, EQType::implication);
+                        bld.mark(Literal::from_rep(nlit), EQType::implication);
                         tr_lits_.clear();
                         tr_lits_.emplace_back(nlit);
                     }
@@ -654,7 +654,7 @@ template <class Sym> class BuilderMinMax {
                         // nlit :- not clit.
                         // nlit :- lit.
                         // nlit | clit :- not not l.
-                        bld.mark(clit, EQType::equivalence);
+                        bld.mark(Literal::from_rep(clit), EQType::equivalence);
                         auto nlit = bld.next_lit();
                         bld.backend().rule(std::array{nlit}, std::array{bld.negate(clit)}, false);
                         bld.backend().rule(std::array{nlit}, std::array{bld.negate(lit)}, false);
@@ -849,7 +849,7 @@ class BuilderSum {
             auto it = elems.begin();
             for (auto const &nlit : nlits) {
                 auto clit = it++->second;
-                bld.mark(clit, nlit > 0 ? EQType::equivalence : EQType::implication);
+                bld.mark(Literal::from_rep(clit), nlit > 0 ? EQType::equivalence : EQType::implication);
                 if (nlit > 0) {
                     // nlit :- lit.                % saturate
                     bld.backend().rule(std::array{nlit}, std::array{lit}, false);
@@ -1052,19 +1052,19 @@ class BuilderCondLit {
         // - G: captures the conclusion
         // - F: catures the premise
         for (auto const &[g, f] : elems) {
-            bld.mark(f, EQType::implication);
+            bld.mark(Literal::from_rep(f), EQType::implication);
             if (g) {
                 auto rec = bld.in_cycle(lit, f);
                 auto k = bld.next_lit();
                 // formula G : F is replaced by K
                 // K :- G.
                 // K :- not F.
-                bld.mark(*g, EQType::implication);
+                bld.mark(Literal::from_rep(*g), EQType::implication);
                 bld.backend().rule(std::array{k}, std::array{*g}, false);
                 bld.backend().rule(std::array{k}, std::array{bld.negate(f)}, false);
                 if (rec) {
                     // K | F :- not not G.
-                    bld.mark(f, EQType::equivalence);
+                    bld.mark(Literal::from_rep(f), EQType::equivalence);
                     bld.backend().rule(std::array{k, f}, std::array{bld.negate(bld.negate(*g))}, false);
                 } else {
                 }
@@ -1142,7 +1142,7 @@ class BuilderDisjunction {
                     auto y = bld.next_lit();
                     Util::into_vec(lits_, conds, uid_to_atom);
                     auto c = bld.clause(lits_, ClauseType::disjunctive);
-                    bld.mark(c, EQType::implication);
+                    bld.mark(Literal::from_rep(c), EQType::implication);
                     hd_.emplace_back(x);
                     bd_.emplace_back(y);
                     // a :- x.
@@ -1159,7 +1159,7 @@ class BuilderDisjunction {
             } else {
                 Util::into_vec(lits_, conds, uid_to_atom);
                 bd_.emplace_back(bld.negate(bld.clause(lits_, ClauseType::disjunctive)));
-                bld.mark(bd_.back(), EQType::implication);
+                bld.mark(Literal::from_rep(bd_.back()), EQType::implication);
             }
         }
         rule_.add(bld, hd_, bd_, false);
@@ -1249,7 +1249,7 @@ class BuilderMinimize {
                 bld.backend().minimize(prio, std::array{std::pair{lit, weight}});
             } else {
                 auto lit = bld.clause({}, ClauseType::conjunctive);
-                bld.mark(lit, EQType::implication);
+                bld.mark(Literal::from_rep(lit), EQType::implication);
                 bld.backend().minimize(prio, std::array{std::pair{lit, weight}});
             }
             // mark tuple as fact (ignored if enqueued)
@@ -1277,11 +1277,11 @@ class BuilderMinimize {
                 auto &[old, conds] = *it.value(); // NOLINT
                 assert(!conds.empty());
                 for (auto const &lit : conds) {
-                    bld.mark(lit, EQType::implication);
+                    bld.mark(Literal::from_rep(lit), EQType::implication);
                 }
                 old = bld.clause(conds, ClauseType::disjunctive);
                 conds.clear();
-                bld.mark(old, EQType::implication);
+                bld.mark(Literal::from_rep(old), EQType::implication);
                 bld.backend().minimize(prio, std::array{std::pair{old, weight}});
             }
         }
@@ -1586,8 +1586,9 @@ class OutputBackend : public OutputStm, OutputTheory {
                         auto hlit = uid_to_lit(huid);
                         auto elit = bld_.clause(std::array{hlit, clit}, ClauseType::conjunctive);
                         bd_conds.back().emplace_back(elit);
-                        bld_.mark(uid_to_lit(elit), EQType::implication);
-                        bld_.mark(clit, EQType::implication);
+                        // elit is a fresh positive clause literal
+                        bld_.mark(Literal::from_rep(uid_to_lit(static_cast<size_t>(elit))), EQType::implication);
+                        bld_.mark(Literal::from_rep(clit), EQType::implication);
                         rule_.add(bld_, std::array{hlit}, std::array{blit, clit}, true);
                     } else {
                         bd_conds.back().emplace_back(clit);

--- a/lib/output/src/backend.cc
+++ b/lib/output/src/backend.cc
@@ -214,8 +214,9 @@ class BuilderBase {
             assert(lit > 0);
             if (auto &li = info(lit); li.type != EQType::none) {
                 for (auto const &clit : clauses_.nth(li.clause).key().first) {
-                    if (this->mark(Literal::from_rep(clit), li.type)) {
-                        todo.emplace_back(static_cast<prg_lit_t>(Literal::from_rep(clit).atom().index()));
+                    auto clit_lit = Literal::from_rep(clit);
+                    if (this->mark(clit_lit, li.type)) {
+                        todo.emplace_back(static_cast<prg_lit_t>(clit_lit.atom().index()));
                     }
                 }
             }

--- a/lib/output/src/backend.cc
+++ b/lib/output/src/backend.cc
@@ -1588,7 +1588,7 @@ class OutputBackend : public OutputStm, OutputTheory {
                         auto elit = bld_.clause(std::array{hlit, clit}, ClauseType::conjunctive);
                         bd_conds.back().emplace_back(elit);
                         // elit is a fresh positive clause literal
-                        bld_.mark(Literal::from_rep(uid_to_lit(static_cast<size_t>(elit))), EQType::implication);
+                        bld_.mark(Literal::from_rep(uid_to_lit(elit)), EQType::implication);
                         bld_.mark(Literal::from_rep(clit), EQType::implication);
                         rule_.add(bld_, std::array{hlit}, std::array{blit, clit}, true);
                     } else {


### PR DESCRIPTION
Program atoms and literals are carried as raw `prg_atom_t`/`prg_lit_t` integers, and the places that cross between them do it with hand-written sign arithmetic — `std::abs(lit)` to take the atom of a literal, a bare negation to flip a sign, a `static_cast` where the signedness changes. Nothing marks which integers are atoms and which are literals, so the crossings are easy to get subtly wrong and easy to misread.

This adds two small value types in `core/backend.hh`: **`Atom`** (a program atom, positive by construction; `index()`, `to_lit(sign)`) and **`Literal`** (a signed atom; `atom()`, `sign()`, `operator~`). The crossings go through these accessors — `std::abs(lit)` becomes `literal.atom().index()`, a sign flip becomes `~literal` — and the read side is fully typed. Both are trivially copyable and the same size as the underlying integer, converting to and from the raw representation only at the edges via `from_rep`/`to_rep`.

There is no invalid default state. The default constructors are deleted, so an `Atom` or `Literal` can only be formed from a real value — there is no zero-initialized instance a caller has to guard against. The one site that needs a placeholder (the atom-map entry inserted before its id is minted) uses a named `Atom::invalid()` factory that is overwritten with the real id on insertion and discarded otherwise, so it never reaches a read. `from_rep` asserts its argument is a non-zero id in range.

Scope: C++ internals only. The C API keeps its plain `uint32`/`int32` — it is intended for higher-level bindings that provide their own safety — converted at the `Potassco::*` seam. These are bespoke value-classes mirroring `Symbol`/`Number` rather than typed enums, so the accessors are real members. No behaviour change: ground programs and answer sets are identical, and the test suite passes (with new `roles.cc` unit tests).

This grew out of the discussion on #659, where the initial approach — unsigned casts to quiet conversion warnings — gave way to @rkaminsk's suggestion of strongly-typed atom/literal values. @BenKaufmann and @rkaminsk then pointed out that a default-constructed value was an invalid state callers had to account for; deleting the default constructor and the explicit `Atom::invalid()` above address that. The checked index/distance helpers (`to_unsigned`/`forward_distance`) sketched in that thread can follow as a separate step.
