### PR TITLE
Read the upper bound when scoring intervals

### DIFF
--- a/lib/ground/src/literal.cc
+++ b/lib/ground/src/literal.cc
@@ -57,7 +57,7 @@ auto LitInterval::do_matcher([[maybe_unused]] std::pmr::monotonic_buffer_resourc
 }
 
 auto LitInterval::do_score(std::vector<bool> const &bound) const -> double {
-    if (auto *l = dynamic_cast<TermSymbol *>(lower_.get()), *r = dynamic_cast<TermSymbol *>(lower_.get());
+    if (auto *l = dynamic_cast<TermSymbol *>(lower_.get()), *r = dynamic_cast<TermSymbol *>(upper_.get());
         l != nullptr && r != nullptr) {
         VariableSet vars;
         lhs_->vars(vars);


### PR DESCRIPTION
`LitInterval::do_score` casts the lower bound twice (`dynamic_cast<TermSymbol *>(lower_.get())` for both `l` and `r`), so a constant interval's estimated width is always computed as `lower − lower = 0`, regardless of the actual bounds. The join-order heuristic then treats a wide constant interval such as `1..1000000` as essentially free and can schedule it ahead of a more selective literal, enumerating the whole range instead of binding the variable from the selective side first.

Reading the upper bound for the second cast restores the intended `upper − lower` width.

Only the join order is affected — the estimate stays non-negative, so the set of ground instances is unchanged. On a small example joining a 1000-element predicate with a wide interval:

```
val(1..1000).
q(W) :- val(W), W = 1..1000000.
```

grounding does **3,000** matches after the fix versus **1,002,000** before (identical ground program either way). Verified on `wip-20` (`e7da6500`): builds clean, `ctest` 241/241.

This is a sibling of #660 — both correct the grounder's body-ordering cost model.
